### PR TITLE
fritzbox: document "open window" switch

### DIFF
--- a/source/_integrations/fritzbox.markdown
+++ b/source/_integrations/fritzbox.markdown
@@ -121,7 +121,7 @@ Self defined [templates](https://fritz.com/en/apps/knowledge-base/FRITZ-Box-7590
 
 Thermostats like the FRITZ!Smart Thermo series or Eurotronic Comet DECT will be integrated as {% term climate %} entities.
 
-Further there are additional {% term switch %}, {% term sensor %} and {% term binary_sensor "binary sensor" %} entities created for each device which can be useful for {% term automations %} and {% term templates %}, based on its capabilities:
+Further there are additional {% term sensor %} and {% term binary_sensor "binary sensor" %} entities created for each device which can be useful for {% term automations %} and {% term templates %}, based on its capabilities:
 
 - Battery
 - Battery low
@@ -135,9 +135,25 @@ Further there are additional {% term switch %}, {% term sensor %} and {% term bi
 - Next Scheduled Preset
 - Next Scheduled Temperature
 - Open window detected
-- Manual open window indication (in combination with distinct window sensors)
 - Summer mode
 - Temperature
+
+#### Thermostat Actions
+
+Thermostat devices also support {% term actions %} which can be useful for {% term automations %}:
+
+##### Action: fritzbox.set_window_open
+
+This action triggers the open window detecton. This will override the schedule for the specified duration. You might call this
+action from an automation based on a separate window sensor.
+
+| Data attribute | Required | Description |
+| --- | --- | --- |
+| `duration` | yes | Timeout (seconds) after which the termostat will revert to its normal schedule. Valid values: 1 to 86400. Default: 600. |
+
+##### Action: fritzbox.set_window_close
+
+This action cancels a previous fritzbox.set_window_open action (or the device's internal open window detection). The device will revert to its schedule-based operation.
 
 ### Other devices
 

--- a/source/_integrations/fritzbox.markdown
+++ b/source/_integrations/fritzbox.markdown
@@ -121,7 +121,7 @@ Self defined [templates](https://fritz.com/en/apps/knowledge-base/FRITZ-Box-7590
 
 Thermostats like the FRITZ!Smart Thermo series or Eurotronic Comet DECT will be integrated as {% term climate %} entities.
 
-Further there are additional {% term sensor %} and {% term binary_sensor "binary sensor" %} entities created for each device which can be useful for {% term automations %} and {% term templates %}, based on its capabilities:
+Further there are additional {% term switch %}, {% term sensor %} and {% term binary_sensor "binary sensor" %} entities created for each device which can be useful for {% term automations %} and {% term templates %}, based on its capabilities:
 
 - Battery
 - Battery low
@@ -135,6 +135,7 @@ Further there are additional {% term sensor %} and {% term binary_sensor "binary
 - Next Scheduled Preset
 - Next Scheduled Temperature
 - Open window detected
+- Manual open window indication (in combination with distinct window sensors)
 - Summer mode
 - Temperature
 


### PR DESCRIPTION
Documentation pieces for the new set_window_{open,close} actions (https://github.com/home-assistant/core/pull/167125)

## Proposed change 
(from  https://github.com/home-assistant/core/pull/167125)
The new "notify open window" and "notify close window" actions can be used from automations to indicate an open or closed window (e.g. based on actual window sensors as in my case) . The "open window" detection (triggered manually via API) plays better with comfort/eco schedules than off hvac mode.

Currently one can only use the "off" hvac mode which can be cancelled too early (by the device itself) if interrupted by a schedule transition.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/167125

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
