### PR TITLE
Samsung TVs that don't work

### DIFF
--- a/source/_components/media_player.samsungtv.markdown
+++ b/source/_components/media_player.samsungtv.markdown
@@ -44,8 +44,12 @@ Currently known supported models:
 - F6500
 - EH5600
 - F6400AF
-
+ 
 If your model is not on the list then give it a test, if everything works correctly then add it to the list on [GitHub](https://github.com/home-assistant/home-assistant.io).
 The two letters at the beginning of the model number represent the region, UE is Europe, UN is North America and UA is Asia & Australia. The two numbers following that represent the screen size. If you add your model remember to remove these before adding them to the list.
 
 There's currently a [known issue](https://github.com/home-assistant/home-assistant/issues/2098) with some TV's receiving a *Key press UP* that can interrupt certain applications. 
+
+Currently tested but not working models:
+
+- KU6300 - Shows in GUI but unable to control.


### PR DESCRIPTION
Tested but not working Samsung Models.  - Because it's annoying to set up stuff and then find out they don't work.