### PR TITLE
Document UniFi Protect detection event entities

### DIFF
--- a/source/_integrations/unifiprotect.markdown
+++ b/source/_integrations/unifiprotect.markdown
@@ -590,7 +590,7 @@ License Plate Recognition can be triggered by various sources, including images 
 - **Event Attributes**:
   - **event_type**: `motion`
   - **event_id**: A unique ID that identifies the motion event.
-- **Description**: This event fires each time a camera starts a motion detection. It complements the camera's **Motion** sensor by giving you a point-in-time event to trigger automations on, and provides an `event_id` you can use to fetch related media.
+- **Description**: This event fires each time a camera starts detecting motion. It complements the camera's **Motion** sensor by giving you a point-in-time event to trigger automations on, and provides an `event_id` you can use to fetch related media.
 
 ### Smart Detection Event
 

--- a/source/_integrations/unifiprotect.markdown
+++ b/source/_integrations/unifiprotect.markdown
@@ -584,6 +584,63 @@ Vehicle detection events are fired even if no license plate is detected. The `li
 License Plate Recognition can be triggered by various sources, including images or printed materials showing license plates. Always use caution when creating automations based on license plate detection, especially for security-sensitive actions like opening garage doors or unlocking gates. Consider implementing additional verification methods or time-based restrictions to prevent unwanted triggering. Use at your own risk.
 {% endwarning %}
 
+### Motion Detection Event
+
+- **Event Name**: Motion detection
+- **Event Attributes**:
+  - **event_type**: `motion`
+  - **event_id**: A unique ID that identifies the motion event.
+- **Description**: This event fires each time a camera starts a motion detection. It complements the camera's **Motion** sensor by giving you a point-in-time event to trigger automations on, and provides an `event_id` you can use to fetch related media.
+
+### Smart Detection Event
+
+- **Event Name**: Smart detection
+- **Event Attributes**:
+  - **event_type**: The detected object type, such as `person`, `vehicle`, `animal`, `package`, `license_plate`, `face`, `car`, or `pet`. New types are surfaced automatically as UniFi Protect adds support for them.
+  - **event_id**: A unique ID that identifies the detection event.
+  - **smart_detect_types**: The full set of object types detected during the event.
+- **Description**: This event fires for each object type a Smart Detection camera detects, including types that do not have their own sensor. Each detected type fires once across the lifecycle of an event (start, update, and end), so a type that UniFi Protect only reports partway through an event still surfaces reliably.
+
+{% note %}
+The Smart detection event reports _which_ type was detected, not the richer recognized metadata behind it. The UniFi Protect public API does not currently expose details such as the recognized license plate text, vehicle color and type, or detection confidence on this event. For the recognized license plate and vehicle attributes, use the dedicated [Vehicle Detection Event](#vehicle-detection-event), which still sources that data from the private API.
+{% endnote %}
+
+#### Example Smart Detection Automation
+
+```yaml
+alias: Person Detected Notification
+description: Automation that triggers when a person is detected
+triggers:
+  - event_type: state_changed
+    event_data:
+      entity_id: event.driveway_camera_smart_detection # Replace with your camera entity
+    trigger: event
+conditions:
+  - condition: template
+    value_template: >
+      {% raw %}{{
+         trigger.event.data.old_state is not none and
+         not trigger.event.data.old_state.attributes.get('restored', false) and
+         trigger.event.data.old_state.state != 'unavailable' and
+         trigger.event.data.new_state is not none and
+         trigger.event.data.new_state.attributes.event_type == 'person'
+       }}{% endraw %}
+actions:
+  - data:
+      message: A person was detected.
+      title: Smart Detection
+    action: notify.mobile_app_your_device # Replace with your notification target
+```
+
+### Sound Detection Event
+
+- **Event Name**: Sound detection
+- **Event Attributes**:
+  - **event_type**: The detected sound type, such as `smoke`, `co`, `siren`, `baby_cry`, `speaking`, `bark`, `car_alarm`, `car_horn`, or `glass_break`. New types are surfaced automatically as UniFi Protect adds support for them.
+  - **event_id**: A unique ID that identifies the detection event.
+  - **smart_detect_types**: The full set of sound types detected during the event.
+- **Description**: This event fires for each sound a camera with audio detection detects. As with smart detection, each type fires once across the lifecycle of an event, so an audio alarm that UniFi Protect reports partway through an event surfaces reliably.
+
 ## Troubleshooting
 
 ### Delay in video feed

--- a/source/_integrations/unifiprotect.markdown
+++ b/source/_integrations/unifiprotect.markdown
@@ -607,30 +607,31 @@ The Smart detection event reports _which_ type was detected, not the richer reco
 
 #### Example Smart Detection Automation
 
-```yaml
-alias: Person Detected Notification
-description: Automation that triggers when a person is detected
-triggers:
-  - event_type: state_changed
-    event_data:
-      entity_id: event.driveway_camera_smart_detection # Replace with your camera entity
-    trigger: event
-conditions:
-  - condition: template
-    value_template: >
-      {% raw %}{{
-         trigger.event.data.old_state is not none and
-         not trigger.event.data.old_state.attributes.get('restored', false) and
-         trigger.event.data.old_state.state != 'unavailable' and
-         trigger.event.data.new_state is not none and
-         trigger.event.data.new_state.attributes.event_type == 'person'
-       }}{% endraw %}
-actions:
-  - data:
-      message: A person was detected.
-      title: Smart Detection
-    action: notify.mobile_app_your_device # Replace with your notification target
-```
+{% example %}
+automation: |
+  alias: "Person detected notification"
+  description: "Automation that triggers when a person is detected"
+  triggers:
+    - trigger: event
+      event_type: state_changed
+      event_data:
+        entity_id: event.driveway_camera_smart_detection # Replace with your camera entity
+  conditions:
+    - condition: template
+      value_template: >
+        {{
+          trigger.event.data.old_state is not none and
+          not trigger.event.data.old_state.attributes.get('restored', false) and
+          trigger.event.data.old_state.state != 'unavailable' and
+          trigger.event.data.new_state is not none and
+          trigger.event.data.new_state.attributes.event_type == 'person'
+        }}
+  actions:
+    - action: notify.mobile_app_your_device # Replace with your notification target
+      data:
+        message: "A person was detected."
+        title: "Smart detection"
+{% endexample %}
 
 ### Sound Detection Event
 


### PR DESCRIPTION
## Proposed change

Document the three detection event entities added in home-assistant/core#174948 — **Motion detection**, **Smart detection**, and **Sound detection** — in the Event Entities Support section, alongside the existing doorbell, NFC, fingerprint, and vehicle events. Each entry covers its `event_type`, `event_id`, and `smart_detect_types` attributes and the fire-once-per-type-per-event behavior, plus a smart-detection example automation.

It also adds a note clarifying that the public detection events report _which_ type was detected, but the UniFi Protect public API does not currently expose the richer recognized metadata (recognized license plate text, vehicle color and type, or detection confidence). For the recognized license plate and vehicle attributes, the dedicated Vehicle detection event remains the source.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#174948
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #
