### PR TITLE
Add RGBICWW Ceiling Light to SwitchBot integration

### DIFF
--- a/source/_integrations/switchbot.markdown
+++ b/source/_integrations/switchbot.markdown
@@ -154,6 +154,7 @@ For instructions on how to obtain the encryption key, see README in [PySwitchbot
 - [Floor Lamp](https://www.switch-bot.com/products/switchbot-floor-lamp)
 - [RGBICWW Strip Light](https://www.switch-bot.com/products/switchbot-rgbicww-strip-light)
 - [RGBICWW Floor Lamp](https://www.switch-bot.com/products/switchbot-rgbicww-floor-lamp)
+- [RGBICWW Ceiling Light](https://www.switch-bot.com/products/switchbot-rgbicww-ceiling-light)
 - [Permanent Outdoor Light](https://www.switch-bot.com/products/switchbot-permanent-outdoor-light)
 
 ### Locks
@@ -657,6 +658,15 @@ Features:
 - change color temperature
 - change color
 - set effect
+
+#### RGBICWW Ceiling Light
+
+This is an encrypted device.
+
+The RGBICWW Ceiling Light exposes two separate light entities that you can control independently:
+
+- A main light (warm white) that supports turning on or off, changing brightness, and changing color temperature.
+- A color light (RGB) that supports turning on or off, changing brightness, changing color, and setting an effect.
 
 #### Permanent Outdoor Light
 


### PR DESCRIPTION
## Proposed change

Add documentation for SwitchBot RGBICWW Ceiling Light support in the `switchbot` integration.

The RGBICWW Ceiling Light is an encrypted Bluetooth device that exposes two independent light entities: a main (warm-white) light with brightness and color temperature, and a color (RGB) light with brightness, color, and effects.


## Note from SwitchBot team

This change is developed by the **official SwitchBot team**. The implementation has been verified with real hardware testing on physical devices.

If you have any questions or need clarification, please reach out:
- Discord: @7eaves
- GitHub: @fankai777
## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#173261
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
