### PR TITLE
Restart command should be restart instead of start.

### DIFF
--- a/source/getting-started/installation-raspberry-pi-all-in-one.markdown
+++ b/source/getting-started/installation-raspberry-pi-all-in-one.markdown
@@ -66,7 +66,7 @@ To upgrade with fabric:
 After upgrading, you can restart Home Assistant a few different ways:
 
 * Restarting the Raspberry Pi `sudo reboot`
-* Restarting the Home-Assistant Service `sudo systemctl start home-assistant.service`
+* Restarting the Home-Assistant Service `sudo systemctl restart home-assistant.service`
 
 
 ### {% linkable_title Using the OZWCP web application %}


### PR DESCRIPTION
Restart command used with [systemd](https://wiki.debian.org/systemd) should be **restart** instead of **start**.
Reference material can be found at https://wiki.debian.org/systemd .