### PR TITLE
Add documentation for ISEO Argo BLE lock integration

### DIFF
--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -3,7 +3,7 @@ title: ISEO Argo BLE
 description: Instructions on how to integrate your ISEO Argo smart lock into Home Assistant via Bluetooth.
 ha_category:
   - Lock
-ha_release: 2026.4
+ha_release: 2026.9
 ha_iot_class: Local Polling
 ha_config_flow: true
 ha_codeowners:

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -4,7 +4,7 @@ description: Instructions on how to integrate your ISEO Argo smart lock into Hom
 ha_category:
   - Lock
 ha_release: 2026.9
-ha_iot_class: Local Push
+ha_iot_class: Local Polling
 ha_config_flow: true
 ha_codeowners:
   - '@FezVrasta'
@@ -39,33 +39,14 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 4. Select **Submit** and within 30 seconds, scan the Master Card on the lock to authorize Home Assistant. 
    - **Result**: The lock's LED will blink green when the card is successfully read.
 
-That same Master Card scan also enables the lock's **Door Status Advice** setting, which makes the lock broadcast its door state. Home Assistant reads the door state from those broadcasts, so it does not connect to the lock to check on it.
-
 ## Supported functionality
 
 - **Lock**: Controls the lock (unlock only). Reflects the current locked/unlocked state.
-
-## Door state updates
-
-Home Assistant follows the door state the lock broadcasts in its Bluetooth advertisements. Changes are reported as they happen, and the lock is only connected to when you unlock it.
-
-This needs two things: the lock must have a door sensor, and its **Door Status Advice** setting must be enabled. Setting the integration up enables it for you. If your lock was added before this was the case, you can also enable Door Status Advice for the lock in the official Argo app.
-
-Locks without a door sensor report no door state at all. Their entity is marked as assumed state, and shows as locked between unlocks.
-
-## Configuration options
-
-{% configuration_basic %}
-Connect to the lock to read door status:
-  description: "Connect to the lock every 30 seconds and read the door state, in addition to following its broadcasts. Enable this only if the broadcasts do not reach Home Assistant reliably, for example at the edge of Bluetooth range or with no Bluetooth proxy nearby. It wakes the lock on every check, so it is off by default. It does not help if the lock reports no door state at all."
-{% endconfiguration_basic %}
 
 ## Known limitations
 
 - The lock only supports _one active Bluetooth connection_ at a time. Close the Argo app on all phones before unlocking or during setup.
 - The ISEO X1R is a momentary actuator: it re-latches automatically after every unlock. The `lock` action is therefore not supported.
-- Door state requires a lock with a door sensor and **Door Status Advice** enabled. Without it, the lock's state is assumed rather than reported.
-- The lock broadcasts in bursts when something happens and then goes quiet for several minutes, so an unlock can take a few seconds while Home Assistant connects to it.
 
 ## Removing the integration
 

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -4,7 +4,7 @@ description: Instructions on how to integrate your ISEO Argo smart lock into Hom
 ha_category:
   - Lock
 ha_release: 2026.9
-ha_iot_class: Local Polling
+ha_iot_class: Local Push
 ha_config_flow: true
 ha_codeowners:
   - '@FezVrasta'
@@ -39,14 +39,33 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 4. Select **Submit** and within 30 seconds, scan the Master Card on the lock to authorize Home Assistant. 
    - **Result**: The lock's LED will blink green when the card is successfully read.
 
+That same Master Card scan also enables the lock's **Door Status Advice** setting, which makes the lock broadcast its door state. Home Assistant reads the door state from those broadcasts, so it does not connect to the lock to check on it.
+
 ## Supported functionality
 
 - **Lock**: Controls the lock (unlock only). Reflects the current locked/unlocked state.
