### PR TITLE
Add warning to the MPC-HC media_player component documentation.

### DIFF
--- a/source/_components/media_player.mpchc.markdown
+++ b/source/_components/media_player.mpchc.markdown
@@ -22,6 +22,12 @@ For this component to function, you will need to enable the Web Interface in the
   <img src='{{site_root}}/images/screenshots/mpc-hc.png' />
 </p>
 
+If the server running Home Assistant is not the same device that is running MPC-HC, you will need to ensure that the *allow access from localhost only* option is not set.
+
+<p class='note warning'>
+The MPC-HC web interface is highly insecure, and allows remote clients full player control file-system access without authentication. Never allow access to the Web UI from outside of your trusted network, and if possible [use a proxy script to restrict control or redact sensitive information](https://github.com/abcminiuser/mpc-hc-webui-proxy).
+</p>
+
 To add MPC-HC to your installation, add the following to your `configuration.yaml` file:
 
 ```yaml


### PR DESCRIPTION
I thought it prudent to add a warning to the new MPC-HC media player component, telling users to be cautious about exposing the web UI to actors outside of their trusted network (it allows for arbitrary filesystem browsing and media player control without authentication).

I've also added a link to a simple proxy script I wrote last night that can act as a bridge between MPC-HC running with the web UI restricted to `localhost` and a remote client, redacting and restricting the command set to a sane subset. I'm using this to allow HA to observe and have only basic control over my main PC's MPC-HC, while redacting the current playing information.