### PR TITLE
Display HA release

### DIFF
--- a/source/_components/camera.rpi_camera.markdown
+++ b/source/_components/camera.rpi_camera.markdown
@@ -10,6 +10,7 @@ footer: true
 logo: raspberry-pi.png
 ha_category: Camera
 ha_iot_class: "Local Polling"
+ha_release: 0.17
 ---
 
 

--- a/source/_components/feedreader.markdown
+++ b/source/_components/feedreader.markdown
@@ -9,6 +9,7 @@ sharing: true
 footer: true
 logo: rss.gif
 ha_category: Other
+ha_release: 0.18
 ---
 
 Add an RSS/Atom feed reader that polls feeds every hour and sends new entries into the event bus.

--- a/source/_components/garage_door.mqtt.markdown
+++ b/source/_components/garage_door.mqtt.markdown
@@ -9,6 +9,7 @@ sharing: true
 footer: true
 logo: mqtt.png
 ha_category: Garage Door
+ha_release: 0.18
 ---
 
 

--- a/source/_components/media_player.onkyo.markdown
+++ b/source/_components/media_player.onkyo.markdown
@@ -9,6 +9,7 @@ sharing: true
 footer: true
 logo: onkyo.png
 ha_category: Media Player
+ha_release: 0.17
 ---
 
 

--- a/source/_components/notify.twitter.markdown
+++ b/source/_components/notify.twitter.markdown
@@ -9,6 +9,7 @@ sharing: true
 footer: true
 logo: twitter.png
 ha_category: Notifications
+ha_release: 0.16
 ---
 
 

--- a/source/_components/sensor.gtfs.markdown
+++ b/source/_components/sensor.gtfs.markdown
@@ -10,6 +10,7 @@ footer: true
 logo: 'gtfs.png'
 ha_category: Sensor
 ha_iot_class: "Local Polling"
+ha_release: 0.17
 ---
 
 

--- a/source/_components/sensor.thinkingcleaner.markdown
+++ b/source/_components/sensor.thinkingcleaner.markdown
@@ -10,6 +10,7 @@ footer: true
 logo: thinkingcleaner.png
 ha_category: Sensor
 ha_iot_class: "Local Poll"
+ha_release: 0.18
 ---
 
 The `ThinkingCleaner` sensor platform simple displays information about your [ThinkingCleaner](http://www.thinkingcleaner.com) addon.

--- a/source/_components/switch.arest.markdown
+++ b/source/_components/switch.arest.markdown
@@ -10,6 +10,7 @@ footer: true
 logo: arest.png
 ha_category: Switch
 ha_iot_class: "Local Polling"
+ha_release: 0.16
 ---
 
 The `arest` switch platform allows you to toggle pins of your devices (like Arduino boards with a ethernet/wifi connection, ESP8266 based devices, and the Raspberry Pi) running the [aREST](http://arest.io/) RESTful framework.

--- a/source/_components/switch.thinkingcleaner.markdown
+++ b/source/_components/switch.thinkingcleaner.markdown
@@ -10,6 +10,7 @@ footer: true
 logo: thinkingcleaner.png
 ha_category: Switch
 ha_iot_class: "Local Poll"
+ha_release: 0.18
 ---
 
 The `ThinkingCleaner` switch platform allows you to control your [ThinkingCleaner](http://www.thinkingcleaner.com) addon.

--- a/source/_components/upnp.markdown
+++ b/source/_components/upnp.markdown
@@ -8,6 +8,7 @@ comments: false
 sharing: true
 footer: true
 ha_category: "Other"
+ha_release: 0.18
 ---
 
 The `upnp` component automatically creates port forwarding mappings on your router for Home Assistant. UPnP or NAT-PMP needs to be enabled on your router for this component to work.

--- a/source/_components/zeroconf.markdown
+++ b/source/_components/zeroconf.markdown
@@ -8,6 +8,7 @@ comments: false
 sharing: true
 footer: true
 ha_category: "Other"
+ha_release: 0.18
 ---
 
 The `zeroconf` component exposes your Home Assistant to the local network using [Zeroconf](https://en.wikipedia.org/wiki/Zero-configuration_networking). Zeroconf is also sometimes known as Bonjour, Rendezvous and Avahi.

--- a/source/_includes/asides/component_navigation.html
+++ b/source/_includes/asides/component_navigation.html
@@ -27,6 +27,12 @@
     </div>
   {% endif %}
 
+  {% if page.ha_release %}
+    <div class='section'>
+    Introduced in release: {{ page.ha_release }}
+    </div>
+  {% endif %}
+
   {% if is_platform and parent_name != 'sensor' and parent_name != 'binary_sensor' %}
     <div class='section'>
       This is a platform for


### PR DESCRIPTION
I agree with @captainnapalm to display the Home Assistant release in which the platform/component was introduced. This could create a better user experience for people who don't update regularly.

Related: #435  