### PR TITLE
Line wrap was causing formatting shenaigans

### DIFF
--- a/source/_components/group.markdown
+++ b/source/_components/group.markdown
@@ -64,11 +64,13 @@ Notice in the example below that in order to refer to the group "Living Room", y
     entities:
       - light.light_family_1
       - binary_sensor.motion_living
+
   Bedroom: light.light_bedroom, switch.sleeping
-  Rooms:                                                                                                                                                       
-    view: yes                                                                                                                                                  
+
+  Rooms:
+    view: yes                                 
     name: Rooms
-    entities:                                                                                                                                                  
-      - group.living_room                                                                                                                                      
+    entities:
+      - group.living_room                                 
       - group.bedroom                                                                                                                                          
 ``` 


### PR DESCRIPTION
There were a ton of trailing spaces at the end of some of the YAML definitions which caused the resulting output to look rather ugly.