### PR TITLE
Update installation-raspberry-pi-all-in-one.markdown

### DIFF
--- a/source/getting-started/installation-raspberry-pi-all-in-one.markdown
+++ b/source/getting-started/installation-raspberry-pi-all-in-one.markdown
@@ -9,7 +9,7 @@ footer: true
 
 The [Raspberry Pi All-In-One Installer](https://github.com/home-assistant/fabric-home-assistant) deploys a complete Home Assistant server including support for MQTT with websockets, Z-Wave, and the Open-Zwave Control Panel.
 
-The only requirement is that you have a Raspberry Pi with a fresh installation of [Raspbian Jessie/Jessie Lite](https://www.raspberrypi.org/downloads/raspbian/) connected to your network.
+The only requirement is that you have a Raspberry Pi with a fresh installation of [Raspbian Jessie](https://www.raspberrypi.org/downloads/raspbian/) connected to your network.
 
 *  Login to Raspberry Pi. For example with `ssh pi@your_raspberry_pi_ip`
 *  Run the following command


### PR DESCRIPTION
A clean Raspbian Jessie Lite installation on a Raspberry Pi 3 found not working as promised by the manual. Suggest to remove the reference or even discourage Jessie Lite while installer/instructions are not updated for the Lite version.