### PR TITLE
Add LG AC climate platform to lg_infrared docs

### DIFF
--- a/source/_integrations/lg_infrared.markdown
+++ b/source/_integrations/lg_infrared.markdown
@@ -35,20 +35,22 @@ The integration supports:
 
 Before setting up the LG Infrared integration, you need a working infrared emitter, an infrared receiver, or both, already set up in Home Assistant. Each must expose an [Infrared](/integrations/infrared/) entity. For example, you can use an ESPHome device with an IR LED pointed at your LG device to send commands, and an IR receiver module to capture commands from your LG remote.
 
+For an air conditioner, an infrared emitter is required. The **Air conditioner** option only appears once you have at least one infrared emitter available.
+
 {% include integrations/config_flow.md %}
 
+The first step asks which type of LG device you want to set up: **TV** or **Air conditioner**. The remaining options depend on that choice. To set up both, add the integration twice.
+
 {% configuration_basic %}
-Device type:
-  description: The type of LG device to control. Select **TV** for an LG television or **Air conditioner** for a compatible LG split air conditioner.
 Infrared emitter:
-  description: The infrared emitter entity to use for sending commands to your LG device. This must be an entity provided by a hardware integration (such as ESPHome) that has already been set up with an IR emitter.
+  description: The infrared emitter entity to use for sending commands to your LG device. This must be an entity provided by a hardware integration (such as ESPHome) that has already been set up with an IR emitter. It is required for an air conditioner.
 Infrared receiver:
-  description: The infrared receiver entity to use for receiving commands from your LG remote. This must be an entity provided by a hardware integration (such as ESPHome) that has already been set up with an IR receiver.
-Heat mode:
-  description: Enable this option if your LG air conditioner supports heat mode. Not all LG air conditioner models support it. This option is only shown when setting up an **Air conditioner** device.
+  description: The infrared receiver entity to use for receiving commands from your LG remote. This must be an entity provided by a hardware integration (such as ESPHome) that has already been set up with an IR receiver. For a TV, received commands are available as events you can use in automations. For an air conditioner, they keep the climate entity in sync with the physical remote.
+Supported modes:
+  description: The operating modes your air conditioner supports: **Cool**, **Heat**, **Dry**, and **Fan only**. Select at least one. Check your remote or the manual of your unit to see which modes it has. Selecting a mode your unit does not have breaks nothing. Your air conditioner simply does not respond to it. This option is shown for an air conditioner only.
 {% endconfiguration_basic %}
 
-At least one of **Infrared emitter** or **Infrared receiver** must be selected. Select both if you want to be able to send commands to your device and react to commands from the remote.
+For a TV, select at least one of **Infrared emitter** or **Infrared receiver**. Select both if you want to be able to send commands to your TV and react to commands from the remote.
 
 ## Supported functionality
 
@@ -94,18 +96,18 @@ A media player entity is created when an infrared emitter is configured.
 
 ### Air conditioner
 
-A climate entity is created when an infrared emitter is configured for an LG air conditioner device.
+A climate entity is created for each LG air conditioner device you set up.
 
 - **LG AC**
   - **Description**: Represents the LG split air conditioner and allows you to control it via IR commands.
-  - **Supported features**: Set HVAC mode, set fan mode, and set target temperature.
+  - **Supported features**: Set HVAC mode and set fan mode. Set target temperature is also available when **Cool** or **Heat** is one of the supported modes you selected during setup.
 
 #### Supported modes
 
-During setup, you select which modes your unit supports. Not all LG air conditioner models support heat mode.
+The climate entity offers the modes you selected during setup.
 
 - **Cool**: Cools to a set temperature.
-- **Heat**: Heats to a set temperature. Enable this only if your unit supports it.
+- **Heat**: Heats to a set temperature. Not all LG air conditioner models have it.
 - **Dry**: Dehumidify mode. The temperature is fixed at 24 °C by the protocol.
 - **Fan only**: Fan circulation without heating or cooling.
 
@@ -114,7 +116,9 @@ During setup, you select which modes your unit supports. Not all LG air conditio
 - **Auto**: The unit selects the speed automatically.
 - **Quiet**: Lowest noise level.
 - **Low**: Low fan speed.
+- **Medium low**: Between low and medium.
 - **Medium**: Medium fan speed.
+- **Medium high**: Between medium and high.
 - **High**: High fan speed.
 
 #### Temperature range
@@ -123,15 +127,16 @@ Supported range: 16 °C to 30 °C in 1 °C steps.
 
 #### Physical remote state tracking
 
-If you also have an infrared receiver entity (from an IR blaster that can also listen), you can optionally select it during setup. When selected, the integration decodes signals from the physical LG air conditioner remote and keeps the climate entity state in sync automatically.
+If you also have an infrared receiver entity (from an IR blaster that can also listen), you can optionally select it during setup. When selected, the integration decodes signals from the physical LG air conditioner remote and updates the climate entity to match, so the mode, fan speed, and target temperature stay in sync.
 
 ## Known limitations
 
 - The TV media player and button entities use assumed state, meaning Home Assistant cannot verify the actual state of the TV. Commands received from the physical remote are exposed as events only and do not update the TV entity state.
-- The climate entity for the air conditioner also uses assumed state unless you enable physical remote state tracking during setup. Without it, the climate entity state is not updated when you use the physical remote.
+- The climate entity for the air conditioner also uses assumed state, even with physical remote state tracking enabled. The receiver reports what the remote sent, not what the unit is actually doing, so the two can still drift apart, for example if something blocks the line of sight.
 - Turning on and turning off the TV both send the same IR power toggle command, as is standard with infrared remotes.
 - Volume control for the TV is step-based only; there is no way to set an absolute volume level.
-- For the air conditioner, the dry mode temperature is fixed at 24 °C by the LG air conditioner infrared protocol and cannot be changed.
+- For the air conditioner, the dry mode temperature is fixed at 24 °C by the LG air conditioner infrared protocol and cannot be changed. Fan only mode has no target temperature at all. Changing the target temperature in either mode is remembered for the next time you switch to cool or heat, but nothing is sent to the unit.
+- Changing the fan speed while the air conditioner is off is also remembered rather than sent. It is applied with the next command that turns the unit on.
 
 ## Removing the integration
 

--- a/source/_integrations/lg_infrared.markdown
+++ b/source/_integrations/lg_infrared.markdown
@@ -43,11 +43,11 @@ The first step asks which type of LG device you want to set up: **TV** or **Air 
 
 {% configuration_basic %}
 Infrared emitter:
-  description: The infrared emitter entity to use for sending commands to your LG device. This must be an entity provided by a hardware integration (such as ESPHome) that has already been set up with an IR emitter. It is required for an air conditioner.
+  description: "The infrared emitter entity to use for sending commands to your LG device. This must be an entity provided by a hardware integration (such as ESPHome) that has already been set up with an IR emitter. It is required for an air conditioner."
 Infrared receiver:
-  description: The infrared receiver entity to use for receiving commands from your LG remote. This must be an entity provided by a hardware integration (such as ESPHome) that has already been set up with an IR receiver. For a TV, received commands are available as events you can use in automations. For an air conditioner, they keep the climate entity in sync with the physical remote.
+  description: "The infrared receiver entity to use for receiving commands from your LG remote. This must be an entity provided by a hardware integration (such as ESPHome) that has already been set up with an IR receiver. For a TV, received commands are available as events you can use in automations. For an air conditioner, they keep the climate entity in sync with the physical remote."
 Supported modes:
-  description: The operating modes your air conditioner supports: **Cool**, **Heat**, **Dry**, and **Fan only**. Select at least one. Check your remote or the manual of your unit to see which modes it has. Selecting a mode your unit does not have breaks nothing. Your air conditioner simply does not respond to it. This option is shown for an air conditioner only.
+  description: "The operating modes your air conditioner supports. Select at least one of **Cool**, **Heat**, **Dry**, and **Fan only**. Check your remote or the manual of your unit to see which modes it has. Selecting a mode your unit does not have breaks nothing. Your air conditioner simply does not respond to it. This option is shown for an air conditioner only."
 {% endconfiguration_basic %}
 
 For a TV, select at least one of **Infrared emitter** or **Infrared receiver**. Select both if you want to be able to send commands to your TV and react to commands from the remote.

--- a/source/_integrations/lg_infrared.markdown
+++ b/source/_integrations/lg_infrared.markdown
@@ -24,9 +24,16 @@ The **LG Infrared** {% term integration %} lets you control an LG TV or a compat
 
 Because the integration communicates over infrared, it operates in a one-way, fire-and-forget fashion: commands are sent to the device but there is no feedback channel to confirm the current state. The integration therefore uses assumed states.
 
+## Supported devices
+
+The integration supports:
+
+- LG TVs that can be controlled via the standard LG infrared protocol.
+- Compatible LG split air conditioners that can be controlled via the standard LG air conditioner infrared protocol.
+
 ## Prerequisites
 
-Before setting up the LG Infrared integration, you need a working infrared emitter, an infrared receiver, or both, already set up in Home Assistant. Each must expose an [Infrared](/integrations/infrared/) entity. For example, you can use an ESPHome device with an IR LED pointed at your LG TV to send commands, and an IR receiver module to capture commands from your LG remote.
+Before setting up the LG Infrared integration, you need a working infrared emitter, an infrared receiver, or both, already set up in Home Assistant. Each must expose an [Infrared](/integrations/infrared/) entity. For example, you can use an ESPHome device with an IR LED pointed at your LG device to send commands, and an IR receiver module to capture commands from your LG remote.
 
 {% include integrations/config_flow.md %}
 
@@ -34,25 +41,18 @@ Before setting up the LG Infrared integration, you need a working infrared emitt
 Device type:
   description: The type of LG device to control. Select **TV** for an LG television or **Air conditioner** for a compatible LG split air conditioner.
 Infrared emitter:
-  description: The infrared emitter entity to use for sending commands to your LG TV. This must be an entity provided by a hardware integration (such as ESPHome) that has already been set up with an IR emitter.
+  description: The infrared emitter entity to use for sending commands to your LG device. This must be an entity provided by a hardware integration (such as ESPHome) that has already been set up with an IR emitter.
 Infrared receiver:
   description: The infrared receiver entity to use for receiving commands from your LG remote. This must be an entity provided by a hardware integration (such as ESPHome) that has already been set up with an IR receiver.
+Heat mode:
+  description: Enable this option if your LG air conditioner supports heat mode. Not all LG air conditioner models support it. This option is only shown when setting up an **Air conditioner** device.
 {% endconfiguration_basic %}
 
-At least one of **Infrared emitter** or **Infrared receiver** must be selected. Select both if you want to be able to send commands to the TV and react to commands from the remote.
-
-## Supported devices
-
-The integration supports:
-
-- LG TVs that can be controlled via the standard LG infrared protocol.
-- Compatible LG split air conditioners that can be controlled via the standard LG AC infrared protocol.
+At least one of **Infrared emitter** or **Infrared receiver** must be selected. Select both if you want to be able to send commands to your device and react to commands from the remote.
 
 ## Supported functionality
 
-### Entities
-
-The **LG Infrared** integration provides the following entities.
+### TV
 
 #### Buttons
 
@@ -92,25 +92,21 @@ A media player entity is created when an infrared emitter is configured.
   - **Description**: Represents the LG TV and allows you to control it via IR commands.
   - **Supported features**: Turn on, turn off, volume up, volume down, mute, channel up, channel down, play, pause, and stop.
 
-#### Climate
+### Air conditioner
 
 A climate entity is created when an infrared emitter is configured for an LG air conditioner device.
 
 - **LG AC**
   - **Description**: Represents the LG split air conditioner and allows you to control it via IR commands.
-  - **Supported features**: Set HVAC mode, set fan mode, set target temperature.
-
-### Air conditioner
-
-The LG Infrared AC device type creates a **climate** entity that lets you control a compatible LG split air conditioner over infrared.
+  - **Supported features**: Set HVAC mode, set fan mode, and set target temperature.
 
 #### Supported modes
 
-During setup you select which modes your unit supports. Not all LG AC models support heat mode.
+During setup, you select which modes your unit supports. Not all LG air conditioner models support heat mode.
 
 - **Cool**: Cools to a set temperature.
-- **Heat**: Heats to a set temperature (select only if your unit supports it).
-- **Dry**: Dehumidify mode (temperature is fixed at 24 °C by the protocol).
+- **Heat**: Heats to a set temperature. Enable this only if your unit supports it.
+- **Dry**: Dehumidify mode. The temperature is fixed at 24 °C by the protocol.
 - **Fan only**: Fan circulation without heating or cooling.
 
 #### Fan speeds
@@ -127,13 +123,15 @@ Supported range: 16 °C to 30 °C in 1 °C steps.
 
 #### Physical remote state tracking
 
-If you also have an infrared receiver entity (from an IR blaster that can also listen), you can optionally select it during setup. When selected, the integration decodes signals from the physical LG remote and keeps the climate entity state in sync automatically.
+If you also have an infrared receiver entity (from an IR blaster that can also listen), you can optionally select it during setup. When selected, the integration decodes signals from the physical LG air conditioner remote and keeps the climate entity state in sync automatically.
 
 ## Known limitations
 
-- The integration uses assumed state, meaning Home Assistant cannot read the actual state of the TV (for example, whether it is on or off, or what the current volume is). Commands received through the infrared receiver are exposed as events only; they do not update the state of the media player entity.
+- The TV media player and button entities use assumed state, meaning Home Assistant cannot verify the actual state of the TV. Commands received from the physical remote are exposed as events only and do not update the TV entity state.
+- The climate entity for the air conditioner also uses assumed state unless you enable physical remote state tracking during setup. Without it, the climate entity state is not updated when you use the physical remote.
 - Turning on and turning off the TV both send the same IR power toggle command, as is standard with infrared remotes.
-- Volume control is step-based only; there is no way to set an absolute volume level.
+- Volume control for the TV is step-based only; there is no way to set an absolute volume level.
+- For the air conditioner, the dry mode temperature is fixed at 24 °C by the LG air conditioner infrared protocol and cannot be changed.
 
 ## Removing the integration
 

