### PR TITLE
Update switch.command_line.markdown

### DIFF
--- a/source/_components/switch.command_line.markdown
+++ b/source/_components/switch.command_line.markdown
@@ -103,3 +103,4 @@ switch:
       offcmd: 'curl -k "https://ipaddress:443/cgi-bin/CGIProxy.fcgi?cmd=setMotionDetectConfig&isEnable=0&usr=admin&pwd=password"'
       statecmd: 'curl -k --silent "https://ipaddress:443/cgi-bin/CGIProxy.fcgi?cmd=getMotionDetectConfig&usr=admin&pwd=password" | grep -oP "(?<=isEnable>).*?(?=</isEnable>)"'
       value_template: '{{ value == "1" }}'
+```


### PR DESCRIPTION
Looks like this is missing the trailing ``` to close the final yaml configuration, which causes it to be improperly displayed on the page