### PR TITLE
Fix error in turn_off_action documentation.

### DIFF
--- a/source/_components/media_player.kodi.markdown
+++ b/source/_components/media_player.kodi.markdown
@@ -37,4 +37,4 @@ Configuration variables:
 - **name** (*Optional*): The name of the device used in the frontend.
 - **username** (*Optional*): The XBMC/Kodi HTTP username.
 - **password** (*Optional*): The XBMC/Kodi HTTP password.
-- **turn_off_action** (*Optional*): The desired turn off action. Options are `none`, `quit`, `hibernate`, `suspend`, `reboot`, or `poweroff`. Default `none`.
+- **turn_off_action** (*Optional*): The desired turn off action. Options are `none`, `quit`, `hibernate`, `suspend`, `reboot`, or `shutdown`. Default `none`.


### PR DESCRIPTION
The documentation for `turn_off_action` incorrectly listed `poweroff` when it should have listed `shutdown`.
https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/media_player/kodi.py#L195