### PR TITLE
Update libv8 dependency to fix failures with clang 7.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     jekyll-watch (1.3.0)
       listen (~> 3.0)
     kramdown (1.9.0)
-    libv8 (3.16.14.13)
+    libv8 (3.16.14.15)
     liquid (3.0.6)
     listen (3.0.3)
       rb-fsevent (>= 0.9.3)


### PR DESCRIPTION
See https://github.com/cowboyd/libv8/issues/205 for some details of the
problem. It's fixed in 3.16.14.15 of libv8. 