### PR TITLE
Add ac_mode option to thermostat.heat_control docs

### DIFF
--- a/source/_components/thermostat.heat_control.markdown
+++ b/source/_components/thermostat.heat_control.markdown
@@ -33,3 +33,4 @@ Configuration variables:
 - **min_temp** (*Optional*): Set minimum set point available (default: 7)
 - **max_temp** (*Optional*): Set maximum set point available (default: 35)
 - **target_temp** (*Required*): Set intital target temperature. Failure to set this variable will result in target temperature being set to null on startup.
+- **ac_mode** (*Optional*): Set the switch specified in the *heater* option to be treated as a cooling device instead of a heating device.


### PR DESCRIPTION
This commit adds the heat_control option add in change:
home-assistant/home-assistant#2719 to the documentation for that
component.