### PR TITLE
Add BLANCO integration documentation

### DIFF
--- a/source/_integrations/blanco.markdown
+++ b/source/_integrations/blanco.markdown
@@ -22,9 +22,9 @@ The **BLANCO** {% term integration %} connects Home Assistant to the BLANCO Smar
 
 The integration is currently compatible with the following devices:
 
-- **CHOICE.ALL** – All‑in‑one water system (still, sparkling, hot)
-- **EVOL‑S PRO SODA (Rev F or later)** – Sparkling water system
-- **AQUA** – Filtered water system with filter monitoring
+- **CHOICE.ALL**: All‑in‑one water system (still, sparkling, hot)
+- **EVOL‑S PRO SODA (Rev F or later)**: Sparkling water system
+- **AQUA**: Filtered water system with filter monitoring
 
 All other BLANCO device types are not supported at this time.
 

--- a/source/_integrations/blanco.markdown
+++ b/source/_integrations/blanco.markdown
@@ -1,0 +1,157 @@
+---
+title: BLANCO
+description: Instructions on how to integrate BLANCO smart home devices in Home Assistant.
+ha_category:
+  - Water
+ha_release: "2026.x"
+ha_iot_class: Cloud Polling
+ha_config_flow: true
+ha_codeowners:
+  - "@blancoGDPD"
+ha_domain: blanco
+ha_platforms:
+  - binary_sensor
+  - diagnostics
+  - sensor
+ha_integration_type: device
+ha_quality_scale: bronze
+---
+
+The **BLANCO** {% term integration %} connects Home Assistant to the BLANCO Smart Home Cloud API and exposes data from supported BLANCO smart home devices as entities in Home Assistant. Depending on the device model, this includes water temperatures, filter and CO₂ capacities, water consumption values, connectivity information, and device error states.
+
+## Prerequisites
+
+Before setting up the integration, make sure the following requirements are met:
+
+- The **BLANCO UNIT App** is installed on an iOS or Android device.
+- The BLANCO device has already been added in the UNIT App.
+- The device is connected to **Wi-Fi** and available online in the UNIT App.
+- You are within **Bluetooth range** of the device during the Smart Home authorization step.
+
+{% note %}
+The Smart Home authorization must be granted from the BLANCO UNIT App while you are within Bluetooth range of the device.
+{% endnote %}
+
+## Supported devices
+
+The integration is currently compatible with the following devices:
+
+- **CHOICE.ALL** – All‑in‑one water system (still, sparkling, hot)
+- **EVOL‑S PRO SODA (Rev F or later)** – Sparkling water system
+- **AQUA** – Filtered water system with filter monitoring
+
+All other BLANCO device types are not supported at this time.
+
+## Configuration
+
+Before starting the setup in Home Assistant, you must first authorize the connection in the **BLANCO UNIT App** by sending the **RCA (secure connection link)**. The authorization is valid for **5 minutes**.
+
+1. Open the **BLANCO UNIT App**.
+2. Select the device you want to connect.
+3. Open **Settings**.
+4. Navigate to **Smart Home**.
+5. Send the **RCA (secure connection link)** by tapping **Activate**.
+6. Within **5 minutes**, open Home Assistant and start the BLANCO integration setup.
+
+To add the **BLANCO** integration to your Home Assistant instance, use this My button:
+
+{% include integrations/config_flow.md %}
+
+During setup in Home Assistant, confirm the integration and enter the **serial number** and **Service Code** shown in the UNIT App under **Smart Home**.
+
+{% note %}
+You must remain within Bluetooth range of the device when sending the RCA. If the 5‑minute authorization window expires, repeat the Smart Home authorization step in the UNIT App before trying again.
+{% endnote %}
+
+## Configuration variables
+
+{% configuration_basic %}
+Serial number:
+  description: >
+    The serial number of the device, available in the BLANCO UNIT App under
+    Settings → Smart Home and on the device information label.
+Service Code:
+  description: >
+    The Service Code for the device, shown in the BLANCO UNIT App under
+    Settings → Smart Home.
+{% endconfiguration_basic %}
+
+## Available entities
+
+The following entities are updated roughly every 30 seconds:
+
+### Sensors
+
+- **Last online** – The timestamp of the last successful connection to the BLANCO cloud.
+- **Active errors** – The number of currently active errors reported by the device. To see detailed error information, open the BLANCO UNIT App.
+- **Temperature: Cold** – The target temperature to which the cold water is cooled (if cooling is supported).
+- **Temperature: Hot** – The target temperature to which the hot water is heated.
+- **CO2: Remaining capacity** – Percentage of CO₂ remaining in the sparkling‑water system (EVOL‑S PRO SODA and CHOICE.ALL).
+- **Filter: Remaining capacity** – Percentage of the filter’s capacity remaining, depending on the device model.
+- **Filter: Remaining quantity** – Remaining water volume in liters before the filter is exhausted (AQUA devices).
+- **Filter: Remaining time** – Remaining time in days before the filter is exhausted (AQUA devices).
+- **Consumption: Last** – Volume of the most recent water dispensing event in milliliters.
+- **Consumption: Total** – Total water volume dispensed by the device.
+- **Consumption: Total - Still** – Total volume of still water dispensed.
+- **Consumption: Total - Medium** – Total volume of medium‑carbonated water dispensed.
+- **Consumption: Total - Classic** – Total volume of classic‑sparkling water dispensed.
+- **Consumption: Total - Hot** – Total volume of hot water dispensed.
+- **Consumption: Today** – Total water volume dispensed today.
+- **Consumption: This week** – Total water volume dispensed this week.
+- **Consumption: This month** – Total water volume dispensed this month.
+- **Consumption: This year** – Total water volume dispensed this year.
+
+### Binary sensors
+
+- **Connected to cloud** – Indicates whether the device is currently connected to the BLANCO cloud.
+- **Error** – Becomes `on` when the device has at least one active error.
+- **Mode: Hot water** – Indicates that the device is in hot water mode (CHOICE.ALL).
+- **Mode: Absence** – Indicates that the device is in absence mode (CHOICE.ALL).
+
+## Data updates
+
+The integration polls the BLANCO Cloud API approximately every **30 seconds**.  
+Entity values are updated whenever the cloud reports a change. If no change is reported, values are refreshed at the next polling cycle.
+
+The integration uses cloud polling and therefore requires an active internet connection for both the device and the Home Assistant instance.
+
+## Long‑term statistics
+
+Water consumption data is also available as {% term "Long-term statistics" %} via the Home Assistant [recorder](/integrations/recorder/) integration. These statistics are stored under the IDs `blanco:<serial>_water_all`, `blanco:<serial>_water_still`, `blanco:<serial>_water_medium`, `blanco:<serial>_water_classic`, and `blanco:<serial>_water_hot`, where `<serial>` is the device serial number in lowercase with non‑alphanumeric characters replaced by underscores.
+
+You can use these statistics in the Energy Dashboard or custom graphs and dashboards.
+
+## Known limitations
+
+- A single BLANCO device can only be linked to **one** Home Assistant instance at a time.
+- The integration is **cloud‑based** and does not provide local communication.
+- The integration provides monitoring entities only. Device control and actions are not supported.
+- Initial Smart Home authorization requires **Bluetooth proximity** to the device.
+- The following device types are currently not supported: all other BLANCO devices besides CHOICE.ALL, EVOL‑S PRO SODA (Rev F or later), and AQUA.
+
+## Troubleshooting
+
+### Setup fails with an invalid Service Code or serial number
+
+Verify that both the **Serial number** and the **Service Code** were entered exactly as shown in the UNIT App. If necessary, open the device information page or the **Smart Home** page in the UNIT App and compare the values again.
+
+### Setup fails while sending the RCA
+
+Make sure you are within **Bluetooth range** of the device when sending the RCA (secure connection link) from the UNIT App. If Bluetooth proximity is missing, the authorization cannot be completed.
+
+### Setup fails because the RCA expired
+
+The RCA authorization is valid for **5 minutes** only. If the setup is not completed in time, repeat the Smart Home authorization step in the UNIT App and generate a new RCA.
+
+### Device cannot be added to Home Assistant
+
+A BLANCO device can only be connected to **one Home Assistant instance** at a time. If the device was previously linked to a different Home Assistant instance, remove that connection first before trying again.
+
+## Removing the integration
+
+The integration can be removed in two ways:
+
+- In **Home Assistant**: Remove the integration as usual via **Settings → Devices & Services**.
+- In the **BLANCO UNIT App**: Open the UNIT App, go to **Settings → Smart Home**, select the device, and tap **Deactivate** to end the Smart Home connection there.
+
+If you want to link the device again to a Home Assistant instance later, repeat the Smart Home authorization step in the UNIT App and follow the setup procedure anew.

