### PR TITLE
Remove warning from media_player.yamaha page

### DIFF
--- a/source/_components/media_player.yamaha.markdown
+++ b/source/_components/media_player.yamaha.markdown
@@ -11,10 +11,6 @@ logo: yamaha.png
 ha_category: Media Player
 ---
 
-<p class='note warning'>
-Some users are experiencing errors loading the frontend while using this platform.
-</p>
-
 The `yamaha` platform allows you to control [Yamaha Network Receivers](http://usa.yamaha.com/products/audio-visual/av-receivers-amps/rx) from Home Assistant.
 
 Supported devices:


### PR DESCRIPTION
The front-end loading issue (home-assistant/home-assistant#1686) has been solved, hence removing the warning.