### PR TITLE
Document Modbus climate fan read/write values

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -782,50 +782,52 @@ climates:
           type: [integer, list]
         values:
           description: "Mapping between the register values and Fan modes
-            This is typically used to control one of: Speed, Direction or On/Off state."
+            This is typically used to control one of: Speed, Direction or On/Off state.
+            Use an integer when the read and write values are the same.
+            Use a two-item list in the form [read value, write value] when the device reports one value but expects another value for the same fan mode."
           required: true
           type: map
           keys:
             state_fan_on:
               description: "Value corresponding to Fan On mode."
               required: false
-              type: integer
+              type: [integer, list]
             state_fan_off:
               description: "Value corresponding to Fan Off mode."
               required: false
-              type: integer
+              type: [integer, list]
             state_fan_low:
               description: "Value corresponding to Fan Low mode."
               required: false
-              type: integer
+              type: [integer, list]
             state_fan_medium:
               description: "Value corresponding to Fan Medium mode."
               required: false
-              type: integer
+              type: [integer, list]
             state_fan_high:
               description: "Value corresponding to Fan High mode."
               required: false
-              type: integer
+              type: [integer, list]
             state_fan_auto:
               description: "Value corresponding to Fan Auto mode."
               required: false
-              type: integer
+              type: [integer, list]
             state_fan_top:
               description: "Value corresponding to Fan Top mode."
               required: false
-              type: integer
+              type: [integer, list]
             state_fan_middle:
               description: "Value corresponding to Fan Middle mode."
               required: false
-              type: integer
+              type: [integer, list]
             state_fan_focus:
               description: "Value corresponding to Fan Focus mode."
               required: false
-              type: integer
+              type: [integer, list]
             state_fan_diffuse:
               description: "Value corresponding to Fan Diffuse mode."
               required: false
-              type: integer
+              type: [integer, list]
     hvac_onoff_coil:
       description: "Address of On/Off state.
         Only use this setting if your On/Off state is not handled as a HVAC mode.
@@ -934,6 +936,31 @@ modbus:
         target_temp_write_registers: true
         temp_step: 1
         temperature_unit: C
+```
+
+### Example: Modbus climate fan mode with different read and write values
+
+Some Modbus climate devices report one register value for a fan mode but expect a different value when writing that same fan mode. In that case, configure the affected fan mode as `[read value, write value]`.
+
+```yaml
+# Example configuration.yaml entry
+modbus:
+  - name: hub1
+    type: tcp
+    host: IP_ADDRESS
+    port: 502
+    climates:
+      - name: "Gree VRF"
+        address: 117
+        slave: 10
+        target_temp_register: 116
+        fan_mode_register:
+          address: 118
+          values:
+            state_fan_low: 0
+            state_fan_medium: 1
+            state_fan_high: 2
+            state_fan_top: [3, 4]
 ```
 
 ## Configuring cover entities


### PR DESCRIPTION
## Proposed change

Document that Modbus climate fan mode values can be configured either as a single integer for matching read/write values, or as a two-item list `[read value, write value]` when a device reports one value but expects another for the same fan mode.

This supports the companion core PR and replaces the earlier closed documentation PR with the updated compact configuration format.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/174133
- Replaces closed documentation PR: https://github.com/home-assistant/home-assistant.io/pull/39874
- Related closed core PR: https://github.com/home-assistant/core/pull/148242
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards