### PR TITLE
Add stage 1 heater state to monitored conditions

### DIFF
--- a/source/_components/binary_sensor.nest.markdown
+++ b/source/_components/binary_sensor.nest.markdown
@@ -22,6 +22,7 @@ binary_sensor:
   monitored_conditions:
     - 'fan'
     - 'hvac_ac_state'
+    - 'hvac_heater_state'
     - 'hvac_aux_heater_state'
     - 'hvac_heat_x2_state'
     - 'hvac_heat_x3_state'


### PR DESCRIPTION
Condition for monitoring Stage 1 heat was missing from the list. Added in line 25.