### PR TITLE
docs: Update iZone integration documentation for multi-controller config flow support

### DIFF
--- a/source/_integrations/izone.markdown
+++ b/source/_integrations/izone.markdown
@@ -18,7 +18,7 @@ related:
     title: Configuration file
 ---
 
-The **iZone** {% term integration %} allows access of control of a local [iZone](https://izone.com.au/) ducted reverse-cycle climate control devices. These are largely available in Australia.
+The **iZone** {% term integration %} lets you monitor and control local [iZone](https://izone.com.au/) ducted reverse-cycle climate control systems. These systems are largely available in Australia.
 
 ## Supported hardware
 
@@ -28,11 +28,15 @@ Any current iZone unit with ducted reverse cycle air-conditioning, and the CB wi
 
 ## Multiple iZone systems
 
-If you have more than one iZone system on your local network, the iZone integration will discover all available controllers and show them to you. When you set up the integration, you can choose which controller you want to configure. You can add additional controllers by running the integration setup again.
+If you have more than one iZone system on your local network, the iZone integration discovers all available controllers and shows them during setup. You can then choose the controller you want to configure.
+
+Any other controllers found during the search will become available as discovered controllers.
 
 ## Legacy YAML configuration
 
-For legacy setups or if you need to exclude specific controllers from integration with Home Assistant, you can configure the iZone integration via the {% term "`configuration.yaml`" %} file with the `exclude` option.
+YAML configuration is now deprecated, it will be removed in a future update. 
+
+For legacy setups, or if you need to exclude specific controllers from Home Assistant, you can configure the iZone integration via the {% term "`configuration.yaml`" %} file with the `exclude` option.
 
 {% include integrations/restart_ha_after_config_inclusion.md %}
 
@@ -45,7 +49,7 @@ izone:
 
 {% configuration %}
 exclude:
-  description: Exclude particular units from integration with Home Assistant. Only applies to YAML-based configuration.
+  description: Exclude specific units from Home Assistant. This option applies only to YAML-based configuration.
   required: false
   type: list
 {% endconfiguration %}

--- a/source/_integrations/izone.markdown
+++ b/source/_integrations/izone.markdown
@@ -26,15 +26,18 @@ Any current iZone unit with ducted reverse cycle air-conditioning, and the CB wi
 
 {% include integrations/config_flow.md %}
 
-## Manual configuration
+## Multiple iZone systems
 
-Alternatively, the iZone integration can be configured manually via the
-{% term "`configuration.yaml`" %} file if there is more than one iZone system on the local
-network and one or more must be excluded use manual configuration.
+If you have more than one iZone system on your local network, the iZone integration will discover all available controllers and show them to you. When you set up the integration, you can choose which controller you want to configure. You can add additional controllers by running the integration setup again.
+
+## Legacy YAML configuration
+
+For legacy setups or if you need to exclude specific controllers from integration with Home Assistant, you can configure the iZone integration via the {% term "`configuration.yaml`" %} file with the `exclude` option.
+
 {% include integrations/restart_ha_after_config_inclusion.md %}
 
 ```yaml
-# Full manual example configuration.yaml entry
+# Example configuration.yaml entry with excluded controllers
 izone:
   exclude:
     - "000013170"
@@ -42,7 +45,7 @@ izone:
 
 {% configuration %}
 exclude:
-  description: Exclude particular units from integration with Home Assistant.
+  description: Exclude particular units from integration with Home Assistant. Only applies to YAML-based configuration.
   required: false
   type: list
 {% endconfiguration %}


### PR DESCRIPTION
## Proposed change

This updates the iZone integration documentation to match the new config flow behavior for multiple discovered controllers.

- Clarifies that config flow now discovers multiple controllers and lets you choose which one to set up
- Clarifies that additional controllers can be added by running setup again
- Keeps YAML `exclude` documented as a legacy/manual configuration path - note that I'm going to deprecate this code path as it's no longer really needed, and the implementation is flakey and not really consistent with best practice.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/169251
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - [x] The `next` branch if it documents a new or changed feature in Home Assistant
  - [ ] The `current` branch if it corrects current documentation