--- a/source/_integrations/blanco.markdown
+++ b/source/_integrations/blanco.markdown
@@ -10,13 +10,12 @@ ha_codeowners:
   - "@blancoGDPD"
 ha_domain: blanco
 ha_platforms:
-  - diagnostics
   - sensor
 ha_integration_type: device
 ha_quality_scale: bronze
 ---
 
-The **BLANCO** {% term integration %} connects Home Assistant to the BLANCO Smart Home Cloud API and exposes data from supported BLANCO smart home devices as entities in Home Assistant. Depending on the device model, this includes water temperatures, filter and CO₂ capacities, water consumption values, connectivity information, and device error states.
+The **BLANCO** {% term integration %} connects Home Assistant to the BLANCO Smart Home Cloud API and exposes data from supported BLANCO smart home devices as entities in Home Assistant. Depending on the device model, this includes water temperatures, filter and CO₂ capacities, connectivity information, and device error states.
 
 ## Supported devices
 
@@ -89,16 +88,6 @@ The following entities are updated roughly every 30 seconds:
 - **Filter: Remaining capacity**: Percentage of the filter's capacity remaining, depending on the device model.
 - **Filter: Remaining quantity**: Remaining water volume in liters before the filter is exhausted (AQUA devices).
 - **Filter: Remaining time**: Remaining time in days before the filter is exhausted (AQUA devices).
