### PR TITLE
Update device_tracker.icloud.markdown

### DIFF
--- a/source/_components/device_tracker.icloud.markdown
+++ b/source/_components/device_tracker.icloud.markdown
@@ -40,3 +40,7 @@ This may cause battery drainage as it wakes up your device to get the current lo
 You may receive an email from Apple stating that someone has logged into your account.
 </p>
 
+<p class='note warning'>
+If you have two-factor authentication enabled on your iCloud account you will not be able to use this presence detection in HA, even with an app-specific password.
+</p>
+


### PR DESCRIPTION
Adding a note regarding that iCloud in hass is not compatible with 2FA at this time. Took me a while to figure this out and then found the bug report on github (#1789)