### PR TITLE
Add warning about compiling openzwave as root

### DIFF
--- a/source/_components/zwave.markdown
+++ b/source/_components/zwave.markdown
@@ -33,7 +33,7 @@ $ sudo pip3 install --upgrade cython
 ```
 
 Then get the OpenZWave files and switch to the `python3` branch:
-
+<p class='note warning'>Do not use root to build python-openzwave as it will surely fail.</p>
 ```bash
 $ git clone https://github.com/OpenZWave/python-openzwave.git
 $ cd python-openzwave


### PR DESCRIPTION
This part is (minus a typo) in [the openzwave repo under INSTALL_REPO](https://github.com/OpenZWave/python-openzwave/blob/python3/INSTALL_REPO.txt#L63).

Especially some rPI distros come without another user and work with root by default.