### PR TITLE
HotFix - Needs to pipe integer to delay

### DIFF
--- a/source/getting-started/scripts.markdown
+++ b/source/getting-started/scripts.markdown
@@ -72,7 +72,7 @@ delay:
 ```yaml
 # Waits however many minutes input_slider.minute_delay is set to
 # Valid formats include HH:MM and HH:MM:SS
-delay: {% raw %}'00:{{ input_slider.minute_delay }}:00'{% endraw %}
+delay: {% raw %}'00:{{ input_slider.minute_delay | int }}:00'{% endraw %}
 ```
 
 #### {% linkable_title Fire an Event %}


### PR DESCRIPTION
Using the delay template as specified in the documentation worked when the delay template was being implemented, but input_slider is now floating point - update documentation to pipe the float into an integer.

@balloob This may be considered a hotfix so I labelled it as such. Someone already had issues in the gitter chat following the example I provided in the docs.