### PR TITLE
samsungtv: add trigger

### DIFF
--- a/source/_integrations/samsungtv.markdown
+++ b/source/_integrations/samsungtv.markdown
@@ -65,6 +65,8 @@ The Samsung Smart TV integration provides the following entities and functionali
 
 - **Device diagnostics**: Troubleshooting information for device connectivity and status
 
+{% include integrations/triggers.md %}
+
 ## Data updates
 
 The **SamsungTV** integration uses a local REST API with a WebSocket notification channel for immediate state information for media metadata, playback progress, volume level, and other state information.

--- a/source/_triggers/samsungtv.turn_on.markdown
+++ b/source/_triggers/samsungtv.turn_on.markdown
@@ -1,4 +1,4 @@
----
+git---
 title: "Device is requested to turn on"
 trigger: samsungtv.turn_on
 domain: samsungtv
@@ -86,7 +86,7 @@ trigger:
 ## Good to know
 
 - This trigger fires when `media_player.turn_on` is called targeting the TV entity, not when the TV turns on by itself (for example, after a power cut). It represents a request from Home Assistant, not a state change on the TV.
-- If the TV supports Wake-on-LAN and it is enabled in the integration, Home Assistant will attempt WoL automatically without needing this trigger. Use this trigger only when you need to override or supplement that built-in behavior.
+- If the TV supports Wake-on-LAN (WoL) and it is enabled in the integration, Home Assistant will attempt WoL automatically without needing this trigger. Use this trigger only when you need to override or supplement that built-in behavior.
 - The trigger does not include a **For at least** option or a **Trigger when** option, which means that it fires immediately on every turn-on request and targets a single device, not a group.
 - If you use this trigger to send a Wake-on-LAN packet manually, make sure the `wake_on_lan` integration is enabled in your `configuration.yaml`.
 - This trigger is the recommended way to handle Samsung TVs connected to a smart power strip, where the TV cannot be woken by WoL alone and the strip must be switched on first.

--- a/source/_triggers/samsungtv.turn_on.markdown
+++ b/source/_triggers/samsungtv.turn_on.markdown
@@ -1,0 +1,134 @@
+---
+title: "Device is requested to turn on"
+trigger: samsungtv.turn_on
+domain: samsungtv
+description: "Triggers when a Samsung TV device is requested to turn on."
+---
+
+The **Device is requested to turn on** trigger fires when Home Assistant requests a Samsung TV to turn on. This happens when the `media_player.turn_on` action is called by an automation, a script or from the UI, targeting a Samsung TV entity.
+
+Use it when the built-in Wake-on-LAN (WoL) support in the Samsung TV integration is not sufficient for your setup. For example, when the TV is connected to a smart strip, when WoL is not supported on the TV model, or when you want to run additional actions alongside the turn-on sequence, such as switching on a connected AV receiver or adjusting the room lighting.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the searchbox, search and select the **Device** trigger.
+5. From the **Device** list, select your Samsung TV device.
+6. In **Trigger**, select **Device is requested to turn on**.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: >
+    The Samsung TV media player device that should be watched for a turn-on request. Only Samsung TV entities are valid targeted devices for this trigger.
+  required: true
+Trigger:
+  description: >
+    The trigger **Device is requested to turn on**.
+  required: true
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `device` of type `samsungtv.turn_on`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  device_id: my_samsungtv_device_id
+  domain: samsungtv
+  entity_id: media_player.samsung_living_room
+  type: samsungtv.turn_on
+  trigger: device
+{% endexample %}
+
+This fires every time Home Assistant requests `media_player.samsung_living_room` to turn on.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+device_id:
+  description: >
+    The ID of the Samsung TV media player device that should be watched for a turn-on request. Only Samsung TV devices are valid targets for this trigger.
+  required: true
+  type: string
+domain:
+  description: >
+    Domain of the device entity: `samsungtv`.
+  required: true
+  type: string
+entity_id:
+  description: >
+    The Samsung TV media player entity that should be watched for a turn-on request. Only Samsung TV entities are valid targets for this trigger.
+  required: true
+  type: string
+type:
+  description: >
+    The trigger `samsungtv.turn_on`.
+  required: true
+  type: string
+trigger:
+  description: >
+    The Samsung TV media player device that should be watched for a turn-on request. Only Samsung TV entities are valid targeted devices for this trigger.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- This trigger fires when `media_player.turn_on` is called targeting the TV entity, not when the TV turns on by itself (for example, after a power cut). It represents a request from Home Assistant, not a state change on the TV.
+- If the TV supports Wake-on-LAN and it is enabled in the integration, Home Assistant will attempt WoL automatically without needing this trigger. Use this trigger only when you need to override or supplement that built-in behavior.
+- The trigger does not include a **For at least** option or a **Trigger when** option, which means that it fires immediately on every turn-on request and targets a single device, not a group.
+- If you use this trigger to send a Wake-on-LAN packet manually, make sure the `wake_on_lan` integration is enabled in your `configuration.yaml`.
+- This trigger is the recommended way to handle Samsung TVs connected to a smart power strip, where the TV cannot be woken by WoL alone and the strip must be switched on first.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn on a smart power strip before waking the TV to avoid standby energy waste
+
+When the TV is requested to turn on, this automation first switches on the smart power strip the TV is connected to, then sends a Wake-on-LAN packet. This avoids leaving the strip switched on permanently, which would power all connected devices in standby, while still ensuring the TV receives power before the WoL packet is sent.
+
+- **Trigger**: Device is requested to turn on
+  - **Targeted device**: `my_samsungtv_device_id`
+- **Action**: Switch: Turn on (living room AV strip)
+- **Action**: Delay: 5 seconds (to allow the TV to receive power)
+- **Action**: Wake-on-LAN: Send magic packet
+
+{% details "YAML example for turning on a smart strip and sending a WoL packet when the TV is requested to turn on" %}
+
+{% example %}
+automation: |
+  alias: "Turn on AV strip and wake TV on turn-on request"
+  triggers:
+    - device_id: my_samsungtv_device_id
+      domain: samsungtv
+      entity_id: media_player.samsung_living_room
+      type: samsungtv.turn_on
+      trigger: device
+  actions:
+    - action: switch.turn_on
+      target:
+        entity_id: switch.living_room_av_strip
+    - delay:
+        seconds: 5
+    - action: wake_on_lan.send_magic_packet
+      data:
+        mac: "AA:BB:CC:DD:EE:FF"
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/samsungtv.turn_on.markdown
+++ b/source/_triggers/samsungtv.turn_on.markdown
@@ -60,21 +60,6 @@ device_id:
     The ID of the Samsung TV media player device that should be watched for a turn-on request. Only Samsung TV devices are valid targets for this trigger.
   required: true
   type: string
-domain:
-  description: >
-    Domain of the device entity: `samsungtv`.
-  required: true
-  type: string
-type:
-  description: >
-    The trigger type: `samsungtv.turn_on`.
-  required: true
-  type: string
-trigger:
-  description: >
-    The trigger: `device`
-  required: true
-  type: string
 {% endoptions_yaml %}
 
 ## Good to know

--- a/source/_triggers/samsungtv.turn_on.markdown
+++ b/source/_triggers/samsungtv.turn_on.markdown
@@ -27,7 +27,7 @@ To use this trigger in an automation:
 {% options_ui %}
 Device:
   description: >
-    The Samsung TV media player device that should be watched for a turn-on request. Only Samsung TV entities are valid targeted devices for this trigger.
+    The Samsung TV media player device that should be watched for a turn-on request. Only Samsung TV devices can be selected.
   required: true
 Trigger:
   description: >
@@ -36,6 +36,7 @@ Trigger:
 {% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}
+
 In YAML, refer to this trigger as `samsungtv.turn_on`. A basic example looks like this:
 
 {% example %}
@@ -44,7 +45,7 @@ triggers:
     entity_id: media_player.samsung_smart_tv
 {% endexample %}
 
-This fires every time Home Assistant requires the device with ID `my_samsungtv_device_id` to turn on.
+This fires every time Home Assistant requires `media_player.samsung_smart_tv` to turn on.
 
 ### Options in YAML
 
@@ -52,7 +53,7 @@ YAML sometimes provides additional options for more complex use cases that are n
 
 {% options_yaml %}
 trigger:
-  description: The trigger type. For this trigger, use `samsungtv.turn_on`.
+  description: The trigger `samsungtv.turn_on`.
   required: true
   type: string
 device_id:
@@ -93,10 +94,8 @@ When the TV is requested to turn on, this automation first switches on the smart
 automation: |
   alias: "Turn on AV strip and wake TV on turn-on request"
   triggers:
-    - device_id: my_samsungtv_device_id
-      domain: samsungtv
-      type: samsungtv.turn_on
-      trigger: device
+    - trigger: samsungtv.turn_on
+      device_id: my_samsungtv_device_id
   actions:
     - action: switch.turn_on
       target:

--- a/source/_triggers/samsungtv.turn_on.markdown
+++ b/source/_triggers/samsungtv.turn_on.markdown
@@ -18,10 +18,9 @@ To use this trigger in an automation:
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
 2. Open an existing automation, or select **Create automation** > **Create new automation**.
 3. In the **When** section, select **Add trigger**.
-4. Under **By type**, search and select **Device**.
-5. From the **Device** list, select your Samsung TV device.
-6. Select the **Device is requested to turn on** trigger.
-7. Select **Save**.
+4. Under **By device**, select your Samsung TV device.
+5. Select the available trigger **Device is requested to turn on**.
+6. Select **Save**.
 
 ### Options in the UI
 

--- a/source/_triggers/samsungtv.turn_on.markdown
+++ b/source/_triggers/samsungtv.turn_on.markdown
@@ -1,4 +1,4 @@
-git---
+---
 title: "Device is requested to turn on"
 trigger: samsungtv.turn_on
 domain: samsungtv

--- a/source/_triggers/samsungtv.turn_on.markdown
+++ b/source/_triggers/samsungtv.turn_on.markdown
@@ -20,7 +20,7 @@ To use this trigger in an automation:
 3. In the **When** section, select **Add trigger**.
 4. Under **By type**, search and select **Device**.
 5. From the **Device** list, select your Samsung TV device.
-6. From the **Trigger** list, select **Device is requested to turn on**.
+6. Select the **Device is requested to turn on** trigger.
 7. Select **Save**.
 
 ### Options in the UI
@@ -42,33 +42,22 @@ In YAML, refer to this trigger as `device` of type `samsungtv.turn_on`. A basic 
 
 {% example %}
 trigger: |
-  type: samsungtv.turn_on
   device_id: my_samsungtv_device_id
-  entity_id: media_player.samsung_living_room
   domain: samsungtv
+  type: samsungtv.turn_on
   trigger: device
 {% endexample %}
 
-This fires every time Home Assistant requests `media_player.samsung_living_room` to turn on.
+This fires every time Home Assistant requires the device with ID `my_samsungtv_device_id` to turn on.
 
 ### Options in YAML
 
 YAML sometimes provides additional options for more complex use cases that are not available through the UI.
 
 {% options_yaml %}
-type:
-  description: >
-    The trigger `samsungtv.turn_on`.
-  required: true
-  type: string
 device_id:
   description: >
     The ID of the Samsung TV media player device that should be watched for a turn-on request. Only Samsung TV devices are valid targets for this trigger.
-  required: true
-  type: string
-entity_id:
-  description: >
-    The Samsung TV media player entity that should be watched for a turn-on request. Only Samsung TV entities are valid targets for this trigger.
   required: true
   type: string
 domain:
@@ -76,9 +65,14 @@ domain:
     Domain of the device entity: `samsungtv`.
   required: true
   type: string
+type:
+  description: >
+    The trigger type: `samsungtv.turn_on`.
+  required: true
+  type: string
 trigger:
   description: >
-    `device`
+    The trigger: `device`
   required: true
   type: string
 {% endoptions_yaml %}
@@ -88,7 +82,7 @@ trigger:
 - This trigger fires when `media_player.turn_on` is called targeting the TV entity, not when the TV turns on by itself (for example, after a power cut). It represents a request from Home Assistant, not a state change on the TV.
 - If the TV supports Wake-on-LAN (WoL) and it is enabled in the integration, Home Assistant will attempt WoL automatically without needing this trigger. Use this trigger only when you need to override or supplement that built-in behavior.
 - The trigger does not include a **For at least** option or a **Trigger when** option, which means that it fires immediately on every turn-on request and targets a single device, not a group.
-- If you use this trigger to send a Wake-on-LAN packet manually, make sure the `wake_on_lan` integration is enabled in your `configuration.yaml`.
+- If you use this trigger to send a Wake-on-LAN packet manually, make sure the [Wake-on-LAN integration](/integrations/wake_on_lan/) is set up.
 - This trigger is the recommended way to handle Samsung TVs connected to a smart power strip, where the TV cannot be woken by WoL alone and the strip must be switched on first.
 
 {% include triggers/try_it.md %}
@@ -111,10 +105,9 @@ When the TV is requested to turn on, this automation first switches on the smart
 automation: |
   alias: "Turn on AV strip and wake TV on turn-on request"
   triggers:
-    - type: samsungtv.turn_on
-      device_id: my_samsungtv_device_id
-      entity_id: media_player.samsung_living_room
+    - device_id: my_samsungtv_device_id
       domain: samsungtv
+      type: samsungtv.turn_on
       trigger: device
   actions:
     - action: switch.turn_on

--- a/source/_triggers/samsungtv.turn_on.markdown
+++ b/source/_triggers/samsungtv.turn_on.markdown
@@ -36,15 +36,12 @@ Trigger:
 {% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}
-
-In YAML, refer to this trigger as `device` of type `samsungtv.turn_on`. A basic example looks like this:
+In YAML, refer to this trigger as `samsungtv.turn_on`. A basic example looks like this:
 
 {% example %}
-trigger: |
-  device_id: my_samsungtv_device_id
-  domain: samsungtv
-  type: samsungtv.turn_on
-  trigger: device
+triggers:
+  - trigger: samsungtv.turn_on
+    entity_id: media_player.samsung_smart_tv
 {% endexample %}
 
 This fires every time Home Assistant requires the device with ID `my_samsungtv_device_id` to turn on.
@@ -54,10 +51,17 @@ This fires every time Home Assistant requires the device with ID `my_samsungtv_d
 YAML sometimes provides additional options for more complex use cases that are not available through the UI.
 
 {% options_yaml %}
-device_id:
-  description: >
-    The ID of the Samsung TV media player device that should be watched for a turn-on request. Only Samsung TV devices are valid targets for this trigger.
+trigger:
+  description: The trigger type. For this trigger, use `samsungtv.turn_on`.
   required: true
+  type: string
+device_id:
+  description: One or more device IDs of Samsung TV devices to watch. At least one of `device_id` or `entity_id` must be set. To use more than one device ID, enter them as a list.
+  required: false
+  type: string
+entity_id:
+  description: One or more entity IDs of Samsung TV entities to watch. At least one of `device_id` or `entity_id` must be set. To use more than one entity ID, enter them as a list.
+  required: false
   type: string
 {% endoptions_yaml %}
 

--- a/source/_triggers/samsungtv.turn_on.markdown
+++ b/source/_triggers/samsungtv.turn_on.markdown
@@ -5,7 +5,7 @@ domain: samsungtv
 description: "Triggers when a Samsung TV device is requested to turn on."
 ---
 
-The **Device is requested to turn on** trigger fires when Home Assistant requests a Samsung TV to turn on. This happens when the `media_player.turn_on` action is called by an automation, a script or from the UI, targeting a Samsung TV entity.
+The **Device is requested to turn on** trigger fires when Home Assistant requests a Samsung TV to turn on. This happens when a turn_on action is called by an automation, a script or from the UI, targeting a Samsung TV entity.
 
 Use it when the built-in Wake-on-LAN (WoL) support in the Samsung TV integration is not sufficient for your setup. For example, when the TV is connected to a smart strip, when WoL is not supported on the TV model, or when you want to run additional actions alongside the turn-on sequence, such as switching on a connected AV receiver or adjusting the room lighting.
 
@@ -18,9 +18,9 @@ To use this trigger in an automation:
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
 2. Open an existing automation, or select **Create automation** > **Create new automation**.
 3. In the **When** section, select **Add trigger**.
-4. From the searchbox, search and select the **Device** trigger.
+4. Under **By type**, search and select **Device**.
 5. From the **Device** list, select your Samsung TV device.
-6. In **Trigger**, select **Device is requested to turn on**.
+6. From the **Trigger** list, select **Device is requested to turn on**.
 7. Select **Save**.
 
 ### Options in the UI
@@ -42,10 +42,10 @@ In YAML, refer to this trigger as `device` of type `samsungtv.turn_on`. A basic 
 
 {% example %}
 trigger: |
-  device_id: my_samsungtv_device_id
-  domain: samsungtv
-  entity_id: media_player.samsung_living_room
   type: samsungtv.turn_on
+  device_id: my_samsungtv_device_id
+  entity_id: media_player.samsung_living_room
+  domain: samsungtv
   trigger: device
 {% endexample %}
 
@@ -56,14 +56,14 @@ This fires every time Home Assistant requests `media_player.samsung_living_room`
 YAML sometimes provides additional options for more complex use cases that are not available through the UI.
 
 {% options_yaml %}
+type:
+  description: >
+    The trigger `samsungtv.turn_on`.
+  required: true
+  type: string
 device_id:
   description: >
     The ID of the Samsung TV media player device that should be watched for a turn-on request. Only Samsung TV devices are valid targets for this trigger.
-  required: true
-  type: string
-domain:
-  description: >
-    Domain of the device entity: `samsungtv`.
   required: true
   type: string
 entity_id:
@@ -71,14 +71,14 @@ entity_id:
     The Samsung TV media player entity that should be watched for a turn-on request. Only Samsung TV entities are valid targets for this trigger.
   required: true
   type: string
-type:
+domain:
   description: >
-    The trigger `samsungtv.turn_on`.
+    Domain of the device entity: `samsungtv`.
   required: true
   type: string
 trigger:
   description: >
-    The Samsung TV media player device that should be watched for a turn-on request. Only Samsung TV entities are valid targeted devices for this trigger.
+    `device`
   required: true
   type: string
 {% endoptions_yaml %}
@@ -111,10 +111,10 @@ When the TV is requested to turn on, this automation first switches on the smart
 automation: |
   alias: "Turn on AV strip and wake TV on turn-on request"
   triggers:
-    - device_id: my_samsungtv_device_id
-      domain: samsungtv
+    - type: samsungtv.turn_on
+      device_id: my_samsungtv_device_id
       entity_id: media_player.samsung_living_room
-      type: samsungtv.turn_on
+      domain: samsungtv
       trigger: device
   actions:
     - action: switch.turn_on


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add documentation of Samsung Smart TV trigger.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #44930

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
