### PR TITLE
Document optional CCM15 device password

### DIFF
--- a/source/_integrations/ccm15.markdown
+++ b/source/_integrations/ccm15.markdown
@@ -26,19 +26,8 @@ There is currently support for the following device types within Home Assistant:
 
 {% configuration_basic %}
 Device password:
-    description: "Optional. Only needed if your CCM15 firmware requires a password for control commands. Status polling stays unauthenticated, so this is only consulted when Home Assistant writes to the controller. The value to enter is the obfuscated number the controller's web UI sends, not the plain number from its settings page. See [Finding the device password](#finding-the-device-password)."
+    description: "Optional. The password configured on your CCM15 controller's settings page (factory default `123456`). Only needed if your firmware enforces it on control commands; status polling stays unauthenticated. If the controller starts rejecting commands later, Home Assistant prompts you to re-enter it through the reauthentication flow."
 {% endconfiguration_basic %}
-
-### Finding the device password
-
-If your CCM15 firmware rejects control commands without a `pwd` parameter, you can read the obfuscated value off the controller's own web interface:
-
-1. Open the CCM15 web interface in your browser.
-2. Open the browser's developer tools. Press F12, or right-click anywhere on the page and select **Inspect**, or use the browser's menu (in Chrome: **More tools** > **Developer tools**; in Firefox: **Tools** > **Browser tools** > **Web developer tools**; in Safari, first enable the **Develop** menu in **Settings** > **Advanced**, then choose **Develop** > **Show Web Inspector**).
-3. Switch to the **Network** tab.
-4. Change any setting in the web UI (for example the fan speed).
-5. Select the new `ctrl.xml` request.
-6. Copy the value of the `pwd` parameter from the request URL. It is a 6-digit number.
 
 ## Climate
 

--- a/source/_integrations/ccm15.markdown
+++ b/source/_integrations/ccm15.markdown
@@ -34,7 +34,7 @@ Device password:
 If your CCM15 firmware rejects control commands without a `pwd` parameter, you can read the obfuscated value off the controller's own web interface:
 
 1. Open the CCM15 web interface in your browser.
-2. Press F12 to open the browser developer tools.
+2. Open the browser's developer tools. Press F12, or right-click anywhere on the page and select **Inspect**, or use the browser's menu (in Chrome: **More tools** > **Developer tools**; in Firefox: **Tools** > **Browser tools** > **Web developer tools**; in Safari, first enable the **Develop** menu in **Settings** > **Advanced**, then choose **Develop** > **Show Web Inspector**).
 3. Switch to the **Network** tab.
 4. Change any setting in the web UI (for example the fan speed).
 5. Select the new `ctrl.xml` request.

--- a/source/_integrations/ccm15.markdown
+++ b/source/_integrations/ccm15.markdown
@@ -24,6 +24,22 @@ There is currently support for the following device types within Home Assistant:
 
 {% include integrations/config_flow.md %}
 
+{% configuration_basic %}
+Device password:
+    description: "Optional. Only needed if your CCM15 firmware requires a password for control commands. Status polling stays unauthenticated, so this is only consulted when Home Assistant writes to the controller. The value to enter is the obfuscated number the controller's web UI sends, not the plain number from its settings page. See [Finding the device password](#finding-the-device-password)."
+{% endconfiguration_basic %}
+
+### Finding the device password
+
+If your CCM15 firmware rejects control commands without a `pwd` parameter, you can read the obfuscated value off the controller's own web interface:
+
+1. Open the CCM15 web interface in your browser.
+2. Press F12 to open the browser developer tools.
+3. Switch to the **Network** tab.
+4. Change any setting in the web UI (for example the fan speed).
+5. Select the new `ctrl.xml` request.
+6. Copy the value of the `pwd` parameter from the request URL. It is a 6-digit number.
+
 ## Climate
 
 Each data controller can support up to 64 `climate` devices.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the new optional `password` config field added to the CCM15 integration in home-assistant/core#173804.

The field is only consulted when Home Assistant writes to the controller (status polling stays unauthenticated). Some CCM15 firmwares silently reject every `ctrl.xml` write unless a `pwd` query parameter is present and matches — that's the case this PR covers. Existing setups whose firmware accepts unauthenticated writes are unaffected (the field defaults to empty).

The value the user enters is the obfuscated number the controller's web UI sends, not the plain number from its settings page (the web UI applies `XOR 0x56789` before transmitting). To keep the field practically findable, a short "Finding the device password" subsection walks the user through capturing the value via browser DevTools.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#173804
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards