### PR TITLE
Added set_brightness to website docs.

### DIFF
--- a/source/_components/light.markdown
+++ b/source/_components/light.markdown
@@ -61,3 +61,16 @@ Toggles the state of one or multiple lights using [groups]({{site_root}}/compone
 | ---------------------- | -------- | ----------- |
 | `entity_id` | no | String or list of strings that point at `entity_id`s of lights. Else targets all.
 | `transition` | yes | Integer that represents the time the light should take to transition to the new state.
+
+### {% linkable_title Service `light.set_brightness` %}
+
+Changes the brightness of one or multiple lights using [groups]({{site_root}}/components/group/). 
+
+*Note*: This currently is only supported by the [Lifx]({{site_root}}/components/light.lifx/ component.
+
+| Service data attribute | Optional | Description |
+| ---------------------- | -------- | ----------- |
+| `entity_id` | no | String or list of strings that point at `entity_id`s of lights. Else targets all.
+| `transition` | yes | Integer that represents the time the light should take to transition to the new state.
+| `brightness` | yes | Integer between 0 and 255 for how bright the color should be.
+

--- a/source/getting-started/customizing-devices.markdown
+++ b/source/getting-started/customizing-devices.markdown
@@ -19,6 +19,8 @@ You can also use `icon` and refer to any icon from [MaterialDesignIcons.com](htt
 
 For switches with an assumed state two buttons are shown (turn off, turn on) instead of a switch. By setting `assumed_state` to `false` you will get the default switch icon.
 
+To change the order of the card in the view use can set the 'order' state to an numerical value for each group. 
+
 
 ```yaml
 # Example configuration.yaml entry
@@ -40,6 +42,8 @@ homeassistant:
       icon: mdi:kettle
     switch.rfxtrx_switch:
       assumed_state: false
+    group.bedroom_lamp
+      order: 1
 ```
 
 ### [Next step: Setting up presence detection &raquo;](/getting-started/presence-detection/)

--- a/source/getting-started/customizing-devices.markdown
+++ b/source/getting-started/customizing-devices.markdown
@@ -19,8 +19,6 @@ You can also use `icon` and refer to any icon from [MaterialDesignIcons.com](htt
 
 For switches with an assumed state two buttons are shown (turn off, turn on) instead of a switch. By setting `assumed_state` to `false` you will get the default switch icon.
 
-To change the order of the card in the view use can set the 'order' state to an numerical value for each group. 
-
 
 ```yaml
 # Example configuration.yaml entry
@@ -42,8 +40,6 @@ homeassistant:
       icon: mdi:kettle
     switch.rfxtrx_switch:
       assumed_state: false
-    group.bedroom_lamp
-      order: 1
 ```
 
 ### [Next step: Setting up presence detection &raquo;](/getting-started/presence-detection/)


### PR DESCRIPTION
Allows the user to set the brightness of a lifx bulb without the need to turn it on.