### PR TITLE
Add Reolink floodlight schedule time entities documentation

### DIFF
--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -372,6 +372,15 @@ Depending on the supported features of the camera ([see specifications of the ca
 - Battery temperature*+
 - Battery state*+ (discharging, charging, charge complete)
 
+### Time entities
+
+Depending on the supported features of the camera ([see specifications of the camera model on Reolink.com](#tested-models)), the following time entities are added:
+
+- Floodlight schedule start*+
+- Floodlight schedule end*+
+
+**Floodlight schedule start** and **Floodlight schedule end** set the time window during which the floodlight turns on while the **Floodlight mode** select entity is set to **Schedule**. Because the camera only stores the schedule in this mode, setting either time also switches the floodlight to **Schedule** mode. If the configured window covers the current time, the floodlight turns on immediately.
+
 ### Update entity
 
 An update entity is available that checks for firmware updates every 24 hours.

--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -379,7 +379,7 @@ Depending on the supported features of the camera ([see specifications of the ca
 - Floodlight schedule start*+
 - Floodlight schedule end*+
 
-**Floodlight schedule start** and **Floodlight schedule end** set the time window during which the floodlight turns on while the **Floodlight mode** select entity is set to **Schedule**. Because the camera only stores the schedule in this mode, setting either time also switches the floodlight to **Schedule** mode. If the configured window covers the current time, the floodlight turns on immediately.
+**Floodlight schedule start** and **Floodlight schedule end** set the time window during which the floodlight turns on while the **Floodlight mode** select entity is set to **Schedule**. Because the camera only stores the schedule in this mode, setting either time also switches the floodlight to **Schedule** mode. If the configured window covers the current time, the floodlight turns on immediately. The times are entered as 24-hour `HH:MM` and are evaluated using the camera's own clock and time zone (Home Assistant does not convert them). Windows that span midnight are supported, for example a start of `22:00` and an end of `06:00`.
 
 ### Update entity
 


### PR DESCRIPTION
## Proposed change

Documents the two new `time` entities added to the Reolink integration, **Floodlight schedule start** and **Floodlight schedule end**, under a new "Time entities" section. These expose the floodlight schedule (the camera's timer mode). The section notes that setting a time switches the floodlight to Schedule mode, since the camera only persists the schedule in that mode.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/173140
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards