### PR TITLE
feat(google_generative_ai_conversation): add documentation about thinking on gemini 2.5 and gemini 3 models

### DIFF
--- a/source/_integrations/google_generative_ai_conversation.markdown
+++ b/source/_integrations/google_generative_ai_conversation.markdown
@@ -76,7 +76,7 @@ Maximum Tokens to Return in Response:
 Thinking budget:
   description: The token budget for internal reasoning before the model generates a response (Gemini 2.5 models only). Set this to `-1` to let the model decide automatically, `0` to disable reasoning (not available for Gemini 2.5 Pro), or a positive number for a custom budget.
 Thinking level:
-  description: The level of internal reasoning for Gemini 3 models. You can choose **Auto**, **Low**, **Medium**, or **High**. This setting is ignored for Gemini 2.5 models, which use the thinking budget instead.
+  description: The level of internal reasoning for Gemini 3 models. For Gemini Flash series models, you can choose **Minimal**, **Auto**, **Low**, **Medium**, or **High**. For Gemini 3.1 Pro, you can choose **Auto**, **Low**, **Medium**, or **High**. This setting is ignored for Gemini 2.5 models, which use the thinking budget instead.
 Safety settings:
   description: Thresholds for different [harmful categories](https://ai.google.dev/gemini-api/docs/safety-settings).
 Enable Google Search tool:

--- a/source/_integrations/google_generative_ai_conversation.markdown
+++ b/source/_integrations/google_generative_ai_conversation.markdown
@@ -73,6 +73,8 @@ Top K:
   description: Number of top-scored tokens to consider during generation.
 Maximum Tokens to Return in Response:
   description: The maximum number of words or "tokens" that the AI model should generate.
+Thinking budget:
+  description: The number of tokens the model can use for internal reasoning before generating a response. Use -1 for automatic, 0 to disable reasoning (not available for Gemini 2.5 Pro), or a positive number for a custom budget. For Gemini 3 models, this value is mapped to specific thinking levels.
 Safety settings:
   description: Thresholds for different [harmful categories](https://ai.google.dev/gemini-api/docs/safety-settings).
 Enable Google Search tool:

--- a/source/_integrations/google_generative_ai_conversation.markdown
+++ b/source/_integrations/google_generative_ai_conversation.markdown
@@ -74,7 +74,9 @@ Top K:
 Maximum Tokens to Return in Response:
   description: The maximum number of words or "tokens" that the AI model should generate.
 Thinking budget:
-  description: The number of tokens the model can use for internal reasoning before generating a response. Use -1 for automatic, 0 to disable reasoning (not available for Gemini 2.5 Pro), or a positive number for a custom budget. For Gemini 3 models, this value is mapped to specific thinking levels.
+  description: The token budget for internal reasoning before the model generates a response (Gemini 2.5 models only). Set this to `-1` to let the model decide automatically, `0` to disable reasoning (not available for Gemini 2.5 Pro), or a positive number for a custom budget.
+Thinking level:
+  description: The level of internal reasoning for Gemini 3 models. You can choose **Auto**, **Low**, **Medium**, or **High**. This setting is ignored for Gemini 2.5 models, which use the thinking budget instead.
 Safety settings:
   description: Thresholds for different [harmful categories](https://ai.google.dev/gemini-api/docs/safety-settings).
 Enable Google Search tool:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).


  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document the new **Thinking budget** configuration option for the Google Generative AI Conversation integration. This follows the implementation of reasoning token support for Gemini 2.5 and Gemini 3 models.

The update explains:
- How to use the integer field to set a custom reasoning budget.
- The use of `-1` for automatic allocation.
- The use of `0` to disable thinking (where supported).
- How the value maps to `ThinkingLevel` enums for Gemini 3 models.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.


## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/164056
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - [x] I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].


[standards]: https://developers.home-assistant.io/docs/documenting/standards