-- **Consumption: Last**: Volume of the most recent water dispensing event in milliliters.
-- **Consumption: Total**: Total water volume dispensed by the device.
-- **Consumption: Total - Still**: Total volume of still water dispensed.
-- **Consumption: Total - Medium**: Total volume of medium‑carbonated water dispensed.
-- **Consumption: Total - Classic**: Total volume of classic‑sparkling water dispensed.
-- **Consumption: Total - Hot**: Total volume of hot water dispensed.
-- **Consumption: Today**: Total water volume dispensed today.
-- **Consumption: This week**: Total water volume dispensed this week.
-- **Consumption: This month**: Total water volume dispensed this month.
-- **Consumption: This year**: Total water volume dispensed this year.
 
 ## Data updates
 
@@ -106,12 +95,6 @@ The integration uses {% term polling %} to retrieve data from the BLANCO Cloud A
 Entity values are updated whenever the cloud reports a change. If no change is reported, values are refreshed at the next polling cycle.
 
 The integration requires an active internet connection for both the device and the Home Assistant instance.
-
-## Long‑term statistics
-
-Water consumption data is also available as {% term "Long-term statistics" %} via the Home Assistant [recorder](/integrations/recorder/) integration. These statistics are stored under the IDs `blanco:<serial>_water_all`, `blanco:<serial>_water_still`, `blanco:<serial>_water_medium`, `blanco:<serial>_water_classic`, and `blanco:<serial>_water_hot`, where `<serial>` is the device serial number in lowercase with non‑alphanumeric characters replaced by underscores.
-
-You can use these statistics in the Energy Dashboard or custom graphs and dashboards.
 
 ## Known limitations
 

--- a/source/_integrations/blanco.markdown
+++ b/source/_integrations/blanco.markdown
@@ -18,6 +18,16 @@ ha_quality_scale: bronze
 
 The **BLANCO** {% term integration %} connects Home Assistant to the BLANCO Smart Home Cloud API and exposes data from supported BLANCO smart home devices as entities in Home Assistant. Depending on the device model, this includes water temperatures, filter and CO₂ capacities, water consumption values, connectivity information, and device error states.
 
+## Supported devices
+
+The integration is currently compatible with the following devices:
+
+- **CHOICE.ALL** – All‑in‑one water system (still, sparkling, hot)
+- **EVOL‑S PRO SODA (Rev F or later)** – Sparkling water system
+- **AQUA** – Filtered water system with filter monitoring
+
+All other BLANCO device types are not supported at this time.
+
 ## Prerequisites
 
 Before setting up the integration, make sure the following requirements are met:
@@ -31,17 +41,7 @@ Before setting up the integration, make sure the following requirements are met:
 The Smart Home authorization must be granted from the BLANCO UNIT App while you are within Bluetooth range of the device.
 {% endnote %}
 
-## Supported devices
-
-The integration is currently compatible with the following devices:
-
-- **CHOICE.ALL** – All‑in‑one water system (still, sparkling, hot)
-- **EVOL‑S PRO SODA (Rev F or later)** – Sparkling water system
-- **AQUA** – Filtered water system with filter monitoring
-
-All other BLANCO device types are not supported at this time.
-
-## Configuration
+### Authorizing the connection
 
 Before starting the setup in Home Assistant, you must first authorize the connection in the **BLANCO UNIT App** by sending the **RCA (secure connection link)**. The authorization is valid for **5 minutes**.
 
@@ -81,31 +81,31 @@ The following entities are updated roughly every 30 seconds:
 
 ### Sensors
 
-- **Last online** – The timestamp of the last successful connection to the BLANCO cloud.
-- **Active errors** – The number of currently active errors reported by the device. To see detailed error information, open the BLANCO UNIT App.
-- **Temperature: Cold** – The target temperature to which the cold water is cooled (if cooling is supported).
-- **Temperature: Hot** – The target temperature to which the hot water is heated.
-- **CO2: Remaining capacity** – Percentage of CO₂ remaining in the sparkling‑water system (EVOL‑S PRO SODA and CHOICE.ALL).
-- **Filter: Remaining capacity** – Percentage of the filter’s capacity remaining, depending on the device model.
-- **Filter: Remaining quantity** – Remaining water volume in liters before the filter is exhausted (AQUA devices).
-- **Filter: Remaining time** – Remaining time in days before the filter is exhausted (AQUA devices).
-- **Consumption: Last** – Volume of the most recent water dispensing event in milliliters.
-- **Consumption: Total** – Total water volume dispensed by the device.
-- **Consumption: Total - Still** – Total volume of still water dispensed.
-- **Consumption: Total - Medium** – Total volume of medium‑carbonated water dispensed.
-- **Consumption: Total - Classic** – Total volume of classic‑sparkling water dispensed.
-- **Consumption: Total - Hot** – Total volume of hot water dispensed.
-- **Consumption: Today** – Total water volume dispensed today.
-- **Consumption: This week** – Total water volume dispensed this week.
-- **Consumption: This month** – Total water volume dispensed this month.
-- **Consumption: This year** – Total water volume dispensed this year.
+- **Last online**: The timestamp of the last successful connection to the BLANCO cloud.
+- **Active errors**: The number of currently active errors reported by the device. To see detailed error information, open the BLANCO UNIT App.
+- **Temperature: Cold**: The target temperature to which the cold water is cooled (if cooling is supported).
+- **Temperature: Hot**: The target temperature to which the hot water is heated.
+- **CO2: Remaining capacity**: Percentage of CO₂ remaining in the sparkling‑water system (EVOL‑S PRO SODA and CHOICE.ALL).
+- **Filter: Remaining capacity**: Percentage of the filter's capacity remaining, depending on the device model.
+- **Filter: Remaining quantity**: Remaining water volume in liters before the filter is exhausted (AQUA devices).
+- **Filter: Remaining time**: Remaining time in days before the filter is exhausted (AQUA devices).
+- **Consumption: Last**: Volume of the most recent water dispensing event in milliliters.
+- **Consumption: Total**: Total water volume dispensed by the device.
+- **Consumption: Total - Still**: Total volume of still water dispensed.
+- **Consumption: Total - Medium**: Total volume of medium‑carbonated water dispensed.
+- **Consumption: Total - Classic**: Total volume of classic‑sparkling water dispensed.
+- **Consumption: Total - Hot**: Total volume of hot water dispensed.
+- **Consumption: Today**: Total water volume dispensed today.
+- **Consumption: This week**: Total water volume dispensed this week.
+- **Consumption: This month**: Total water volume dispensed this month.
+- **Consumption: This year**: Total water volume dispensed this year.
 
 ## Data updates
 
-The integration polls the BLANCO Cloud API approximately every **30 seconds**.  
+The integration uses {% term polling %} to retrieve data from the BLANCO Cloud API approximately every **30 seconds**.
 Entity values are updated whenever the cloud reports a change. If no change is reported, values are refreshed at the next polling cycle.
 
-The integration uses cloud polling and therefore requires an active internet connection for both the device and the Home Assistant instance.
+The integration requires an active internet connection for both the device and the Home Assistant instance.
 
 ## Long‑term statistics
 

--- a/source/_integrations/blanco.markdown
+++ b/source/_integrations/blanco.markdown
@@ -10,7 +10,6 @@ ha_codeowners:
   - "@blancoGDPD"
 ha_domain: blanco
 ha_platforms:
-  - binary_sensor
   - diagnostics
   - sensor
 ha_integration_type: device
@@ -100,13 +99,6 @@ The following entities are updated roughly every 30 seconds:
 - **Consumption: This week** – Total water volume dispensed this week.
 - **Consumption: This month** – Total water volume dispensed this month.
 - **Consumption: This year** – Total water volume dispensed this year.
-
-### Binary sensors
-
-- **Connected to cloud** – Indicates whether the device is currently connected to the BLANCO cloud.
-- **Error** – Becomes `on` when the device has at least one active error.
-- **Mode: Hot water** – Indicates that the device is in hot water mode (CHOICE.ALL).
-- **Mode: Absence** – Indicates that the device is in absence mode (CHOICE.ALL).
 
 ## Data updates
 

--- a/source/_integrations/blanco.markdown
+++ b/source/_integrations/blanco.markdown
@@ -49,7 +49,7 @@ Before starting the setup in Home Assistant, you must first authorize the connec
 2. Select the device you want to connect.
 3. Open **Settings**.
 4. Navigate to **Smart Home**.
-5. Send the **RCA (secure connection link)** by tapping **Activate**.
+5. Send the **RCA (secure connection link)** by selecting **Activate**.
 6. Within **5 minutes**, open Home Assistant and start the BLANCO integration setup.
 
 To add the **BLANCO** integration to your Home Assistant instance, use this My button:
@@ -68,11 +68,11 @@ You must remain within Bluetooth range of the device when sending the RCA. If th
 Serial number:
   description: >
     The serial number of the device, available in the BLANCO UNIT App under
-    Settings → Smart Home and on the device information label.
+    **Settings** > **Smart Home** and on the device information label.
 Service Code:
   description: >
     The Service Code for the device, shown in the BLANCO UNIT App under
-    Settings → Smart Home.
+    **Settings** > **Smart Home**.
 {% endconfiguration_basic %}
 
 ## Available entities
@@ -143,7 +143,7 @@ A BLANCO device can only be connected to **one Home Assistant instance** at a ti
 
 The integration can be removed in two ways:
 
-- In **Home Assistant**: Remove the integration as usual via **Settings → Devices & Services**.
-- In the **BLANCO UNIT App**: Open the UNIT App, go to **Settings → Smart Home**, select the device, and tap **Deactivate** to end the Smart Home connection there.
+- In **Home Assistant**: Remove the integration as usual via **Settings** > **Devices & services**.
+- In the **BLANCO UNIT App**: Open the UNIT App, go to **Settings** > **Smart Home**, select the device, and select **Deactivate** to end the Smart Home connection there.
 
 If you want to link the device again to a Home Assistant instance later, repeat the Smart Home authorization step in the UNIT App and follow the setup procedure anew.

--- a/source/_integrations/blanco.markdown
+++ b/source/_integrations/blanco.markdown
@@ -3,7 +3,7 @@ title: BLANCO
 description: Instructions on how to integrate BLANCO smart home devices in Home Assistant.
 ha_category:
   - Water
-ha_release: "2026.x"
+ha_release: 2026.5
 ha_iot_class: Cloud Polling
 ha_config_flow: true
 ha_codeowners:


### PR DESCRIPTION
## Proposed change

Adds the integration documentation page for the new BLANCO Smart Home integration. The integration connects Home Assistant to the BLANCO Smart Home Cloud API and exposes sensor entities for water consumption, temperatures, filter and CO₂ status, and device error information.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#168250
- Link to parent pull request in the Brands repository: home-assistant/brands#10139
- This PR fixes or closes issue: N/A

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards