### PR TITLE
RFXtrx component updates

### DIFF
--- a/source/_components/light.rfxtrx.markdown
+++ b/source/_components/light.rfxtrx.markdown
@@ -14,13 +14,13 @@ ha_release: 0.7.5
 
 The `rfxtrx` platform support lights that communicate in the frequency range of 433.92 MHz.
 
-First you have to set up your [rfxtrx hub.](/components/rfxtrx/)
+First you have to set up your [rfxtrx hub](/components/rfxtrx/).
 The easiest way to find your lights is to add this to your `configuration.yaml`:
 
 ```yaml
 light:
- platform: rfxtrx
- automatic_add: True
+  platform: rfxtrx
+  automatic_add: True
 ```
 
 Launch your homeassistant and go the website.
@@ -30,15 +30,15 @@ Push your remote and your device should be added:
 <img src='/images/components/rfxtrx/switch.png' />
 </p>
 
-Here the name is 0b11000102ef9f210010f70 and you can verify that it works from the frontend.
+Here the name is `0b11000102ef9f210010f70` and you can verify that it works from the frontend.
 Then you should update your configuration to:
 
 ```yaml
 light:
- platform: rfxtrx
- devices:
+  platform: rfxtrx
+  devices:
     0b11000102ef9f210010f70:
-        name: device_name
+      name: device_name
 ```
 
 Example configuration:
@@ -46,12 +46,12 @@ Example configuration:
 ```yaml
 # Example configuration.yaml entry
 light:
- platform: rfxtrx
- devices:
-   0b11000f10e9e5660b010f70:
-     name: Light1
-   0b1100100f29e5660c010f70:
-     name: Light_TV
+  platform: rfxtrx
+  devices:
+    0b11000f10e9e5660b010f70:
+      name: Light1
+    0b1100100f29e5660c010f70:
+      name: Light_TV
 ```
 
 Configuration variables:

--- a/source/_components/rfxtrx.markdown
+++ b/source/_components/rfxtrx.markdown
@@ -24,7 +24,6 @@ rfxtrx:
   dummy: False
 ```
 
-
 Configuration variables:
 
 - **device** (*Required*): The path to your device, e.g. `/dev/serial/by-id/usb-RFXCOM_RFXtrx433_A1Y0NJGR-if00-port0`

--- a/source/_components/rollershutter.rfxtrx.markdown
+++ b/source/_components/rollershutter.rfxtrx.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "RFXtrx Rollershutter"
 description: "Instructions how to integrate RFXtrx roller shutters into Home Assistant."
-date: 2016-06-11 22:40
+date: 2016-06-12 12:40
 sidebar: true
 comments: false
 sharing: true
@@ -14,22 +14,22 @@ ha_release: 0.21
 
 The `rfxtrx` platform supports Siemens/LightwaveRF and RFY roller shutters that communicate in the frequency range of 433.92 MHz.
 
-First you have to set up your [rfxtrx hub.](/components/rfxtrx/)
+First you have to set up your [rfxtrx hub](/components/rfxtrx/).
 
 ### {% linkable_title Configuration %}
-#####Siemens/LightwaveRF
+##### Siemens/LightwaveRF
 The easiest way to find your roller shutters is to add this to your `configuration.yaml`:
 
 ```yaml
 rollershutter:
- platform: rfxtrx
- automatic_add: True
+  platform: rfxtrx
+  automatic_add: True
 ```
 
-Launch your homeassistant and go the website.
+Launch your homeassistant and go the website (e.g http://localhost:8123).
 Push your remote and your device should be added.
 
-Once added it will show an id (e.g `0b11000102ef9f210010f70`) and you can verify that it works from the frontend.
+Once added it will show an ID (e.g `0b11000102ef9f210010f70`) and you can verify that it works from the frontend.
 Then you should update your configuration to:
 
 ```yaml
@@ -41,10 +41,9 @@ rollershutter:
 ```
 
 ##### RFY
-The RFXtrx433e is required for RFY support, however it does not support receive for the RFY protocol - as such devices cannot be automatically added. Instead, configure the device in the [rfxmngr](http://www.rfxcom.com/downloads.htm) tool. Make a note of the assigned ID and Unit Code and then add a device to the configuration with the following id `071a0000[id][unit_code]`. Eg, if the id was `0a` `00` `01`, and the unit code was `01` then the fully qualified id would be `071a00000a000101`.
+The [RFXtrx433e](http://www.rfxcom.com/RFXtrx433E-USB-43392MHz-Transceiver/en) is required for RFY support, however it does not support receive for the RFY protocol - as such devices cannot be automatically added. Instead, configure the device in the [rfxmngr](http://www.rfxcom.com/downloads.htm) tool. Make a note of the assigned ID and Unit Code and then add a device to the configuration with the following id `071a0000[id][unit_code]`. Eg, if the id was `0a` `00` `01`, and the unit code was `01` then the fully qualified id would be `071a00000a000101`.
 
-
-#####Common
+##### Common
 Example configuration:
 
 ```yaml

--- a/source/_components/sensor.rfxtrx.markdown
+++ b/source/_components/sensor.rfxtrx.markdown
@@ -13,13 +13,13 @@ ha_category: Sensor
 
 The `rfxtrx` platform support sensors that communicate in the frequency range of 433.92 MHz.
 
-First you have to set up your [rfxtrx hub.](/components/rfxtrx/)
+First you have to set up your [rfxtrx hub](/components/rfxtrx/).
 The easiest way to find your sensors is to add this to your `configuration.yaml`:
 
 ```yaml
 sensor:
- platform: rfxtrx
- automatic_add: True
+  platform: rfxtrx
+  automatic_add: True
 ```
 
 Then when the sensor emits a signal it will be automatically added:
@@ -28,47 +28,45 @@ Then when the sensor emits a signal it will be automatically added:
 <img src='/images/components/rfxtrx/sensor.png' />
 </p>
 
-Here the name is 0a52080000301004d240259 and you can verify that it works from the frontend.
+Here the name is `0a52080000301004d240259` and you can verify that it works from the frontend.
 Then you should update your configuration to:
 
 ```yaml
 sensor:
- platform: rfxtrx
- devices:
+  platform: rfxtrx
+  devices:
     0a52080000301004d240259:
-        name: device_name
+      name: device_name
 ```
 
 If you want to display several data types from one sensor:
 
 ```yaml
 sensor:
- platform: rfxtrx
- devices:
+  platform: rfxtrx
+  devices:
     0a520802060100ff0e0269:
-        name: Bath
-        data_type:
-         - Humidity
-         - Temperature
+      name: Bath
+      data_type:
+       - Humidity
+       - Temperature
 ```
-
-
 
 Example configuration:
 
 ```yaml
 # Example configuration.yaml entry
 sensor:
- platform: rfxtrx
- automatic_add: True
- devices:
-   0a52080705020095220269:
-     name: Lving
-   0a520802060100ff0e0269:
-        name: Bath
-        data_type:
-         - Humidity
-         - Temperature
+  platform: rfxtrx
+  automatic_add: True
+  devices:
+    0a52080705020095220269:
+      name: Lving
+    0a520802060100ff0e0269:
+      name: Bath
+      data_type:
+       - Humidity
+       - Temperature
 ```
 
 Configuration variables:
@@ -76,3 +74,4 @@ Configuration variables:
 - **devices**  (*Optional*): A list of devices with their name to use in the frontend.
 - **automatic_add** (*Optional*): To enable the automatic addition of new lights.
 - **data_type**  (*Optional*): Which data type the sensor should show
+- **fire_event** *Optional*: Fires an event even if the state is the same as before. Can be used for automations.

--- a/source/_components/switch.rfxtrx.markdown
+++ b/source/_components/switch.rfxtrx.markdown
@@ -14,13 +14,13 @@ ha_release: 0.7.5
 
 The `rfxtrx` platform support switches that communicate in the frequency range of 433.92 MHz.
 
-First you have to set up your [rfxtrx hub.](/components/rfxtrx/)
+First you have to set up your [rfxtrx hub](/components/rfxtrx/).
 The easiest way to find your switches is to add this to your `configuration.yaml`:
 
 ```yaml
 switch:
- platform: rfxtrx
- automatic_add: True
+  platform: rfxtrx
+  automatic_add: True
 ```
 
 Launch your homeassistant and go the website.
@@ -30,15 +30,15 @@ Push your remote and your device should be added:
 <img src='/images/components/rfxtrx/switch.png' />
 </p>
 
-Here the name is 0b11000102ef9f210010f70 and you can verify that it works from the frontend.
+Here the name is `0b11000102ef9f210010f70` and you can verify that it works from the frontend.
 Then you should update your configuration to:
 
 ```yaml
 switch:
- platform: rfxtrx
- devices:
+  platform: rfxtrx
+  devices:
     0b11000102ef9f210010f70:
-        name: device_name
+      name: device_name
 ```
 
 Example configuration:
@@ -46,16 +46,16 @@ Example configuration:
 ```yaml
 # Example configuration.yaml entry
 switch:
- platform: rfxtrx
- automatic_add: False
- signal_repetitions: 2
- devices:
-   0b1100ce3213c7f210010f70:
-     name: Movment1
-   0b11000a02ef2gf210010f50:
-     name: Movment2
-   0b1111e003af16aa10000060:
-     name: Door
+  platform: rfxtrx
+  automatic_add: False
+  signal_repetitions: 2
+  devices:
+    0b1100ce3213c7f210010f70:
+      name: Movment1
+    0b11000a02ef2gf210010f50:
+      name: Movment2
+    0b1111e003af16aa10000060:
+      name: Door
 ```
 
 Configuration variables:


### PR DESCRIPTION
More tweaks to the RFXtrx documentation following on from #551.

Changes include:

 - Move punctuation out of links
 - Fix broken headers
 - Correct example yaml indentation
 - Add more links
 - Add missing config parameter to sensors
 - General capitalisation and grammar
 - Put ID's in code blocks
 - Removed unnecessary new lines