### PR TITLE
Whoops, fixed a typo in the new addition

### DIFF
--- a/source/_components/switch.template.markdown
+++ b/source/_components/switch.template.markdown
@@ -48,7 +48,7 @@ Configuration variables:
 ## {% linkable_title Considerations %}
 
 If you are using the state of a platform that takes extra time to load, the template switch may get an 'unknown' state during startup. This results in error messages in your log file until that platform has completed loading. If you use is_state() function in your template, you can avoid this situation. For example, you would replace {% raw %}'{{ states.switch.source.state }}'{% endraw %} with this equivalent that returns true/false and never gives an unknown result:
-{% raw %}'{{ is_state('switch.source', 'on') }}'{% stendraw %}
+{% raw %}'{{ is_state('switch.source', 'on') }}'{% endraw %}
 
 ## {% linkable_title Examples %}
 


### PR DESCRIPTION
somehow added 2 extra characters to the "endraw" in my previous edit, which breaks some of the other elements further down the page. Second edit ever and I am already breaking things.