### PR TITLE
[Draft] Add documentation for Alternative selectors

### DIFF
--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -202,6 +202,13 @@ discriminator_field:
     the value will instead be wrapped in a dict whose single key is used as the discriminator.
   type: string
   required: false
+multiple:
+  description: >
+    Allows adding multiple objects. If set to `true`, the resulting value
+    of this selector will be a list instead of a single map value.
+  type: boolean
+  required: false
+  default: false
 translation_key:
   description: >
     Allows translations provided by an integration where `translation_key`
@@ -211,9 +218,9 @@ translation_key:
     for more information.
   type: string
   required: false
-multiple:
+sort:
   description: >
-    Allows selecting multiple options. If set to `true`, the resulting value of this selector will be a list instead of a single string value. This option is only used if `fields` option set.
+    Display options in alphabetical order.
   type: boolean
   required: false
   default: false

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -105,6 +105,8 @@ For example: `core_ssh`.
 
 ## Alternative selector
 
+_See also: [Object selector](#object-selector) and [Select selector](#select-selector)_
+
 The alternative selector allows choosing between multiple mutually exclusive sets of parameters. This is useful e.g. for choosing & configuring a DNS provider.
 
 ```yaml
@@ -1302,6 +1304,8 @@ number:
 
 ## Object selector
 
+_See also: [Alternative selector](#alternative-selector)_
+
 The object selector can be used to input arbitrary data in YAML form. This is useful for e.g. lists and dictionaries containing data for actions. The value of the input will contain the provided data.
 
 When used without options, the selector will accept a free form object.
@@ -1426,6 +1430,8 @@ This selector does not have any other options; therefore, it only has its key.
 The output of this selector is a list with the three (RGB) color value, for example: `[255, 0, 0]`.
 
 ## Select selector
+
+_See also: [Alternative selector](#alternative-selector)_
 
 The select selector shows a list of available options from which the user can choose. The value of the input contains the value of the selected option. Only a single option can be selected at a time.
 

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -17,6 +17,7 @@ The following selectors are currently available:
 
 - [Action selector](#action-selector)
 - [Add-on selector](#add-on-selector)
+- [Alternative selector](#alternative-selector)
 - [Area selector](#area-selector)
 - [Attribute selector](#attribute-selector)
 - [Assist pipeline selector](#assist-pipeline-selector)
@@ -101,6 +102,97 @@ addon:
 
 The output of this selector is the slug of the selected add-on.
 For example: `core_ssh`.
+
+## Alternative selector
+
+The alternative selector allows choosing between multiple mutually exclusive sets of parameters. This is useful e.g. for choosing & configuring a DNS provider.
+
+```yaml
+alternative:
+  aws:
+    label: Amazon Web Services (AWS)
+    fields:
+      access_key_id:
+        label: AWS Access Key ID
+        required: true
+        selector:
+          text:
+      secret_access_key:
+        label: AWS Secret Access Key
+        selector:
+          text:
+  azure:
+    label: Microsoft Azure
+    fields:
+      azure_config:
+        label: Azure Configuration
+        selector:
+          object: {}
+  cloudflare:
+    fields:
+      api_key:
+        label: Cloudflare API Key
+        selector:
+          text:
+      api_token: str?
+        label: Cloudflare API Token
+        selector:
+          text:
+      email:
+        label: Cloudflare Email Address
+        selector:
+          text:
+```
+
+The output of this selector is a YAML object. For example, given the configuration above:
+
+```
+aws:
+  access_key_id: "abc"
+  secret_access_key: "def"
+```
+
+{% configuration alternative %}
+options:
+  description: >
+    List of mutually exclusive options.
+  type: map
+  required: true
+  keys:
+    label:
+      description: The label of the option
+      required: false
+      type: string
+    fields:
+      description: >
+        List of fields for this option
+      type: map
+      required: false
+      keys:
+        label:
+          description: The label of the field
+          required: false
+          type: string
+        selector:
+          description: The selector to use for this field. It can be any available selector.
+          required: true
+          type: string
+translation_key:
+  description: >
+    Allows translations provided by an integration where `translation_key`
+    is the translation key that is providing the selector option strings
+    translation. See the documentation on
+    [Backend Localization](https://developers.home-assistant.io/docs/internationalization/core/#selectors)
+    for more information.
+  type: string
+  required: false
+multiple:
+  description: >
+    Allows selecting multiple options. If set to `true`, the resulting value of this selector will be a list instead of a single string value. This option is only used if `fields` option set.
+  type: boolean
+  required: false
+  default: false
+{% endconfiguration %}
 
 ## Area selector
 

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -112,7 +112,7 @@ The alternative selector allows choosing between multiple mutually exclusive set
 ```yaml
 alternative:
   options:
-    aws:
+    - value: aws
       label: Amazon Web Services (AWS)
       fields:
         access_key_id:
@@ -124,14 +124,14 @@ alternative:
           label: AWS Secret Access Key
           selector:
             text:
-    azure:
+    - value: azure
       label: Microsoft Azure
       fields:
         azure_config:
           label: Azure Configuration
           selector:
             object: {}
-    cloudflare:
+    - value: cloudflare
       fields:
         api_key:
           label: Cloudflare API Key
@@ -175,9 +175,13 @@ secret_access_key: "def"
 options:
   description: >
     List of mutually exclusive options.
-  type: map
+  type: list
   required: true
   keys:
+    value:
+      description: The key of the option.
+      required: true
+      type: string
     label:
       description: The label of the option.
       required: false

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -109,39 +109,40 @@ The alternative selector allows choosing between multiple mutually exclusive set
 
 ```yaml
 alternative:
-  aws:
-    label: Amazon Web Services (AWS)
-    fields:
-      access_key_id:
-        label: AWS Access Key ID
-        required: true
-        selector:
-          text:
-      secret_access_key:
-        label: AWS Secret Access Key
-        selector:
-          text:
-  azure:
-    label: Microsoft Azure
-    fields:
-      azure_config:
-        label: Azure Configuration
-        selector:
-          object: {}
-  cloudflare:
-    fields:
-      api_key:
-        label: Cloudflare API Key
-        selector:
-          text:
-      api_token: str?
-        label: Cloudflare API Token
-        selector:
-          text:
-      email:
-        label: Cloudflare Email Address
-        selector:
-          text:
+  options:
+    aws:
+      label: Amazon Web Services (AWS)
+      fields:
+        access_key_id:
+          label: AWS Access Key ID
+          required: true
+          selector:
+            text:
+        secret_access_key:
+          label: AWS Secret Access Key
+          selector:
+            text:
+    azure:
+      label: Microsoft Azure
+      fields:
+        azure_config:
+          label: Azure Configuration
+          selector:
+            object: {}
+    cloudflare:
+      fields:
+        api_key:
+          label: Cloudflare API Key
+          selector:
+            text:
+        api_token: str?
+          label: Cloudflare API Token
+          selector:
+            text:
+        email:
+          label: Cloudflare Email Address
+          selector:
+            text:
 ```
 
 The output of this selector is a YAML object. For example, given the configuration above, one possible output would look like this:

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -105,7 +105,7 @@ For example: `core_ssh`.
 
 ## Alternative selector
 
-_See also: [Object selector](#object-selector) and [Select selector](#select-selector)_
+_<small>See also: [Object selector](#object-selector) and [Select selector](#select-selector)</small>_
 
 The alternative selector allows choosing between multiple mutually exclusive sets of parameters. This is useful e.g. for choosing & configuring a DNS provider.
 
@@ -1304,7 +1304,7 @@ number:
 
 ## Object selector
 
-_See also: [Alternative selector](#alternative-selector)_
+_<small>See also: [Alternative selector](#alternative-selector)</small>_
 
 The object selector can be used to input arbitrary data in YAML form. This is useful for e.g. lists and dictionaries containing data for actions. The value of the input will contain the provided data.
 
@@ -1431,7 +1431,7 @@ The output of this selector is a list with the three (RGB) color value, for exam
 
 ## Select selector
 
-_See also: [Alternative selector](#alternative-selector)_
+_<small>See also: [Alternative selector](#alternative-selector)</small>_
 
 The select selector shows a list of available options from which the user can choose. The value of the input contains the value of the selected option. Only a single option can be selected at a time.
 

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -144,9 +144,9 @@ alternative:
           text:
 ```
 
-The output of this selector is a YAML object. For example, given the configuration above:
+The output of this selector is a YAML object. For example, given the configuration above, one possible output would look like this:
 
-```
+```yaml
 aws:
   access_key_id: "abc"
   secret_access_key: "def"

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -161,17 +161,17 @@ options:
   required: true
   keys:
     label:
-      description: The label of the option
+      description: The label of the option.
       required: false
       type: string
     fields:
       description: >
-        List of fields for this option
+        List of fields for this option.
       type: map
       required: false
       keys:
         label:
-          description: The label of the field
+          description: The label of the field.
           required: false
           type: string
         selector:

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -153,6 +153,22 @@ aws:
   secret_access_key: "def"
 ```
 
+When a `discriminator_field` is specified, the output would look this instead:
+
+```yaml
+# Modified schema:
+#
+# alternative:
+#   discriminator_field: provider
+#   options:
+#     aws: { ... }
+#     azure: { ... }
+#     cloudflare: { ... }
+provider: aws
+access_key_id: "abc"
+secret_access_key: "def"
+```
+
 {% configuration alternative %}
 options:
   description: >
@@ -178,6 +194,12 @@ options:
           description: The selector to use for this field. It can be any available selector.
           required: true
           type: string
+discriminator_field:
+  description: >
+    The field to use as the discriminator, for example `type` or `action`. If not set,
+    the value will instead be wrapped in a dict whose single key is used as the discriminator.
+  type: string
+  required: false
 translation_key:
   description: >
     Allows translations provided by an integration where `translation_key`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
> [!NOTE]
> See the next section for different naming proposals.

Add documentation for the (possibly upcoming if accepted) Alternative selector that codifies the pattern of selecting a subtype and providing the corresponding configuration options in a way that makes it accessible to UI:

```yaml
dns_provider:
  aws:
    access_key: ...
    access_token: ...
# Or:
dns_provider:
  cloudflare:
    api_key: ...
    api_token: ...
# Or:
dns_provider:
  bind:
    server_url: ...
    password: ...
# Or:
...
```

It is mostly intended for complex Addon configurations (see home-assistant/supervisor#6171 for related discussion) but should be useful for Blueprints as well.

In addition, a secondary mode supports using a discriminator field instead, to allow for generalization of the following pattern:

```
# Example: Using "condition" as discriminator_field
conditions:
  - condition: numeric_state
    entity_id: sun.sun
    attribute: elevation
    below: 4
  - condition: state
    entity_id: sensor.office_illuminance
    below: 10

# Example: Using "trigger" as discriminator_field
triggers:
  - trigger: state
    entity_id: sensor.office_occupancy
    to: "on"
```

The intended UI is similar to the Selector selector: Select a type (in this case: a selector type), then provide its parameters below:

- Card container / Visual grouping
  - Dropdown: Select type
  - Field 1 of selected type (set of fields will change when selected type is changed)
  - ...
  - Field N of selected type

### A Note about Naming

I'm not 100% sure about the correct name for this selector type, and whether or not to add it as a standalone selector or as an additional feature to an existing selector. The proposed UI and output data schema remains the same, but the schema for defining the selector itself changes.

For reference, I've considered the following names and options:

- Add as a new selector type
  - Alternative selector
  - Choice selector
  - Subtype selector
  - Select Object selector
  - Object Alternative selector
  - Object Choice selector
  - Object Options selector
  - Object Select selector
  - Object Subtype selector
  - Object Type selector
  - Object Kind selector
  - Typed Object selector
- Extend an existing selector type
  - Extend Select selector with <code>select.options.[<em>&lt;index&gt;</em>].fields</code> field
  - Extend Object selector with <code>object.options</code> field

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to core pull request: https://github.com/home-assistant/core/pull/152242
- Link to frontend pull request: (TBD)
- ~~Link to parent pull request in the Brands repository:~~
- ~~This PR fixes or closes issue: fixes #~~

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