+
+## Door state updates
+
+Home Assistant follows the door state the lock broadcasts in its Bluetooth advertisements. Changes are reported as they happen, and the lock is only connected to when you unlock it.
+
+This needs two things: the lock must have a door sensor, and its **Door Status Advice** setting must be enabled. Setting the integration up enables it for you. If your lock was added before this was the case, you can also enable Door Status Advice for the lock in the official Argo app.
+
+Locks without a door sensor report no door state at all. Their entity is marked as assumed state, and shows as locked between unlocks.
+
+## Configuration options
+
+{% configuration_basic %}
+Connect to the lock to read door status:
+  description: "Connect to the lock every 30 seconds and read the door state, in addition to following its broadcasts. Enable this only if the broadcasts do not reach Home Assistant reliably, for example at the edge of Bluetooth range or with no Bluetooth proxy nearby. It wakes the lock on every check, so it is off by default. It does not help if the lock reports no door state at all."
+{% endconfiguration_basic %}
 
 ## Known limitations
 
 - The lock only supports _one active Bluetooth connection_ at a time. Close the Argo app on all phones before unlocking or during setup.
 - The ISEO X1R is a momentary actuator: it re-latches automatically after every unlock. The `lock` action is therefore not supported.
+- Door state requires a lock with a door sensor and **Door Status Advice** enabled. Without it, the lock's state is assumed rather than reported.
+- The lock broadcasts in bursts when something happens and then goes quiet for several minutes, so an unlock can take a few seconds while Home Assistant connects to it.
 
 ## Removing the integration
 

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -29,7 +29,6 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 - The physical Master Card that was supplied with the lock. It is required during the setup process to authorize Home Assistant.
 - The official **Argo** app must be closed on all phones during each setup step, as the lock only accepts one Bluetooth connection at a time.
 
-## Setup
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -24,7 +24,7 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 
 ## Prerequisites
 
