### PR TITLE
Geniushub zone demand next

### DIFF
--- a/source/_integrations/geniushub.markdown
+++ b/source/_integrations/geniushub.markdown
@@ -104,11 +104,9 @@ This is particularly useful for automations that need to know precisely when hea
       entity_id: binary_sensor.hot_water
       to: "on"
   actions:
-    - action: number.set_value
-      target:
-        entity_id: number.opentherm_gateway_ch_water_temperature
+    - action: notify.YOUR_NOTIFICATION_SERVICE
       data:
-        value: 80
+        message: "Hot water is calling for heat"
 ```
 
 {% endraw %}

--- a/source/_integrations/geniushub.markdown
+++ b/source/_integrations/geniushub.markdown
@@ -86,7 +86,7 @@ Individual smart plugs are not yet exposed as switches - you can create one zone
 
 ### Zone demand binary sensors
 
-For each **Radiator**, **Wet Underfloor**, **On/Off** and **Hot Water Temperature** zone, a `Binary sensor` entity with device class `heat` is created. This reflects whether the zone is currently requesting heat from the boiler.
+For each **Radiator**, **Wet Underfloor**, **On/Off**, and **Hot Water Temperature** zone, a `Binary sensor` entity with device class `heat` is created. This reflects whether the zone is currently requesting heat from the boiler.
 
 | State | Meaning |
 | :---: | ------- |

--- a/source/_integrations/geniushub.markdown
+++ b/source/_integrations/geniushub.markdown
@@ -41,9 +41,10 @@ The local API is unofficial, but is faster and has more features, while the clou
 
 Each zone controlled by your Genius Hub will be exposed as either a:
 
-- `Climate` entity, for **Radiator** and **Wet Underfloor** zones, and
-- `Water heater` entity, for **Hot Water Temperature** zones and
-- `Switch` entity, for **On/Off** zones
+- `Climate` entity, for **Radiator** and **Wet Underfloor** zones,
+- `Water heater` entity, for **Hot Water Temperature** zones,
+- `Switch` entity, for **On/Off** zones, and
+- `Binary sensor` entity (device class: `heat`) for all of the above zone types, indicating whether the zone is actively calling for heat from the boiler
 
 **Group** zones are not supported.
 
@@ -82,6 +83,35 @@ Switch entities will report back their state; other properties are available via
 Note: if you turn a Switch entity `Off` via Home Assistant's web UI, it will revert to **Timer** mode - this may not be the behavior you are expecting.
 
 Individual smart plugs are not yet exposed as switches - you can create one zone per smart plug as a work-around.
+
+### Zone demand binary sensors
+
+For each **Radiator**, **Wet Underfloor**, **On/Off** and **Hot Water Temperature** zone, a `Binary sensor` entity with device class `heat` is created. This reflects whether the zone is currently requesting heat from the boiler.
+
+| State | Meaning |
+| :---: | ------- |
+| `on`  | Zone is calling for heat |
+| `off` | Zone is satisfied, not demanding heat |
+
+This is particularly useful for automations that need to know precisely when heating or hot water is actively demanding heat. For example, to switch a condensing boiler between a lower space-heating flow temperature and a higher domestic hot water flow temperature:
+
+{% raw %}
+
+```yaml
+- alias: "Boiler: raise flow temperature for hot water"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.hot_water
+      to: "on"
+  actions:
+    - action: number.set_value
+      target:
+        entity_id: number.opentherm_gateway_ch_water_temperature
+      data:
+        value: 80
+```
+
+{% endraw %}
 
 ### Devices
 


### PR DESCRIPTION
## Proposed change

Document new `binary_sensor` entities added to the GeniusHub integration. A zone demand sensor (device class: `heat`) is now created for each zone type that carries an output field: radiator, wet underfloor, on/off, and hot water temperature.

1. Update the Zones section to list the new binary sensor entity type alongside climate, water heater and switch entities.

2. Add a new "Zone demand binary sensors" subsection explaining the on/off states and include an example automation — using the hot water demand sensor to notify when the cylinder is calling for heat.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/167632
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards