### PR TITLE
Add site_id description to device_tracker.unifi.markdown

### DIFF
--- a/source/_components/device_tracker.unifi.markdown
+++ b/source/_components/device_tracker.unifi.markdown
@@ -25,6 +25,7 @@ device_tracker:
   port: PORT
   username: YOUR_ADMIN_USERNAME
   password: YOUR_ADMIN_PASSWORD
+  site_id: SITE_ID
 ```
 
 Configuration variables:
@@ -33,5 +34,6 @@ Configuration variables:
 - **port** (*Optional*): The port of your controller's web interface. Defaults to 8443.
 - **username** (*Required*: The username of an user with administrative privileges, usually *admin*.
 - **password** (*Required*): The password for your given admin account.
+- **site_id** (*Optional*): Allows you to specify a site_id for device tracking. Defaults to "default". Found in the URL of the controller (i.e. https://CONTROLLER:PORT/manage/site/SITE_ID/dashboard)
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.


### PR DESCRIPTION
Add site_id description to the page. This configuration detail allows you to specify which site is surveyed for devices. Useful if the controller has multiple sites.