### PR TITLE
Add eufy_robovac integration docs with onboarding and supported models

### DIFF
--- a/source/_integrations/eufy_robovac.markdown
+++ b/source/_integrations/eufy_robovac.markdown
@@ -24,7 +24,9 @@ Currently supported:
 
 - Eufy RoboVac G30 Hybrid (`T2253`)
 
-Other RoboVac models may work, but are not yet validated by this integration.
+Not currently supported:
+
+- RoboVac models other than `T2253`
 
 ## Prerequisites
 

--- a/source/_integrations/eufy_robovac.markdown
+++ b/source/_integrations/eufy_robovac.markdown
@@ -1,0 +1,54 @@
+---
+title: Eufy RoboVac
+description: Instructions on how to integrate Eufy RoboVac devices into Home Assistant.
+ha_category:
+  - Sensor
+  - Vacuum
+ha_iot_class: Local Polling
+ha_release: 2026.3
+ha_config_flow: true
+ha_domain: eufy_robovac
+ha_platforms:
+  - sensor
+  - vacuum
+ha_integration_type: device
+---
+
+The **Eufy RoboVac** {% term integration %} allows you to connect supported Eufy RoboVac models to Home Assistant using local control.
+
+The integration uses Eufy account credentials during setup to discover available RoboVacs and retrieve local connection details, then controls the vacuum locally on your network.
+
+{% include integrations/config_flow.md %}
+
+{% configuration_basic %}
+Email:
+  description: The email address used for your Eufy account.
+Password:
+  description: The password used for your Eufy account.
+RoboVac:
+  description: The discovered RoboVac to add.
+Host:
+  description: The local IP address of the RoboVac. If auto-discovery does not populate it, enter it manually.
+Protocol version:
+  description: Tuya protocol version used for local communication. Start with `3.3` for G30 Hybrid (`T2253`).
+{% endconfiguration_basic %}
+
+## Prerequisites
+
+- Your Home Assistant instance must be able to reach the vacuum over the local network.
+- For reliability, assign a DHCP reservation/static IP to your RoboVac.
+
+## Supported functionality
+
+### Vacuum
+
+The vacuum entity supports common controls, including:
+
+- Start cleaning
+- Pause cleaning
+- Return to base
+- Fan speed selection
+
+### Sensor
+
+A battery sensor entity is created for supported RoboVac models.

--- a/source/_integrations/eufy_robovac.markdown
+++ b/source/_integrations/eufy_robovac.markdown
@@ -18,25 +18,33 @@ The **Eufy RoboVac** {% term integration %} allows you to connect supported Eufy
 
 The integration uses Eufy account credentials during setup to discover available RoboVacs and retrieve local connection details, then controls the vacuum locally on your network.
 
-{% include integrations/config_flow.md %}
+## Supported devices
 
-{% configuration_basic %}
-Email:
-  description: The email address used for your Eufy account.
-Password:
-  description: The password used for your Eufy account.
-RoboVac:
-  description: The discovered RoboVac to add.
-Host:
-  description: The local IP address of the RoboVac. If auto-discovery does not populate it, enter it manually.
-Protocol version:
-  description: Tuya protocol version used for local communication. Start with `3.3` for G30 Hybrid (`T2253`).
-{% endconfiguration_basic %}
+Currently supported:
+
+- Eufy RoboVac G30 Hybrid (`T2253`)
+
+Other RoboVac models may work, but are not yet validated by this integration.
 
 ## Prerequisites
 
-- Your Home Assistant instance must be able to reach the vacuum over the local network.
-- For reliability, assign a DHCP reservation/static IP to your RoboVac.
+- Your Home Assistant instance must be able to reach the vacuum over your local network.
+- For reliability, assign a Dynamic Host Configuration Protocol (DHCP) reservation or static IP address to your RoboVac.
+
+{% include integrations/config_flow.md %}
+
+{% configuration_basic %}
+Email address:
+  description: "The email address used to sign in to your Eufy account during setup."
+Password:
+  description: "The password used to sign in to your Eufy account during setup."
+RoboVac:
+  description: "The RoboVac discovered from your Eufy account that you want to add."
+Host:
+  description: "The local IP address of the selected RoboVac. If auto-discovery does not populate it, enter it manually."
+Protocol version:
+  description: "Tuya protocol version used for local communication. Start with `3.3` for G30 Hybrid (`T2253`)."
+{% endconfiguration_basic %}
 
 ## Supported functionality
 

--- a/source/_integrations/eufy_robovac.markdown
+++ b/source/_integrations/eufy_robovac.markdown
@@ -22,11 +22,24 @@ The integration uses Eufy account credentials during setup to discover available
 
 Currently supported:
 
-- Eufy RoboVac G30 Hybrid (`T2253`)
+- RoboVac 30C (`T2118`)
+- RoboVac 15C Max (`T2128`)
+- RoboVac G20 (`T2181`)
+- RoboVac LR30 Hybrid (`T2193`)
+- RoboVac L35 Hybrid (`T2194`)
+- RoboVac G30 Edge (`T2251`)
+- RoboVac G30 Verge (`T2252`)
+- G30 Hybrid (`T2253`)
+- RoboVac G20 Hybrid (`T2254`)
+- RoboVac G35+ (`T2255`)
+- RoboVac G40+ (`T2259`)
+- RoboVac X8 (`T2261`)
+- RoboVac X8 Hybrid (`T2262`)
+- RoboVac LR30 Hybrid+ (`T2268`)
 
 Not currently supported:
 
-- RoboVac models other than `T2253`
+- RoboVac models not listed above
 
 ## Prerequisites
 
@@ -45,7 +58,7 @@ RoboVac:
 Host:
   description: "The local IP address of the selected RoboVac. If auto-discovery does not populate it, enter it manually."
 Protocol version:
-  description: "Tuya protocol version used for local communication. Start with `3.3` for G30 Hybrid (`T2253`)."
+  description: "Tuya protocol version used for local communication. Start with `3.3`; if the device does not respond, try `3.4` or `3.5`."
 {% endconfiguration_basic %}
 
 ## Supported functionality

--- a/source/_integrations/eufy_robovac.markdown
+++ b/source/_integrations/eufy_robovac.markdown
@@ -43,6 +43,7 @@ Not currently supported:
 
 ## Prerequisites
 
+- The vacuum must already be added to your Eufy account in the Eufy app.
 - Your Home Assistant instance must be able to reach the vacuum over your local network.
 - For reliability, assign a Dynamic Host Configuration Protocol (DHCP) reservation or static IP address to your RoboVac.
 
@@ -75,3 +76,18 @@ The vacuum entity supports common controls, including:
 ### Sensor
 
 A battery sensor entity is created for supported RoboVac models.
+
+## Known limitations
+
+- Some models may not return their local IP address during account discovery. If that happens, enter the host manually during setup.
+- Some models require a different Tuya protocol version. Start with `3.3`, then try `3.4` or `3.5` if the device does not respond.
+
+## Remove the integration
+
+To remove the **Eufy RoboVac** integration from Home Assistant:
+
+1. Go to **Settings** > **Devices & services**.
+2. Select the **Eufy RoboVac** integration.
+3. Select the three-dot menu, then select **Delete**.
+
+Removing the integration from Home Assistant does not remove the vacuum from your Eufy account and does not factory-reset the device.


### PR DESCRIPTION
## Proposed change
Add and refine documentation for the new `eufy_robovac` integration, including account-driven onboarding steps and the currently supported model set from the core PR.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/164040
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/9873
- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/164027

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
