### PR TITLE
Remove broken Nest sensor types from documentation

### DIFF
--- a/source/_components/sensor.nest.markdown
+++ b/source/_components/sensor.nest.markdown
@@ -23,8 +23,6 @@ sensor:
   monitored_conditions:
     - 'temperature'
     - 'target'
-    - 'away_temperature[0]'
-    - 'away_temperature[1]'
     - 'humidity'
     - 'mode'
     - 'last_ip'
@@ -45,8 +43,6 @@ Configuration variables:
 - **monitored_conditions** array (*Required*): States to monitor.
   - 'temperature'
   - 'target'
-  - 'away_temperature[0]'
-  - 'away_temperature[1]'
   - 'humidity'
   - 'mode'
   - 'last_ip'


### PR DESCRIPTION
These where removed from code earlier but not from documentation, caused errors with configuration.yaml when used.