### PR TITLE
Fix AsusWRT docs to prevent SSH key confusion

### DIFF
--- a/source/_components/device_tracker.asuswrt.markdown
+++ b/source/_components/device_tracker.asuswrt.markdown
@@ -34,8 +34,8 @@ Configuration variables:
 - **protocol** (*Optional*): The protocol (`ssh` or `telnet`) to use. Defaults to `ssh`.
 - **mode** (*Optional*): The operating mode of the router (`router` or `ap`). Defaults to `router`.
 - **username** (*Required*: The username of an user with administrative privileges, usually *admin*.
-- **password** (*Optional*): The password for your given admin account (use this if no public key is given).
-- **pub_key** (*Optional*): The public key for your given admin account (instead of password).
+- **password** (*Optional*): The password for your given admin account (use this if no SSH key is given).
+- **ssh_key** (*Optional*): The path to your SSH private key file associated with your given admin account (instead of password).
 
 <p class='note warning'>
 You need to enable telnet on your router if you choose to use `protocol: telnet`. 


### PR DESCRIPTION
pxssh is expecting the path to a private key, not a public key