### PR TITLE
Update androidtv_remote.markdown - zeroconf incorrect IP workaround

### DIFF
--- a/source/_integrations/androidtv_remote.markdown
+++ b/source/_integrations/androidtv_remote.markdown
@@ -540,3 +540,9 @@ cards:
 - Some devices experience disconnects every 15 seconds. This is typically resolved by rebooting the Android TV device after the initial setup of the integration.
 - If you are not able to connect to the Android TV device, or are asked to pair it again and again, try force-stopping the Android TV Remote Service and clearing its storage. On the Android TV device, go to **Settings** > **Apps** > **Show system apps**. Then, select **Android TV Remote Service** > **Storage** > **Clear storage**. You will have to pair again.
 - Some onscreen keyboards enabled by TV manufacturers do not support concurrent virtual and onscreen keyboard use. This presents whenever a text field is selected, such as "search" where a constant **use the keyboard on your mobile device** will show, preventing you from opening the onscreen keyboard to type. This can be overcome by either disabling your 3rd party keyboard and using the default Gboard keyboard or by deselecting **Enable IME** in the **Configure** page of the integration.
+- In some instances, zeroconf will assign an incorrect IP address to a device. As a workaround, the below can be added to `configuration.yaml` to prevent zeroconf from assigning IPs for the integration. IPs will need to be manually assigned during setup, or changed in `.storage/core.config_entries`.
+```yaml
+zeroconf:
+  ignore:
+    - androidtv_remote
+```

--- a/source/_integrations/androidtv_remote.markdown
+++ b/source/_integrations/androidtv_remote.markdown
@@ -540,7 +540,7 @@ cards:
 - Some devices experience disconnects every 15 seconds. This is typically resolved by rebooting the Android TV device after the initial setup of the integration.
 - If you are not able to connect to the Android TV device, or are asked to pair it again and again, try force-stopping the Android TV Remote Service and clearing its storage. On the Android TV device, go to **Settings** > **Apps** > **Show system apps**. Then, select **Android TV Remote Service** > **Storage** > **Clear storage**. You will have to pair again.
 - Some onscreen keyboards enabled by TV manufacturers do not support concurrent virtual and onscreen keyboard use. This presents whenever a text field is selected, such as "search" where a constant **use the keyboard on your mobile device** will show, preventing you from opening the onscreen keyboard to type. This can be overcome by either disabling your 3rd party keyboard and using the default Gboard keyboard or by deselecting **Enable IME** in the **Configure** page of the integration.
-- In some instances, zeroconf will assign an incorrect IP address to a device. As a workaround, the below can be added to `configuration.yaml` to prevent zeroconf from assigning IPs for the integration. IPs will need to be manually assigned during setup, or changed in `.storage/core.config_entries`.
+- In some instances, zeroconf will assign an incorrect IP address to a device. As a workaround, the below can be added to `configuration.yaml` to prevent zeroconf from assigning IPs for the integration. IPs will need to be manually entered during setup, as described [above](https://www.home-assistant.io/integrations/androidtv_remote/#configuration).
 ```yaml
 zeroconf:
   ignore:

--- a/source/_integrations/androidtv_remote.markdown
+++ b/source/_integrations/androidtv_remote.markdown
@@ -540,7 +540,7 @@ cards:
 - Some devices experience disconnects every 15 seconds. This is typically resolved by rebooting the Android TV device after the initial setup of the integration.
 - If you are not able to connect to the Android TV device, or are asked to pair it again and again, try force-stopping the Android TV Remote Service and clearing its storage. On the Android TV device, go to **Settings** > **Apps** > **Show system apps**. Then, select **Android TV Remote Service** > **Storage** > **Clear storage**. You will have to pair again.
 - Some onscreen keyboards enabled by TV manufacturers do not support concurrent virtual and onscreen keyboard use. This presents whenever a text field is selected, such as "search" where a constant **use the keyboard on your mobile device** will show, preventing you from opening the onscreen keyboard to type. This can be overcome by either disabling your 3rd party keyboard and using the default Gboard keyboard or by deselecting **Enable IME** in the **Configure** page of the integration.
-- In some instances, zeroconf will assign an incorrect IP address to a device. As a workaround, the below can be added to `configuration.yaml` to prevent zeroconf from assigning IPs for the integration. IPs will need to be manually entered during setup, as described [above](https://www.home-assistant.io/integrations/androidtv_remote/#configuration).
+- In some instances, Zeroconf will assign an incorrect IP address to a device. As a workaround, the below can be added to `configuration.yaml` to prevent Zeroconf from assigning IPs for the integration. IPs will need to be manually entered during setup, as described [above](/integrations/androidtv_remote/#configuration).
 ```yaml
 zeroconf:
   ignore:


### PR DESCRIPTION
## Proposed change
Added the bit at the very end about zeroconf assigning incorrect IP addresses, and a workaround for the issue.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Implemented a workaround to prevent zeroconf from assigning incorrect IP addresses for the `androidtv_remote` integration. Users need to add a new configuration snippet to their `configuration.yaml`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->