--- a/source/_integrations/lg_infrared.markdown
+++ b/source/_integrations/lg_infrared.markdown
@@ -1,7 +1,8 @@
 ---
 title: LG Infrared
-description: Integration to control LG TVs using an infrared emitter and to receive commands from an LG remote using an infrared receiver.
+description: Integration to control LG TVs and LG split air conditioners using an infrared emitter and to receive commands from an LG remote using an infrared receiver.
 ha_category:
+  - Climate
   - Event
   - Media player
 ha_release: 2026.4
@@ -12,15 +13,16 @@ ha_domain: lg_infrared
 ha_config_flow: true
 ha_platforms:
   - button
+  - climate
   - event
   - media_player
 ha_integration_type: device
 ha_quality_scale: silver
 ---
 
-The **LG Infrared** {% term integration %} lets you control an LG TV using any infrared emitter previously configured in Home Assistant. It can also receive commands from an LG remote when you have an infrared receiver set up, allowing you to use the remote to trigger automations in Home Assistant.
+The **LG Infrared** {% term integration %} lets you control an LG TV or a compatible LG split air conditioner using any infrared emitter previously configured in Home Assistant. It can also receive commands from an LG remote when you have an infrared receiver set up, allowing you to use the remote to trigger automations in Home Assistant.
 
-Because the integration communicates over infrared, it operates in a one-way, fire-and-forget fashion: commands are sent to the TV but there is no feedback channel to confirm the current state of the TV. The integration therefore uses assumed states.
+Because the integration communicates over infrared, it operates in a one-way, fire-and-forget fashion: commands are sent to the device but there is no feedback channel to confirm the current state. The integration therefore uses assumed states.
 
 ## Prerequisites
 
@@ -30,7 +32,7 @@ Before setting up the LG Infrared integration, you need a working infrared emitt
 
 {% configuration_basic %}
 Device type:
-  description: The type of LG device to control. Currently, only **TV** is supported.
+  description: The type of LG device to control. Select **TV** for an LG television or **Air conditioner** for a compatible LG split air conditioner.
 Infrared emitter:
   description: The infrared emitter entity to use for sending commands to your LG TV. This must be an entity provided by a hardware integration (such as ESPHome) that has already been set up with an IR emitter.
 Infrared receiver:
@@ -41,7 +43,10 @@ At least one of **Infrared emitter** or **Infrared receiver** must be selected. 
 
 ## Supported devices
 
-The integration supports LG TVs that can be controlled via the standard LG infrared protocol.
+The integration supports:
+
+- LG TVs that can be controlled via the standard LG infrared protocol.
+- Compatible LG split air conditioners that can be controlled via the standard LG AC infrared protocol.
 
 ## Supported functionality
 
@@ -86,6 +91,43 @@ A media player entity is created when an infrared emitter is configured.
 - **LG TV**
   - **Description**: Represents the LG TV and allows you to control it via IR commands.
   - **Supported features**: Turn on, turn off, volume up, volume down, mute, channel up, channel down, play, pause, and stop.
+
+#### Climate
+
+A climate entity is created when an infrared emitter is configured for an LG air conditioner device.
+
+- **LG AC**
+  - **Description**: Represents the LG split air conditioner and allows you to control it via IR commands.
+  - **Supported features**: Set HVAC mode, set fan mode, set target temperature.
+
+### Air conditioner
+
+The LG Infrared AC device type creates a **climate** entity that lets you control a compatible LG split air conditioner over infrared.
+
+#### Supported modes
+
+During setup you select which modes your unit supports. Not all LG AC models support heat mode.
+
+- **Cool**: Cools to a set temperature.
+- **Heat**: Heats to a set temperature (select only if your unit supports it).
+- **Dry**: Dehumidify mode (temperature is fixed at 24 °C by the protocol).
+- **Fan only**: Fan circulation without heating or cooling.
+
+#### Fan speeds
+
+- **Auto**: The unit selects the speed automatically.
+- **Quiet**: Lowest noise level.
+- **Low**: Low fan speed.
+- **Medium**: Medium fan speed.
+- **High**: High fan speed.
+
+#### Temperature range
+
+Supported range: 16 °C to 30 °C in 1 °C steps.
+
+#### Physical remote state tracking
+
+If you also have an infrared receiver entity (from an IR blaster that can also listen), you can optionally select it during setup. When selected, the integration decodes signals from the physical LG remote and keeps the climate entity state in sync automatically.
 
 ## Known limitations
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add documentation for the LG AC (air conditioner) device type added to the `lg_infrared` integration in home-assistant/core#174142.

- Adds `climate` to `ha_platforms` and `ha_category`
- Documents supported HVAC modes, fan speeds, temperature range, and optional physical remote state tracking

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#174142
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards