### PR TITLE
Adding AVR receivers to supported list

### DIFF
--- a/source/_components/media_player.denon.markdown
+++ b/source/_components/media_player.denon.markdown
@@ -19,6 +19,7 @@ Supported devices:
 - Denon DRA-N5
 - Denon RCD-N8 (untested)
 - Denon RCD-N9 (partial support)
+- Denon AVR receivers with Integrated Network support (partial support)
 
 To add a Denon Network Receiver to your installation, add the following to your `configuration.yaml` file:
 


### PR DESCRIPTION
Have tested on older AVR-2312CI and it is able to control volume/mute, power and basic media support while playing internet audio sources.