### PR TITLE
Update letsencrypt blog

### DIFF
--- a/source/_posts/2015-12-13-setup-encryption-using-lets-encrypt.markdown
+++ b/source/_posts/2015-12-13-setup-encryption-using-lets-encrypt.markdown
@@ -4,7 +4,7 @@ title: "Set up encryption using Let's Encrypt"
 description: "Tutorial how to encrypt your connection with Home Assistant."
 date: 2015-12-13 10:05:00 -0800
 date_formatted: "December 13, 2015"
-author: Paulus Schoutsen
+author: Paulus Schoutsen & Martin Hjelmare
 author_twitter: balloob
 comments: true
 categories: How-To
@@ -13,7 +13,7 @@ og_image: /images/blog/2015-12-lets-encrypt/letsencrypt-secured-fb.png
 
 Exposing your Home Assistant instance outside of your network always has been tricky. You have to set up port forwarding on your router and most likely add a dynamic DNS service to work around your ISP changing your IP. After this you would be able to use Home Assistant from anywhere but there is one big red flag: no encryption.
 
-This tutorial will take you through the steps to setup a dynamic DNS for your IP and allow trusted encrypted connection to it - for free using [DuckDNS] and [Let's Encrypt].
+This tutorial will take you through the steps to setup a dynamic DNS for your IP and allow trusted encrypted connection to it - for free using [DuckDNS] and [Let's Encrypt]. It will use the Raspberry Pi 2 with raspbian Jessie as example platform.
 
 <p class='img'>
 <img src='/images/blog/2015-12-lets-encrypt/letsencrypt-secured.png' />
@@ -46,48 +46,45 @@ First step is to acquire and set up our domain name. For this, go to [DuckDNS], 
 
 Let's Encrypt will give you a free 90-day certificate if you pass their domain validation challenge. Domains are validated by having certain data be accessible on your domain for Let's Encrypt ([they describe it better themselves][letsencrypt-technology]).
 
-Assuming that your home is behind a router, the first thing to do is to set up port forwarding from your router to your computer that will run Let's Encrypt. For the Let's Encrypt set up we need to temporary forward ports `80` (http connections) and `443` (https connections). This can be set up by accessing your router admin interface ([Site with port forwarding instructions per router][port-forward]).
+Assuming that your home is behind a router, the first thing to do is to set up port forwarding from your router to your computer that will run Let's Encrypt. For the Let's Encrypt set up we need to forward external port `80` to internal port `80` (http connections). This can be set up by accessing your router admin interface ([Site with port forwarding instructions per router][port-forward]). This port forward must be active whenever you want to request a new certificate from Let's Encrypt, typically every three months. If you normally don't use or have an app that listens to port `80`, it should be safe to leave the port open. This will make renewing certificates easier.
 
-Now you're ready to run Let's Encrypt:
+Now you're ready to install and run Let's Encrypt. The following example will use the [certbot][certbot] client from Let's Encrypt. For a Raspberry Pi 2 on a fresh install of raspbian Jessie:
 
 ```bash
-$ git clone https://github.com/letsencrypt/letsencrypt
-[…]
-$ cd letsencrypt
-$ ./letsencrypt-auto certonly --email your@email.address -d hass-example.duckdns.org
-
-Updating letsencrypt and virtual environment dependencies.......
-Running with virtualenv: sudo /path/letsencrypt/bin/letsencrypt certonly --email your@e-mail.address -d hass-example.duckdns.org
-
-IMPORTANT NOTES:
- - Congratulations! Your certificate and chain have been saved at
-   /etc/letsencrypt/live/hass-example.duckdns.org/fullchain.pem. Your cert
-   will expire on 2016-03-12. To obtain a new version of the
-   certificate in the future, simply run Let's Encrypt again.
- - If like Let's Encrypt, please consider supporting our work by:
-
-   Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate
-   Donating to EFF:                    https://eff.org/donate-le
+$ echo 'deb http://ftp.debian.org/debian jessie-backports main' | sudo tee --append /etc/apt/sources.list.d/backports.list
+$ gpg --keyserver pgpkeys.mit.edu --recv-key 7638D0442B90D010
+$ gpg -a --export 7638D0442B90D010 | sudo apt-key add -
+$ gpg --keyserver pgpkeys.mit.edu --recv-key 8B48AD6246925553
+$ gpg -a --export 8B48AD6246925553 | sudo apt-key add -
+$ sudo apt-get update
+$ sudo apt-get install certbot -t jessie-backports
+$ sudo certbot certonly --standalone --standalone-supported-challenges http-01 \
+                        --email your@email.address -d hass-example.duckdns.org
 ```
 
 If you're using Docker, run the following command to generate the required keys:
 
 ```bash
 sudo mkdir /etc/letsencrypt /var/lib/letsencrypt
-sudo docker run -it --rm -p 443:443 -p 80:80 --name letsencrypt \
+sudo docker run -it --rm -p 80:80 --name certbot \
                 -v "/etc/letsencrypt:/etc/letsencrypt" \
                 -v "/var/lib/letsencrypt:/var/lib/letsencrypt" \
                 quay.io/letsencrypt/letsencrypt:latest certonly \
-                --email your@e-mail.address -d hass-example.duckdns.org
+                --standalone --standalone-supported-challenges http-01 \
+                --email your@email.address -d hass-example.duckdns.org
 ```
 
-With either method your certificate will be generated and put in the directory `/etc/letsencrypt/live/hass-example.duckdns.org`. As the lifetime is only 90 days, you will have to repeat this every 90 days.
+With either method your certificate will be generated and put in the directory `/etc/letsencrypt/live/hass-example.duckdns.org`. As the lifetime is only 90 days, you will have to repeat this every 90 days. For `certbot` there's a special command to simplify renewing certificates:
+
+```
+sudo certbot renew --standalone --standalone-supported-challenges http-01 --quiet
+```
 
 <img width="60" src="/images/favicon-192x192.png" style='float: right; border:none; box-shadow: none;'>
 
 ### {% linkable_title Home Assistant %}
 
-Before updating the Home Assistant configuration, we have to update the port forwarding at your router config. We can drop the port forwarding for port `80` as we no longer care about unecrypted messages. Update port `443` to forward to port `8123` on the computer that will run Home Assistant.
+Before updating the Home Assistant configuration, we have to forward port `443` (https connections) to port `8123` on the computer that will run Home Assistant. Do this in your router configuration as previously done for port `80`.
 
 The final step is to point Home Assistant at the generated certificates. Before you do this, make sure that the user running Home Assistant has read access to the folder that holds the certificates.
 
@@ -105,5 +102,6 @@ _Big thanks to Fabian Affolter for his help and feedback on this article._
 [DuckDNS]: https://duckdns.org
 [duckdns-install]: https://www.duckdns.org/install.jsp
 [Let's Encrypt]: https://letsencrypt.org
-[letsencrypt-technology]: https://letsencrypt.org/howitworks/technology/
+[letsencrypt-technology]: https://letsencrypt.org/how-it-works/
 [port-forward]: http://portforward.com
+[certbot]: https://certbot.eff.org/


### PR DESCRIPTION
* Use certbot with --standalone option instead of letsencrypt-auto.
* Update port instructions. Only port 80 is needed during challenge.