### PR TITLE
Make link to PushBullet Component Absolute

### DIFF
--- a/source/_cookbook/automation_sun.markdown
+++ b/source/_cookbook/automation_sun.markdown
@@ -46,7 +46,7 @@ automation:
 
 #### {% linkable_title Send sun rise/sun set notifications %}
 
-Notifications send through [PushBullet](components/notify.pushbullet/) when the sun state is changed.
+Notifications send through [PushBullet](/components/notify.pushbullet/) when the sun state is changed.
 
 ```yaml
 automation:


### PR DESCRIPTION
As of now, the link tries to go to a deep subdirectory of the documentation.  Making it an absolute link will make it work on the built documentation on the site.  Neither way currently works in github, but I doubt that's the goal.