### PR TITLE
Added device_tracker.mqtt example message

### DIFF
--- a/source/_components/device_tracker.mqtt.markdown
+++ b/source/_components/device_tracker.mqtt.markdown
@@ -31,3 +31,12 @@ Configuration variables:
 - **devices** (*Required*): List of devices with their topic.
 - **qos** (*Optional*): The QoS level of the topic.
 
+
+Example JSON you can publish to the topic (e.g. via mqtt.publish service):
+
+```json
+{
+  "topic": "/location/paulus",
+  "payload": "home"
+}
+```


### PR DESCRIPTION
It might get people started quickly if they know how the data they have to publish via MQTT has to look like. Currently people seem to replicate the ownTracks messages, which could be unnecessary for people that don't need that level of accuracy.