### PR TITLE
Added example of using template in shell_command.

### DIFF
--- a/source/_components/shell_command.markdown
+++ b/source/_components/shell_command.markdown
@@ -26,3 +26,20 @@ Configuration variables:
 
  - Alias for the command
  - Command itself.
+
+The commands can be dynamic, using templates to insert values of other entities. For example
+
+```yaml
+# Apply value of a GUI slider to the shell_command
+input_slider:
+  ac_temperature:
+    name: A/C Setting
+    initial: 24
+    min: 18
+    max: 32
+    step: 1
+{% raw %}
+shell_command:
+  set_ac_to_slider: 'irsend SEND_ONCE DELONGHI AC_{{ states.input_slider.ac_temperature.state}}_AUTO'
+{% endraw %}
+```


### PR DESCRIPTION
Now you can use template in `shell_command`. Related to forthcoming PR in main repo. 