### PR TITLE
Add version of HA supported

### DIFF
--- a/source/_components/device_tracker.bluetooth_tracker.markdown
+++ b/source/_components/device_tracker.bluetooth_tracker.markdown
@@ -26,3 +26,5 @@ device_tracker:
 ```
 
 For additional configuration variables check the [Device tracker page](/components/device_tracker/).
+
+Supported on versions 0.18+


### PR DESCRIPTION
Might be useful to know which version of HA components are supported on for those who don't upgrade regularly, or have to downgrade due to broken components.