-- A Bluetooth adapter accessible to Home Assistant (built-in or via [ESPHome Bluetooth proxy](https://www.home-assistant.io/integrations/esphome/)).
+- A Bluetooth adapter accessible to Home Assistant (built-in or via [ESPHome Bluetooth proxy](https://www.home-assistant.io/integrations/bluetooth/#remote-adapters-bluetooth-proxies)).
 - An ISEO Argo smart lock, such as x1R Smart or AGB Smart.
 - The physical Master Card that was supplied with the lock. It is required during the setup process to authorize Home Assistant.
 - The official **Argo** app must be closed on all phones during each setup step, as the lock only accepts one Bluetooth connection at a time.

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -3,7 +3,7 @@ title: ISEO Argo BLE
 description: Instructions on how to integrate your ISEO Argo smart lock into Home Assistant via Bluetooth.
 ha_category:
   - Lock
-ha_release: "2026.4"
+ha_release: '2026.4'
 ha_iot_class: Local Push
 ha_config_flow: true
 ha_codeowners:
@@ -27,7 +27,7 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 - A Bluetooth adapter accessible to Home Assistant (built-in or via [ESPHome Bluetooth proxy](https://www.home-assistant.io/integrations/esphome/)).
 - An ISEO Argo smart lock, such as x1R Smart or AGB Smart.
 - The physical **Master Card** that was supplied with the lock — it is required during the setup process to authorize Home Assistant.
-- The official **ARGO app must be closed** on all phones during each setup step, as the lock only accepts one Bluetooth connection at a time.
+- The official **Argo app must be closed** on all phones during each setup step, as the lock only accepts one Bluetooth connection at a time.
 
 ## Setup
 
@@ -35,24 +35,24 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 
 ### Step-by-step walkthrough
 
-The setup flow consists of two registration steps, each of which requires you to scan the Master Card on the lock:
+The setup flow consists of three steps. You only need to scan the Master Card during the registration steps:
 
 1. **Select lock** – Home Assistant scans for nearby ISEO locks and presents them in a list. Select your lock and select **Submit**.
-2. **Register Gateway** – Home Assistant generates a unique identity. Select **Submit**, then within 30 seconds scan the **Master Card** on the lock. The lock LEDs blink green when successful.
-3. **Enable Gateway Logs** – Select **Submit** again and scan the **Master Card** a second time within 30 seconds to grant Home Assistant permission to receive real-time log entries. The lock LEDs blink green when successful.
+2. **Register Gateway** – Select **Submit**, then within 30 seconds scan the **Master Card** on the lock to authorize Home Assistant. The lock LEDs blink green when the card is read successfully.
+3. **Enable Gateway Logs** – Select **Submit** again and, within 30 seconds, scan the **Master Card** a second time to grant Home Assistant permission to receive real-time log entries. The lock LEDs blink green when the card is read successfully.
 
 ## Entities
 
 ### Lock
 
-| Entity | Description |
-|--------|-------------|
-| Lock | Controls the lock (unlock only). Reflects the current locked/unlocked state. |
+| Entity | Description                                                                  |
+| ------ | ---------------------------------------------------------------------------- |
+| Lock   | Controls the lock (unlock only). Reflects the current locked/unlocked state. |
 
 ## Known limitations
 
-- The lock only supports **one active Bluetooth connection** at a time. Close the ARGO app on all phones before unlocking or during setup.
-- The ISEO X1R is a momentary actuator: it re-latches automatically after every unlock. The `lock` action is therefore a no-op.
+- The lock only supports **one active Bluetooth connection** at a time. Close the Argo app on all phones before unlocking or during setup.
+- The ISEO X1R is a momentary actuator: it re-latches automatically after every unlock. The `lock` action is therefore not supported.
 
 ## Removing the integration
 

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -33,7 +33,6 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 
 ### Adding your ISEO lock to Home Assistant
 
-The setup flow consists of two steps. You only need to scan the Master Card once:
 
 1. As soon as you add the integration to Home Assistant, Home Assistant scans for nearby ISEO locks and presents them in a list.
 2. In Home Assistant, go to {% my integrations title="**Settings** > **Devices & services**" %}.

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -25,7 +25,7 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 ## Prerequisites
 
 - A Bluetooth adapter accessible to Home Assistant (built-in or via [ESPHome Bluetooth proxy](https://www.home-assistant.io/integrations/esphome/)).
-- An ISEO Argo smart lock (e.g., x1R Smart, AGB Smart).
+- An ISEO Argo smart lock, such as x1R Smart or AGB Smart.
 - The physical **Master Card** that was supplied with the lock — it is required during the setup process to authorize Home Assistant.
 - The official **ARGO app must be closed** on all phones during each setup step, as the lock only accepts one Bluetooth connection at a time.
 

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -35,7 +35,9 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 
 The setup flow consists of two steps. You only need to scan the Master Card once:
 
-1. **Select lock** – Home Assistant scans for nearby ISEO locks and presents them in a list. Select your lock and select **Submit**.
+1. As soon as you add the integration to Home Assistant, Home Assistant scans for nearby ISEO locks and presents them in a list.
+2. In Home Assistant, go to {% my integrations title="**Settings** > **Devices & services**" %}.
+3. From the list, select the lock you want to set up.
 2. **Register Gateway** – Select **Submit**, then within 30 seconds scan the **Master Card** on the lock to authorize Home Assistant. The lock LEDs blink green when the card is read successfully.
 
 ## Supported functionality

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -37,9 +37,9 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 
 The setup flow consists of two registration steps, each of which requires you to scan the Master Card on the lock:
 
-1. **Select lock** – Home Assistant scans for nearby ISEO locks and presents them in a list. Select your lock and click **Submit**.
-2. **Register Gateway** – Home Assistant generates a unique identity. Click **Submit**, then within 30 seconds scan the **Master Card** on the lock. The lock LEDs blink green when successful.
-3. **Enable Gateway Logs** – Click **Submit** again and scan the **Master Card** a second time within 30 seconds to grant Home Assistant permission to receive real-time log entries. The lock LEDs blink green when successful.
+1. **Select lock** – Home Assistant scans for nearby ISEO locks and presents them in a list. Select your lock and select **Submit**.
+2. **Register Gateway** – Home Assistant generates a unique identity. Select **Submit**, then within 30 seconds scan the **Master Card** on the lock. The lock LEDs blink green when successful.
+3. **Enable Gateway Logs** – Select **Submit** again and scan the **Master Card** a second time within 30 seconds to grant Home Assistant permission to receive real-time log entries. The lock LEDs blink green when successful.
 
 ## Entities
 

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -1,0 +1,61 @@
+---
+title: ISEO Argo BLE
+description: Instructions on how to integrate your ISEO Argo smart lock into Home Assistant via Bluetooth.
+ha_category:
+  - Lock
+ha_release: "2026.4"
+ha_iot_class: Local Push
+ha_config_flow: true
+ha_codeowners:
+  - '@FezVrasta'
+ha_domain: iseo_argo_ble
+ha_platforms:
+  - lock
+ha_bluetooth: true
+ha_integration_type: device
+ha_quality_scale: bronze
+---
+
+The **ISEO Argo BLE** {% term integration %} connects Home Assistant to [ISEO](https://www.iseo.com) Argo smart locks over Bluetooth Low Energy. ISEO is an Italian security manufacturer specializing in high-security cylinders and electronic access control, widely used in residential and commercial buildings across Italy and Switzerland.
+
+Home Assistant registers itself as an Argo Gateway, giving it the same privileges as the official Argo app: unlocking the lock and receiving real-time access log entries.
+
+All communication is direct Bluetooth, with no cloud dependency or bridge hardware required.
+
+## Prerequisites
+
+- A Bluetooth adapter accessible to Home Assistant (built-in or via [ESPHome Bluetooth proxy](https://www.home-assistant.io/integrations/esphome/)).
+- An ISEO Argo smart lock (e.g., x1R Smart, AGB Smart).
+- The physical **Master Card** that was supplied with the lock — it is required during the setup process to authorize Home Assistant.
+- The official **ARGO app must be closed** on all phones during each setup step, as the lock only accepts one Bluetooth connection at a time.
+
+## Setup
+
+{% include integrations/config_flow.md %}
+
+### Step-by-step walkthrough
+
+The setup flow consists of two registration steps, each of which requires you to scan the Master Card on the lock:
+
+1. **Select lock** – Home Assistant scans for nearby ISEO locks and presents them in a list. Select your lock and click **Submit**.
+2. **Register Gateway** – Home Assistant generates a unique identity. Click **Submit**, then within 30 seconds scan the **Master Card** on the lock. The lock LEDs blink green when successful.
+3. **Enable Gateway Logs** – Click **Submit** again and scan the **Master Card** a second time within 30 seconds to grant Home Assistant permission to receive real-time log entries. The lock LEDs blink green when successful.
+
+## Entities
+
+### Lock
+
+| Entity | Description |
+|--------|-------------|
+| Lock | Controls the lock (unlock only). Reflects the current locked/unlocked state. |
+
+## Known limitations
+
+- The lock only supports **one active Bluetooth connection** at a time. Close the ARGO app on all phones before unlocking or during setup.
+- The ISEO X1R is a momentary actuator: it re-latches automatically after every unlock. The `lock` action is therefore a no-op.
+
+## Removing the integration
+
+This integration follows standard integration removal. No extra steps are required.
+
+{% include integrations/remove_device_service.md %}

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -4,7 +4,7 @@ description: Instructions on how to integrate your ISEO Argo smart lock into Hom
 ha_category:
   - Lock
 ha_release: 2026.4
-ha_iot_class: Local Push
+ha_iot_class: Local Polling
 ha_config_flow: true
 ha_codeowners:
   - '@FezVrasta'

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -24,7 +24,7 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 
 ## Prerequisites
 
-- A Bluetooth adapter accessible to Home Assistant (built-in or via [ESPHome Bluetooth proxy](https://www.home-assistant.io/integrations/bluetooth/#remote-adapters-bluetooth-proxies)).
+- A Bluetooth adapter accessible to Home Assistant (built-in or via [ESPHome Bluetooth proxy](/integrations/bluetooth/#remote-adapters-bluetooth-proxies)).
 - An ISEO Argo smart lock, such as x1R Smart or AGB Smart.
 - The physical Master Card that was supplied with the lock. It is required during the setup process to authorize Home Assistant.
 - The official **Argo** app must be closed on all phones during each setup step, as the lock only accepts one Bluetooth connection at a time.

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -27,7 +27,7 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 - A Bluetooth adapter accessible to Home Assistant (built-in or via [ESPHome Bluetooth proxy](https://www.home-assistant.io/integrations/esphome/)).
 - An ISEO Argo smart lock, such as x1R Smart or AGB Smart.
 - The physical Master Card that was supplied with the lock. It is required during the setup process to authorize Home Assistant.
-- The official **Argo app must be closed** on all phones during each setup step, as the lock only accepts one Bluetooth connection at a time.
+- The official **Argo** app must be closed on all phones during each setup step, as the lock only accepts one Bluetooth connection at a time.
 
 ## Setup
 

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -26,7 +26,7 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 
 - A Bluetooth adapter accessible to Home Assistant (built-in or via [ESPHome Bluetooth proxy](https://www.home-assistant.io/integrations/esphome/)).
 - An ISEO Argo smart lock, such as x1R Smart or AGB Smart.
-- The physical **Master Card** that was supplied with the lock — it is required during the setup process to authorize Home Assistant.
+- The physical Master Card that was supplied with the lock. It is required during the setup process to authorize Home Assistant.
 - The official **Argo app must be closed** on all phones during each setup step, as the lock only accepts one Bluetooth connection at a time.
 
 ## Setup

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -13,7 +13,7 @@ ha_platforms:
   - lock
 ha_bluetooth: true
 ha_integration_type: device
-ha_quality_scale: platinum
+ha_quality_scale: bronze
 ---
 
 The **ISEO Argo BLE** {% term integration %} connects Home Assistant to [ISEO](https://www.iseo.com) Argo smart locks over Bluetooth Low Energy. ISEO is an Italian security manufacturer specializing in high-security cylinders and electronic access control, widely used in residential and commercial buildings across Italy and Switzerland.

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -13,7 +13,7 @@ ha_platforms:
   - lock
 ha_bluetooth: true
 ha_integration_type: device
-ha_quality_scale: bronze
+ha_quality_scale: platinum
 ---
 
 The **ISEO Argo BLE** {% term integration %} connects Home Assistant to [ISEO](https://www.iseo.com) Argo smart locks over Bluetooth Low Energy. ISEO is an Italian security manufacturer specializing in high-security cylinders and electronic access control, widely used in residential and commercial buildings across Italy and Switzerland.

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -3,7 +3,7 @@ title: ISEO Argo BLE
 description: Instructions on how to integrate your ISEO Argo smart lock into Home Assistant via Bluetooth.
 ha_category:
   - Lock
-ha_release: '2026.4'
+ha_release: 2026.4
 ha_iot_class: Local Push
 ha_config_flow: true
 ha_codeowners:
@@ -29,7 +29,6 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 - The physical Master Card that was supplied with the lock. It is required during the setup process to authorize Home Assistant.
 - The official **Argo** app must be closed on all phones during each setup step, as the lock only accepts one Bluetooth connection at a time.
 
-
 {% include integrations/config_flow.md %}
 
 ### Step-by-step walkthrough
@@ -41,11 +40,7 @@ The setup flow consists of two steps. You only need to scan the Master Card once
 
 ## Supported functionality
 
-### Lock
-
-| Entity | Description                                                                  |
-| ------ | ---------------------------------------------------------------------------- |
-| Lock   | Controls the lock (unlock only). Reflects the current locked/unlocked state. |
+- **Lock**: Controls the lock (unlock only). Reflects the current locked/unlocked state.
 
 ## Known limitations
 

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -35,11 +35,10 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 
 ### Step-by-step walkthrough
 
-The setup flow consists of three steps. You only need to scan the Master Card during the registration steps:
+The setup flow consists of two steps. You only need to scan the Master Card once:
 
 1. **Select lock** – Home Assistant scans for nearby ISEO locks and presents them in a list. Select your lock and select **Submit**.
 2. **Register Gateway** – Select **Submit**, then within 30 seconds scan the **Master Card** on the lock to authorize Home Assistant. The lock LEDs blink green when the card is read successfully.
-3. **Enable Gateway Logs** – Select **Submit** again and, within 30 seconds, scan the **Master Card** a second time to grant Home Assistant permission to receive real-time log entries. The lock LEDs blink green when the card is read successfully.
 
 ## Entities
 

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -39,7 +39,7 @@ The setup flow consists of two steps. You only need to scan the Master Card once
 1. **Select lock** – Home Assistant scans for nearby ISEO locks and presents them in a list. Select your lock and select **Submit**.
 2. **Register Gateway** – Select **Submit**, then within 30 seconds scan the **Master Card** on the lock to authorize Home Assistant. The lock LEDs blink green when the card is read successfully.
 
-## Entities
+## Supported functionality
 
 ### Lock
 

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -38,7 +38,8 @@ The setup flow consists of two steps. You only need to scan the Master Card once
 1. As soon as you add the integration to Home Assistant, Home Assistant scans for nearby ISEO locks and presents them in a list.
 2. In Home Assistant, go to {% my integrations title="**Settings** > **Devices & services**" %}.
 3. From the list, select the lock you want to set up.
-2. **Register Gateway** – Select **Submit**, then within 30 seconds scan the **Master Card** on the lock to authorize Home Assistant. The lock LEDs blink green when the card is read successfully.
+2. Select **Submit** and within 30 seconds, scan the Master Card on the lock to authorize Home Assistant. 
+   - **Result**: The lock's LED will blink green when the card is successfully read.
 
 ## Supported functionality
 

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -37,7 +37,7 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 1. As soon as you add the integration to Home Assistant, Home Assistant scans for nearby ISEO locks and presents them in a list.
 2. In Home Assistant, go to {% my integrations title="**Settings** > **Devices & services**" %}.
 3. From the list, select the lock you want to set up.
-2. Select **Submit** and within 30 seconds, scan the Master Card on the lock to authorize Home Assistant. 
+4. Select **Submit** and within 30 seconds, scan the Master Card on the lock to authorize Home Assistant. 
    - **Result**: The lock's LED will blink green when the card is successfully read.
 
 ## Supported functionality

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -33,7 +33,6 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 
 ### Adding your ISEO lock to Home Assistant
 
-
 1. As soon as you add the integration to Home Assistant, Home Assistant scans for nearby ISEO locks and presents them in a list.
 2. In Home Assistant, go to {% my integrations title="**Settings** > **Devices & services**" %}.
 3. From the list, select the lock you want to set up.

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -31,7 +31,7 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 
 {% include integrations/config_flow.md %}
 
-### Step-by-step walkthrough
+### Adding your ISEO lock to Home Assistant
 
 The setup flow consists of two steps. You only need to scan the Master Card once:
 

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -44,7 +44,7 @@ The setup flow consists of two steps. You only need to scan the Master Card once
 
 ## Known limitations
 
-- The lock only supports **one active Bluetooth connection** at a time. Close the Argo app on all phones before unlocking or during setup.
+- The lock only supports _one active Bluetooth connection_ at a time. Close the Argo app on all phones before unlocking or during setup.
 - The ISEO X1R is a momentary actuator: it re-latches automatically after every unlock. The `lock` action is therefore not supported.
 
 ## Removing the integration


### PR DESCRIPTION
## Proposed change

Add documentation page for the new ISEO Argo BLE integration, which connects Home Assistant to ISEO Argo smart locks over Bluetooth Low Energy.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/164752
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/9921
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards