### PR TITLE
Update Russound RNET docs for config flow migration

### DIFF
--- a/source/_integrations/russound_rnet.markdown
+++ b/source/_integrations/russound_rnet.markdown
@@ -11,7 +11,7 @@ ha_platforms:
 ha_codeowners:
   - '@noahhusby'
 ha_config_flow: true
-ha_integration_type: integration
+ha_integration_type: hub
 ha_quality_scale: bronze
 ---
 

--- a/source/_integrations/russound_rnet.markdown
+++ b/source/_integrations/russound_rnet.markdown
@@ -12,7 +12,7 @@ ha_codeowners:
   - '@noahhusby'
 ha_config_flow: true
 ha_integration_type: hub
-ha_quality_scale: bronze
+ha_quality_scale: legacy
 ---
 
 The **Russound RNET** {% term integration %} allows you to control Russound multi-zone audio systems that use the RNET protocol. Each enabled zone appears as a media player entity, allowing you to control power, volume, mute, and source selection from your Home Assistant dashboard.
@@ -21,43 +21,44 @@ The **Russound RNET** {% term integration %} allows you to control Russound mult
 
 This integration supports Russound controllers that use the RNET protocol:
 
-- Russound CAS44
-- Russound CAA66
-- Russound CAM6.6
 - Russound CAV6.6
+- Russound CAM6.6
+- Russound CAA66
+- Russound CAS44
+- Russound MCA-C5
+- Russound MCA-C3
+- Russound ACA-E5
 
-### Connection requirements
+### Connection methods
 
-The RNET protocol uses a serial (RS-232) connection. To connect to Home Assistant, you need a TCP-to-Serial gateway (such as an IP-to-Serial adapter or [tcp_serial_redirect](https://github.com/pyserial/pyserial/blob/master/examples/tcp_serial_redirect.py)) that bridges the serial port to a TCP socket.
+The RNET protocol uses a serial (RS-232) connection. You can connect to Home Assistant in two ways:
+
+- **TCP**: Use a TCP-to-Serial gateway (such as an IP-to-Serial adapter or [tcp_serial_redirect](https://github.com/pyserial/pyserial/blob/master/examples/tcp_serial_redirect.py)) that bridges the serial port to a TCP socket.
+- **Serial**: Connect the Russound controller directly to a serial port on the Home Assistant host.
 
 If you are using a Russound CAA66, use a null-modem cable for the serial connection.
 
 ## Multi-controller support
 
-If you have multiple controllers connected via the RNET link ports, each controller adds 6 zones. For example, with 2 controllers you get zones 1–12: zones 1–6 map to controller 1, and zones 7–12 map to controller 2.
+Some Russound models (CAV6.6, CAM6.6, CAA66, MCA-C5, MCA-C3, ACA-E5) support daisy-chaining multiple controllers via the RNET link ports. During setup, the zone naming step shows all zones across all supported controllers for your model.
 
 {% include integrations/config_flow.md %}
 
-The setup consists of three steps:
+The setup consists of five steps:
 
-1. **Connection and sources**: Enter the IP address and port of your TCP-to-Serial gateway, the number of controllers, and the names of your audio sources.
-2. **Zone selection**: Select which zones to enable. Deselect any zones that are not in use.
-3. **Zone naming**: Enter a descriptive name for each selected zone (for example, "Living Room" or "Kitchen").
-
-{% configuration_basic %}
-Host:
-    description: The IP address or hostname of your TCP-to-Serial gateway.
-Port:
-    description: "The TCP port of your gateway (default: 9621)."
-Controllers:
-    description: "The number of Russound controllers connected (each supports 6 zones)."
-Source 1–6:
-    description: "Names for each audio source input (for example: TV, Radio, Sonos). Leave blank for unused sources."
-{% endconfiguration_basic %}
+1. **Transport type**: Choose between TCP or Serial connection.
+2. **Connection details**: Enter the IP address and port (TCP) or serial device path and baud rate (Serial).
+3. **Model selection**: Select your Russound controller model. This determines the number of available zones, sources, and controllers.
+4. **Source naming**: Enter a name for each audio source input (for example: TV, Radio, Sonos). Leave blank for unused sources.
+5. **Zone naming**: Enter a descriptive name for each zone (for example, "Living Room" or "Kitchen"). Leave blank for unused zones.
 
 ## Configuration
 
-After setup, you can reconfigure sources and enable or disable zones by selecting **Configure** on the integration card under {% my integrations title="**Settings** > **Devices & services**" %}.
+After setup, you can reconfigure source names by selecting **Configure** on the integration card under {% my integrations title="**Settings** > **Devices & services**" %}.
+
+## Migrating from YAML
+
+If you previously configured this integration via YAML under `media_player: - platform: russound_rnet`, a repair issue will appear prompting you to migrate. The repair flow will guide you through selecting your model, naming sources, and naming zones. Once complete, a second repair issue will remind you to remove the deprecated YAML configuration.
 
 ## Data updates
 
@@ -72,14 +73,14 @@ This integration follows standard integration removal. No extra steps are requir
 ## Known limitations
 
 - The RNET protocol is request/response only — the device does not push state changes. There may be a short delay before changes made directly on the device (or via a physical keypad) are reflected in Home Assistant.
-- The mute command toggles mute on/off. There is no way to explicitly set mute to a specific state.
+- The RNET protocol does not report mute state. Mute is tracked locally within Home Assistant. If mute is toggled externally (for example, via a physical keypad), Home Assistant may be out of sync until the next volume change.
 - Volume range is 0–50 on the device, mapped to 0%–100% in Home Assistant.
 
 ## Troubleshooting
 
 ### Cannot connect during setup
 
-- Verify the IP address and port of your TCP-to-Serial gateway are correct.
+- Verify the IP address and port of your TCP-to-Serial gateway are correct, or that your serial device path is valid.
 - Ensure the gateway is powered on and connected to the Russound controller's serial port.
 - The integration retries the connection up to 3 times during setup. If it still fails, check your network connectivity.
 

--- a/source/_integrations/russound_rnet.markdown
+++ b/source/_integrations/russound_rnet.markdown
@@ -8,80 +8,82 @@ ha_iot_class: Local Polling
 ha_domain: russound_rnet
 ha_platforms:
   - media_player
-ha_integration_type: integration
-related:
-  - docs: /docs/configuration/
-    title: Configuration file
-ha_quality_scale: legacy
 ha_codeowners:
   - '@noahhusby'
+ha_config_flow: true
+ha_integration_type: integration
+ha_quality_scale: bronze
 ---
 
-The **Russound RNET** {% term integration %} allows you to control Russound devices that make use of the RNET protocol.
-
-This has initially been tested against a Russound CAV6.6 unit with six zones and six sources. It will also work with a Russound CAA66, but be sure to use a null-modem cable. If you have mutiple controllers connected via the RNET link ports, every increment of 6 zones maps to the corresponding controller ID.
-
-Connecting to the Russound device is only possible by TCP, you can make use of a TCP to Serial gateway such as [tcp_serial_redirect](https://github.com/pyserial/pyserial/blob/master/examples/tcp_serial_redirect.py)
+The **Russound RNET** {% term integration %} allows you to control Russound multi-zone audio systems that use the RNET protocol. Each enabled zone appears as a media player entity, allowing you to control power, volume, mute, and source selection from your Home Assistant dashboard.
 
 ## Supported devices
 
-This integration allows you to connect the following controllers:
+This integration supports Russound controllers that use the RNET protocol:
 
 - Russound CAS44
 - Russound CAA66
 - Russound CAM6.6
 - Russound CAV6.6
 
-To add an {% term integration %} to your installation, add the following to your {% term "`configuration.yaml`" %} file.
-{% include integrations/restart_ha_after_config_inclusion.md %}
+### Connection requirements
 
-```yaml
-# Example configuration.yaml entry
-media_player:
-  - platform: russound_rnet
-    host: 192.168.1.10
-    port: 1337
-    name: Russound
-    zones:
-      1:
-        name: Main Bedroom
-      2:
-        name: Living Room
-      3:
-        name: Kitchen
-      4:
-        name: Bathroom
-      5:
-        name: Dining Room
-      6:
-        name: Guest Bedroom
-      # controller 2 - zone 1 (connected via RNET link ports)
-      7:
-        name: Basement Recroom
-    sources:
-      - name: Sonos
-      - name: Sky+
-```
+The RNET protocol uses a serial (RS-232) connection. To connect to Home Assistant, you need a TCP-to-Serial gateway (such as an IP-to-Serial adapter or [tcp_serial_redirect](https://github.com/pyserial/pyserial/blob/master/examples/tcp_serial_redirect.py)) that bridges the serial port to a TCP socket.
 
-{% configuration %}
-host:
-  description: The IP of the TCP gateway.
-  required: true
-  type: string
-port:
-  description: The port of the TCP gateway.
-  required: true
-  type: integer
-name:
-  description: The name of the device.
-  required: true
-  type: string
-zones:
-  description: This is the list of zones available.
-  required: true
-  type: integer
-sources:
-  description: The list of sources available, these must be in order as they are connected to the device.
-  required: true
-  type: list
-{% endconfiguration %}
+If you are using a Russound CAA66, use a null-modem cable for the serial connection.
+
+## Multi-controller support
+
+If you have multiple controllers connected via the RNET link ports, each controller adds 6 zones. For example, with 2 controllers you get zones 1–12: zones 1–6 map to controller 1, and zones 7–12 map to controller 2.
+
+{% include integrations/config_flow.md %}
+
+The setup consists of three steps:
+
+1. **Connection and sources**: Enter the IP address and port of your TCP-to-Serial gateway, the number of controllers, and the names of your audio sources.
+2. **Zone selection**: Select which zones to enable. Deselect any zones that are not in use.
+3. **Zone naming**: Enter a descriptive name for each selected zone (for example, "Living Room" or "Kitchen").
+
+{% configuration_basic %}
+Host:
+    description: The IP address or hostname of your TCP-to-Serial gateway.
+Port:
+    description: "The TCP port of your gateway (default: 9621)."
+Controllers:
+    description: "The number of Russound controllers connected (each supports 6 zones)."
+Source 1–6:
+    description: "Names for each audio source input (for example: TV, Radio, Sonos). Leave blank for unused sources."
+{% endconfiguration_basic %}
+
+## Configuration
+
+After setup, you can reconfigure sources and enable or disable zones by selecting **Configure** on the integration card under {% my integrations title="**Settings** > **Devices & services**" %}.
+
+## Data updates
+
+This integration polls the Russound device every 30 seconds to retrieve the current state of all enabled zones. When a command is sent (such as turning a zone on or changing volume), the affected zone is polled immediately for fast feedback.
+
+## Removing the integration
+
+This integration follows standard integration removal. No extra steps are required.
+
+{% include integrations/remove_device_service.md %}
+
+## Known limitations
+
+- The RNET protocol is request/response only — the device does not push state changes. There may be a short delay before changes made directly on the device (or via a physical keypad) are reflected in Home Assistant.
+- The mute command toggles mute on/off. There is no way to explicitly set mute to a specific state.
+- Volume range is 0–50 on the device, mapped to 0%–100% in Home Assistant.
+
+## Troubleshooting
+
+### Cannot connect during setup
+
+- Verify the IP address and port of your TCP-to-Serial gateway are correct.
+- Ensure the gateway is powered on and connected to the Russound controller's serial port.
+- The integration retries the connection up to 3 times during setup. If it still fails, check your network connectivity.
+
+### Zones show as unavailable
+
+- The serial connection may have dropped. The integration will automatically reconnect on the next poll cycle (within 30 seconds).
+- If using an IP-to-Serial bridge, ensure it is not configured to drop idle connections too aggressively.

--- a/source/_integrations/russound_rnet.markdown
+++ b/source/_integrations/russound_rnet.markdown
@@ -44,17 +44,14 @@ Some Russound models (CAV6.6, CAM6.6, CAA66, MCA-C5, MCA-C3, ACA-E5) support dai
 
 {% include integrations/config_flow.md %}
 
-The setup consists of five steps:
+The setup consists of six steps:
 
 1. **Transport type**: Choose between TCP or Serial connection.
-2. **Connection details**: Enter the IP address and port (TCP) or serial device path and baud rate (Serial).
+2. **Connection details**: Enter the IP address and port (TCP) or serial device path (Serial).
 3. **Model selection**: Select your Russound controller model. This determines the number of available zones, sources, and controllers.
-4. **Source naming**: Enter a name for each audio source input (for example: TV, Radio, Sonos). Leave blank for unused sources.
-5. **Zone naming**: Enter a descriptive name for each zone (for example, "Living Room" or "Kitchen"). Leave blank for unused zones.
-
-## Configuration
-
-After setup, you can reconfigure source names by selecting **Configure** on the integration card under {% my integrations title="**Settings** > **Devices & services**" %}.
+4. **Number of controllers**: Enter the number of controllers in your system. This step is skipped for models that only support a single controller (CAS44).
+5. **Source naming**: Enter a name for each audio source input (for example: TV, Radio, Sonos). Leave blank for unused sources.
+6. **Zone naming**: Enter a descriptive name for each zone (for example, "Living Room" or "Kitchen"). Leave blank for unused zones.
 
 ## Migrating from YAML
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Update documentation for the `russound_rnet` integration to reflect the migration from legacy YAML configuration to config flow (PR #168475).

- Replaced YAML configuration example with 6-step config flow setup instructions
- Added `ha_config_flow: true` to frontmatter
- Added supported devices to the list: MCA-C5, MCA-C3, ACA-E5
- Added TCP and serial connection methods
- Added model selection step documentation
- Added YAML migration section explaining the repair flow
- Added "Data updates" section explaining polling behavior
- Added "Known limitations" section (no push, local mute tracking, volume range)
- Added "Troubleshooting" section for common issues
- Added multi-controller documentation
- Removed `{% configuration_basic %}` block (no longer needed with config flow)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/168475
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
