### PR TITLE
Update notify.telegram.markdown

### DIFF
--- a/source/_components/notify.telegram.markdown
+++ b/source/_components/notify.telegram.markdown
@@ -20,16 +20,7 @@ The requirements are:
 - You need a [Telegram bot](https://core.telegram.org/bots). Please follow those [instructions](https://core.telegram.org/bots#botfather) to create one and get the token for your bot. Keep in mind that bots are not allowed to contact users. You need to make the first contact with your user. Meaning that you need to send a message to the bot from your user.
 - The `chat_id` of an user.
 
-An easy way to get your chat ID is described below:
-
-```python
-import telegram
-bot = telegram.Bot(token='YOUR_API_TOKEN')
-chat_id = bot.getUpdates()[-1].message.chat_id
-print(chat_id)
-```
-
-Another way to retrieve your `chat_id` is visiting [https://api.telegram.org/botYOUR_API_TOKEN/getUpdates](https://api.telegram.org/botYOUR_API_TOKEN/getUpdates).
+An easy way to get your `chat_id` is by visiting: [https://api.telegram.org/botYOUR_API_TOKEN/getUpdates](https://api.telegram.org/botYOUR_API_TOKEN/getUpdates).
 
 The result set will include your chat ID as `id` in the `from` section:
 
@@ -47,6 +38,14 @@ The result set will include your chat ID as `id` in the `from` section:
 ...
 ```
 
+Another way to retrieve your `chat_id` is described below:
+
+```python
+import telegram
+bot = telegram.Bot(token='YOUR_API_TOKEN')
+chat_id = bot.getUpdates()[-1].message.chat_id
+print(chat_id)
+```
 To enable Telegram notifications in your installation, add the following to your `configuration.yaml` file:
 
 ```yaml
@@ -65,6 +64,21 @@ Configuration variables:
 - **chat_id** (*Required*: The chat ID of your user.
 
 To use notifications, please see the [getting started with automation page](/getting-started/automation/).
+
+### {% linkable_title Sending a message %}
+
+```yaml
+...
+
+action:
+  service: notify.NOTIFIER_NAME
+  data:
+    title: Message from HASS.
+    message: This is a testmessage from Home Assistant!
+```
+
+- **title** (*Required*): Title of the message.
+- **message** (*Required*): The message to send.
 
 ### {% linkable_title Photo support %}
 


### PR DESCRIPTION
Added small explanation on how to send a simple message as the page was lacking this explanation.
Swapped method for getting chat_id around, opening a URL is easier than creating a Python script.