### PR TITLE
Update garage_door.mqtt.markdown

### DIFF
--- a/source/_components/garage_door.mqtt.markdown
+++ b/source/_components/garage_door.mqtt.markdown
@@ -36,7 +36,7 @@ garage_door:
   state_closed: "STATE_CLOSED"
   service_open: "SERVICE_OPEN"
   service_close: "SERVICE_CLOSE"
-  value_template: '{% raw %}{{ value.x }}{% endraw %}'
+  value_template: '{% raw %}{{ value }}{% endraw %}'
 ```
 
 Configuration variables:


### PR DESCRIPTION
The `.x` doesn't bring any value (no idea where that comes from). If I publish "STATE_OPEN" on my MQTT instance, then we want HA to compare with the raw value.