### PR TITLE
Docs for new smtp image attachments.

### DIFF
--- a/source/_components/notify.smtp.markdown
+++ b/source/_components/notify.smtp.markdown
@@ -29,6 +29,10 @@ notify:
   username: YOUR_SMTP_USERNAME
   password: YOUR_SMTP_PASSWORD
   recipient: YOUR_RECIPIENT
+  data:
+    images: 
+        - /path/to/file1.jpg
+        - /path/to/file2.jpg
 ```
 
 Configuration variables:
@@ -41,6 +45,7 @@ Configuration variables:
 - **password** (*Optional*):Password for the SMTP server that belongs to the given username. If the password contains a colon it need to be wrapped in apostrophes.
 - **recipient** (*Required*): Recipient of the notification.
 - **starttls** (*Optional*): Enables STARTTLS, eg. 1 or 0. Defaults to 0.
+- **images** (*Optional*): Adds in-line image attachments to email. Triggers text/HTML multi-part message instead of text default.
 
 This platform is fragile and not able to catch all exceptions in a smart way because of the large number of possible configuration combinations.
 

--- a/source/_components/notify.smtp.markdown
+++ b/source/_components/notify.smtp.markdown
@@ -29,10 +29,6 @@ notify:
   username: YOUR_SMTP_USERNAME
   password: YOUR_SMTP_PASSWORD
   recipient: YOUR_RECIPIENT
-  data:
-    images: 
-        - /path/to/file1.jpg
-        - /path/to/file2.jpg
 ```
 
 Configuration variables:
@@ -45,7 +41,27 @@ Configuration variables:
 - **password** (*Optional*):Password for the SMTP server that belongs to the given username. If the password contains a colon it need to be wrapped in apostrophes.
 - **recipient** (*Required*): Recipient of the notification.
 - **starttls** (*Optional*): Enables STARTTLS, eg. 1 or 0. Defaults to 0.
-- **images** (*Optional*): Adds in-line image attachments to email. Triggers text/HTML multi-part message instead of text default.
+
+To use the smtp notification, refer to it in an automation or script like in this example:
+
+```yaml
+  burglar: 
+    alias: Burglar Alarm
+    sequence:
+      - service: shell_command.snapshot
+      - delay:
+            seconds: 1
+      - service: notify.NOTIFIER_NAME
+        data:
+            title: 'Intruder alert'
+            message: 'Intruder alert at apartment!!'
+            data:
+                images: 
+                    - /home/pi/snapshot1.jpg
+                    - /home/pi/snapshot2.jpg
+```
+
+The optional **images** field adds in-line image attachments to the email. This sends a text/HTML multi-part message instead of the plain text default.
 
 This platform is fragile and not able to catch all exceptions in a smart way because of the large number of possible configuration combinations.
 


### PR DESCRIPTION
Now you can have the SMTP notifier attach one or more images in-line in the email. This is useful to send security camera stills in a burglar alarm, or lots of other things. 

See home-assistant/home-assistant#2738