### PR TITLE
Updates to LIRC documentation to deal with broken dep in PyPI (#2306).

### DIFF
--- a/source/_components/lirc.markdown
+++ b/source/_components/lirc.markdown
@@ -23,8 +23,38 @@ Sending IR commands is not supported in this component (yet), but can be accompl
 To allow Home Assistant to talk to your IR receiver, you need to first make sure you have the correct dependencies installed:
 
 ```bash
-$ sudo apt-get install lirc
+$ sudo apt-get install lirc python3-lirc
 ```
+
+Check the version of `python3-lirc`:
+
+```bash
+$ apt-cache show python3-lirc
+Package: python3-lirc
+Source: python-lirc
+Version: 1.2.1-2
+```
+
+If you do not have this version or you are running in a virtual environment, then your system will completely freeze with this component active. You will need to build `python3-lirc` from source. The version of this library in the Python package index is also broken, so the typical dependency system cannot fix this. Build it from source like this:
+
+As regular user:
+
+```bash
+sudo apt-get install liblircclient-dev
+```
+
+As the user that runs hass:
+
+```bash
+(hass) $  git clone https://github.com/tompreston/python-lirc.git
+(hass) $  cd python-lirc
+(hass) $  make py3
+(hass) $  python3 setup.py build
+(hass) $  python3 setup.py install
+```
+
+If you are not using a virtual environment setup, then you'll need a `sudo` before the install line above. 
+
 
 <p class='note'>
 If you are configuring on a Raspberry Pi, there are excellent instructions with GPIO schematics and driver configurations [here](http://alexba.in/blog/2013/01/06/setting-up-lirc-on-the-raspberrypi/). Consider following these.
@@ -60,10 +90,10 @@ end
 Test your LIRC installation before proceeding by running:
 
 ```bash
-$ irexec -n home-assistant
+$ ircat home-assistant
 ```
 
-and pressing some buttons on the remote.
+and pressing some buttons on the remote. You should see them register on the screen if LIRC is properly configured.
 
 
 ### {% linkable_title Configuration Home Assistant %}
@@ -72,10 +102,6 @@ and pressing some buttons on the remote.
 # Example configuration.yaml entry
 lirc:
 ```
-
-<p class='note'>
-If you are on a Debian based system (like Raspberry Pi) and are having issues loading the component due to it being unable to install python-lirc, install it manually using `apt-get install python3-lirc`.
-</p>
 
 #### {% linkable_title Events %}
 


### PR DESCRIPTION
See https://github.com/home-assistant/home-assistant/issues/2306. The PyPI package is broken so if you have an out-of-date `python3-lirc` or are in a virtualenv you need to build `python3-lirc` from the github source. 