### PR TITLE
feat: Add `set_curfew` action to Sure Petcare integration

### DIFF
--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -35,12 +35,6 @@ The `surepetcare.set_lock_state` action changes the locking state of a flap.
 | `flap_id` | `True` | integer | Flap ID to change - see below for instructions on finding device ID
 | `lock_state` | `True` | string | New state to change the flap to
 
-The `flap_id` can be found following these instructions:
-
-- Log into [surepetcare.io](https://surepetcare.io/).
-- Open the sidebar and click your flap.
-- The `flap_id` will be at the end of the URL (i.e., `https://surepetcare.io/control/device/FLAP-ID`)
-
 `lock_state` should be one of:
 
 - `unlocked` - flap is unlocked, pets are allowed both in and out.
@@ -61,3 +55,31 @@ The `surepetcare.set_pet_location` action sets the pet location.
 
 - `Inside` - Pet is inside.
 - `Outside` - Pet is outside.
+
+### Action: Set curfew
+
+The `surepetcare.set_curfew` action sets curfew times for a flap. Curfew automatically locks and unlocks the flap at specified times daily.
+
+| Data attribute | Required | Type | Description |
+| ---------------------- | -------- | -------- | ----------- |
+| `flap_id` | yes | string or integer | Flap ID to change - see below for instructions on finding device ID
+| `lock_time` | yes | string | Time to automatically lock the flap each day. Format: HH:MM:SS (24-hour format). For example: "22:00:00" for 10 PM.
+| `unlock_time` | yes | string | Time to automatically unlock the flap each day. Format: HH:MM:SS (24-hour format). For example: "07:00:00" for 7 AM.
+
+This example configures the flap to automatically lock at 10 PM and unlock at 7 AM every day:
+
+```yaml
+action: surepetcare.set_curfew
+data:
+  flap_id: 123456
+  lock_time: "22:00:00"
+  unlock_time: "07:00:00"
+```
+
+## Finding device IDs
+
+The `flap_id` can be found following these instructions:
+
+- Log into [surepetcare.io](https://surepetcare.io/).
+- Open the sidebar and click your flap.
+- The `flap_id` will be at the end of the URL (i.e., `https://surepetcare.io/control/device/FLAP-ID`)


### PR DESCRIPTION
Adds the `surepetcare.set_curfew` action to the Sure Petcare integration.

This action allows users to set curfew times for a flap, which automatically locks and unlocks the flap at specified times daily, enhancing control and automation for pet owners.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- https://github.com/home-assistant/core/pull/163739

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
