### PR TITLE
Add heating schedule action to BSB-LAN integration documentation

### DIFF
--- a/source/_integrations/bsblan.markdown
+++ b/source/_integrations/bsblan.markdown
@@ -90,32 +90,35 @@ The **Total Energy** sensor is not real-time. It updates in 1 kWh steps, so the 
 
 The integration provides the following actions.
 
+### Action: Set heating schedule
+
+The `bsblan.set_heating_schedule` action allows you to set the weekly heating schedule for a BSB-LAN heating circuit. Select the heating-circuit sub-device you want to update, such as **Heating circuit 1**. The selected circuit determines which heating schedule is changed.
+
+- **Target**: `device_id`
+  - **Description**: The heating-circuit sub-device to configure.
+  - **Required**: Yes
+
 ### Action: Set hot water schedule
 
 The `bsblan.set_hot_water_schedule` action allows you to set the hot water heating schedule for your BSB-LAN device. Each day of the week can have one or more time slots when hot water heating should be active.
 
 - **Target**: `device_id`
-  - **Description**: The BSB-LAN device to configure.
+  - **Description**: The BSB-LAN water heater device to configure.
   - **Required**: Yes
-- **Data attributes**:
-  - **`monday_slots`**: List of time slots for Monday. Each slot contains `start_time` and `end_time`.
-    - **Optional**: Yes
-  - **`tuesday_slots`**: List of time slots for Tuesday. Each slot contains `start_time` and `end_time`.
-    - **Optional**: Yes
-  - **`wednesday_slots`**: List of time slots for Wednesday. Each slot contains `start_time` and `end_time`.
-    - **Optional**: Yes
-  - **`thursday_slots`**: List of time slots for Thursday. Each slot contains `start_time` and `end_time`.
-    - **Optional**: Yes
-  - **`friday_slots`**: List of time slots for Friday. Each slot contains `start_time` and `end_time`.
-    - **Optional**: Yes
-  - **`saturday_slots`**: List of time slots for Saturday. Each slot contains `start_time` and `end_time`.
-    - **Optional**: Yes
-  - **`sunday_slots`**: List of time slots for Sunday. Each slot contains `start_time` and `end_time`.
-    - **Optional**: Yes
-  - **`standard_values_slots`**: List of standard/default time slots. Each slot contains `start_time` and `end_time`.
-    - **Optional**: Yes
 
-Time slots are defined using time pickers for easy configuration without manual formatting. You only need to specify the days you want to configure.
+### Schedule data attributes
+
+The `bsblan.set_heating_schedule` and `bsblan.set_hot_water_schedule` actions use the same schedule fields. Each field is optional. Only specify the days you want to configure.
+
+- **`monday_slots`**: List of time slots for Monday
+- **`tuesday_slots`**: List of time slots for Tuesday
+- **`wednesday_slots`**: List of time slots for Wednesday
+- **`thursday_slots`**: List of time slots for Thursday
+- **`friday_slots`**: List of time slots for Friday
+- **`saturday_slots`**: List of time slots for Saturday
+- **`sunday_slots`**: List of time slots for Sunday
+
+Each slot contains a `start_time` and an `end_time`. Time slots are defined using time pickers for easy configuration without manual formatting.
 
 ### Action `bsblan.sync_time`
 
@@ -155,16 +158,16 @@ automation:
 
 ## Examples
 
-The following examples show how to use the BSB-LAN integration actions in Home Assistant automations.
+The following examples show how to use the BSB-LAN integration schedule actions in Home Assistant automations.
 
 ### Setting a weekday and weekend schedule
 
-This example sets different schedules for weekdays and weekends. Each day can have multiple time slots.
+This example sets different schedules for weekdays and weekends for one heating circuit. Use the device ID of the heating-circuit sub-device you want to configure. To use the same schedule for domestic hot water, use the `bsblan.set_hot_water_schedule` action and target the BSB-LAN water heater device instead.
 
 ```yaml
-action: bsblan.set_hot_water_schedule
+action: bsblan.set_heating_schedule
 target:
-  device_id: abc123device456
+  device_id: abc123heatingcircuit456
 data:
   monday_slots:
     - start_time: "06:00:00"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This pull request updates the BSB-LAN integration documentation to add support for configuring heating schedules and clarifies how to set up both heating and hot water schedules. The documentation is reorganized for clarity, with shared schedule attributes now described in a single section, and example automations updated to reflect the new capabilities.

**New features and documentation improvements:**

* Added documentation for the new `bsblan.set_heating_schedule` action, allowing users to set the weekly heating schedule for a specific heating circuit sub-device.
* Unified the description of schedule data attributes for both `bsblan.set_heating_schedule` and `bsblan.set_hot_water_schedule` actions, clarifying that both use the same fields for specifying daily time slots.

**Clarifications and example updates:**

* Updated the example automation to demonstrate how to set different weekday and weekend schedules for a heating circuit, and explained how to apply similar schedules to hot water by targeting the appropriate device and action.
* Improved the description of the `device_id` target for both heating circuit and hot water actions to make it clear which device type each action should target.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/169323
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
