### PR TITLE
Add tesla_fleet.time_of_use action documentation

### DIFF
--- a/source/_integrations/tesla_fleet.markdown
+++ b/source/_integrations/tesla_fleet.markdown
@@ -305,20 +305,14 @@ These are the entities available in the Tesla Fleet integration. Not all entitie
 
 ## Actions
 
-The Tesla Fleet integration provides the following custom {% term actions %}.
+### Action: Time of use
 
-### Time of use
+The `tesla_fleet.time_of_use` action pushes a time-of-use tariff schedule to a Tesla energy site (Powerwall), wrapping the Tesla Fleet API `time_of_use_settings` endpoint. The Tesla application must have been granted the **Energy Product Settings** scope, otherwise the action fails with an error.
 
-`tesla_fleet.time_of_use`
-
-Pushes a time-of-use tariff schedule to a Tesla energy site (Powerwall), wrapping the Tesla Fleet API `time_of_use_settings` endpoint. The config entry must have been granted the energy commands scope during setup, otherwise the {% term action %} fails with an error.
-
-| Field        | Description                 | Example                                                                                                          |
-| ------------ | --------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| device_id    | The energy site's device ID | 0d462c0c4c0b064b1a91cdbd1ffcbd31                                                                                 |
-| tou_settings | Time of use settings        | See [Tesla Fleet API documentation](https://developer.tesla.com/docs/fleet-api#time_of_use_settings) for details |
-
-The `tou_settings` value is the `tariff_content_v2` object from Tesla's Fleet API. If you wrap it in an outer `tariff_content_v2` key, that wrapper is stripped automatically.
+| Data attribute | Required | Description                                                                                                                                                                                                                          |
+| -------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `device_id`    | yes      | The energy site's device ID.                                                                                                                                                                                                        |
+| `tou_settings` | yes      | The `tariff_content_v2` tariff object, as described in the [Tesla Fleet API documentation](https://developer.tesla.com/docs/fleet-api#time_of_use_settings). An outer `tariff_content_v2` key, if present, is stripped automatically. |
 
 ## Vehicle sleep
 

--- a/source/_integrations/tesla_fleet.markdown
+++ b/source/_integrations/tesla_fleet.markdown
@@ -307,12 +307,129 @@ These are the entities available in the Tesla Fleet integration. Not all entitie
 
 ### Action: Time of use
 
-The `tesla_fleet.time_of_use` action pushes a time-of-use tariff schedule to a Tesla energy site (Powerwall), wrapping the Tesla Fleet API `time_of_use_settings` endpoint. The Tesla application must have been granted the **Energy Product Settings** scope, otherwise the action fails with an error.
+The `tesla_fleet.time_of_use` {% term action %} configures the time-of-use tariff on a Tesla energy site (Powerwall), so the battery knows when energy is cheap or expensive and can charge and discharge accordingly. The Tesla application must have been granted the **Energy Product Settings** scope, otherwise the action fails with an error.
 
-| Data attribute | Required | Description                                                                                                                                                                                                                          |
-| -------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `device_id`    | yes      | The energy site's device ID.                                                                                                                                                                                                        |
-| `tou_settings` | yes      | The `tariff_content_v2` tariff object, as described in the [Tesla Fleet API documentation](https://developer.tesla.com/docs/fleet-api#time_of_use_settings). An outer `tariff_content_v2` key, if present, is stripped automatically. |
+| Data attribute | Required | Description |
+| -------------- | -------- | ----------- |
+| `device_id` | yes | The energy site to apply the tariff to. |
+| `name` | yes | Name of the tariff, for example `Agile Octopus`. |
+| `utility` | yes | Name of the energy supplier, for example `Octopus Energy`. |
+| `currency` | yes | Three-letter currency code for the rates, for example `GBP`. |
+| `daily_charge` | no | Fixed standing charge applied each day, in the selected currency. |
+| `seasons` | yes | The seasons that make up the tariff. |
+
+#### Seasons
+
+A tariff is made up of one or more seasons. A single season with no dates applies all year, which is the common case. If you use more than one season, every season needs all four date fields.
+
+| Data attribute | Required | Description |
+| -------------- | -------- | ----------- |
+| `name` | yes | Name of the season, for example `Summer`. `ALL` is reserved by Tesla and cannot be used. |
+| `start_month` | no | Month the season starts, between `1` and `12`. |
+| `start_day` | no | Day of the start month the season begins on. |
+| `end_month` | no | Month the season ends, between `1` and `12`. |
+| `end_day` | no | Day of the end month the season runs until. |
+| `periods` | yes | The rate periods in this season. |
+
+A season may wrap the end of the year, for example October to March.
+
+#### Periods
+
+| Data attribute | Required | Description |
+| -------------- | -------- | ----------- |
+| `name` | yes | Name of the rate period, for example `On peak`. |
+| `days` | no | Days of the week the period applies to. Leave empty for every day. |
+| `start_time` | no | Time the period starts. |
+| `end_time` | no | Time the period ends. |
+| `buy_rate` | yes | Import price per kWh. Negative prices are supported. |
+| `sell_rate` | no | Export price per kWh. Negative prices are supported. |
+
+`start_time` and `end_time` must be given together. Leave both out for a period that runs from midnight to midnight.
+
+If you set `sell_rate` on any period, you must set it on every period. Export rates use the same time boundaries as import rates.
+
+You can reuse a period name within a season to describe a period that is split across the day, such as an off-peak rate that runs overnight and again in the afternoon. Every occurrence of the same name must use the same rates.
+
+{% note %}
+Period names are converted into Tesla time-of-use labels, so `Off peak` becomes `OFF_PEAK`. Any name works, but the Tesla mobile app only displays the labels `ON_PEAK`, `OFF_PEAK`, `PARTIAL_PEAK` and `SUPER_OFF_PEAK`.
+{% endnote %}
+
+#### Examples
+
+A day and night tariff with a standing charge:
+
+```yaml
+action: tesla_fleet.time_of_use
+data:
+  device_id: 1a2b3c4d5e6f
+  name: Economy 7
+  utility: Example Energy
+  currency: GBP
+  daily_charge: 0.6
+  seasons:
+    - name: All year
+      periods:
+        - name: Off peak
+          start_time: "00:30:00"
+          end_time: "07:30:00"
+          buy_rate: 0.09
+        - name: On peak
+          start_time: "07:30:00"
+          end_time: "00:30:00"
+          buy_rate: 0.27
+```
+
+A seasonal tariff with export rates, where the peak rate only applies on weekdays:
+
+```yaml
+action: tesla_fleet.time_of_use
+data:
+  device_id: 1a2b3c4d5e6f
+  name: Seasonal saver
+  utility: Example Energy
+  currency: GBP
+  seasons:
+    - name: Summer
+      start_month: 4
+      start_day: 1
+      end_month: 9
+      end_day: 30
+      periods:
+        - name: On peak
+          days:
+            - monday
+            - tuesday
+            - wednesday
+            - thursday
+            - friday
+          start_time: "16:00:00"
+          end_time: "19:00:00"
+          buy_rate: 0.30
+          sell_rate: 0.15
+        - name: Off peak
+          buy_rate: 0.18
+          sell_rate: 0.08
+    - name: Winter
+      start_month: 10
+      start_day: 1
+      end_month: 3
+      end_day: 31
+      periods:
+        - name: On peak
+          days:
+            - monday
+            - tuesday
+            - wednesday
+            - thursday
+            - friday
+          start_time: "16:00:00"
+          end_time: "19:00:00"
+          buy_rate: 0.42
+          sell_rate: 0.15
+        - name: Off peak
+          buy_rate: 0.21
+          sell_rate: 0.08
+```
 
 ## Vehicle sleep
 

--- a/source/_integrations/tesla_fleet.markdown
+++ b/source/_integrations/tesla_fleet.markdown
@@ -348,6 +348,8 @@ A season may wrap the end of the year, for example October to March.
 
 If you set `sell_rate` on any period, you must set it on every period. Export rates use the same time boundaries as import rates.
 
+Periods within a season must not overlap, and seasons must not cover the same dates. A period that runs past midnight continues into the following day.
+
 You can reuse a period name within a season to describe a period that is split across the day, such as an off-peak rate that runs overnight and again in the afternoon. Every occurrence of the same name must use the same rates.
 
 {% note %}
@@ -379,7 +381,7 @@ data:
           buy_rate: 0.27
 ```
 
-A seasonal tariff with export rates, where the peak rate only applies on weekdays:
+A seasonal tariff with export rates, where the peak rate only applies on weekday evenings. The off-peak name is reused to cover the rest of the week, which is allowed as long as the rates match:
 
 ```yaml
 action: tesla_fleet.time_of_use
@@ -407,6 +409,31 @@ data:
           buy_rate: 0.30
           sell_rate: 0.15
         - name: Off peak
+          days:
+            - monday
+            - tuesday
+            - wednesday
+            - thursday
+            - friday
+          start_time: "00:00:00"
+          end_time: "16:00:00"
+          buy_rate: 0.18
+          sell_rate: 0.08
+        - name: Off peak
+          days:
+            - monday
+            - tuesday
+            - wednesday
+            - thursday
+            - friday
+          start_time: "19:00:00"
+          end_time: "00:00:00"
+          buy_rate: 0.18
+          sell_rate: 0.08
+        - name: Off peak
+          days:
+            - saturday
+            - sunday
           buy_rate: 0.18
           sell_rate: 0.08
     - name: Winter
@@ -427,6 +454,31 @@ data:
           buy_rate: 0.42
           sell_rate: 0.15
         - name: Off peak
+          days:
+            - monday
+            - tuesday
+            - wednesday
+            - thursday
+            - friday
+          start_time: "00:00:00"
+          end_time: "16:00:00"
+          buy_rate: 0.21
+          sell_rate: 0.08
+        - name: Off peak
+          days:
+            - monday
+            - tuesday
+            - wednesday
+            - thursday
+            - friday
+          start_time: "19:00:00"
+          end_time: "00:00:00"
+          buy_rate: 0.21
+          sell_rate: 0.08
+        - name: Off peak
+          days:
+            - saturday
+            - sunday
           buy_rate: 0.21
           sell_rate: 0.08
 ```

--- a/source/_integrations/tesla_fleet.markdown
+++ b/source/_integrations/tesla_fleet.markdown
@@ -303,6 +303,23 @@ These are the entities available in the Tesla Fleet integration. Not all entitie
 | Sensor | State       | Yes     |
 | Sensor | Vehicle     | Yes     |
 
+## Actions
+
+The Tesla Fleet integration provides the following custom {% term actions %}.
+
+### Time of use
+
+`tesla_fleet.time_of_use`
+
+Pushes a time-of-use tariff schedule to a Tesla energy site (Powerwall), wrapping the Tesla Fleet API `time_of_use_settings` endpoint. The config entry must have been granted the energy commands scope during setup, otherwise the {% term action %} fails with an error.
+
+| Field        | Description                 | Example                                                                                                          |
+| ------------ | --------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| device_id    | The energy site's device ID | 0d462c0c4c0b064b1a91cdbd1ffcbd31                                                                                 |
+| tou_settings | Time of use settings        | See [Tesla Fleet API documentation](https://developer.tesla.com/docs/fleet-api#time_of_use_settings) for details |
+
+The `tou_settings` value is the `tariff_content_v2` object from Tesla's Fleet API. If you wrap it in an outer `tariff_content_v2` key, that wrapper is stripped automatically.
+
 ## Vehicle sleep
 
 Constant API {% term polling %} will prevent most Model S and Model X vehicles manufactured before 2021 from sleeping. The {% term integration %} automatically stops {% term polling %} these vehicles for 15 minutes after inactivity. You can call the `homeassistant.update_entity` {% term action %} to force {% term polling %}, which will reset the timer.


### PR DESCRIPTION
## Proposed change

Documents the `tesla_fleet.time_of_use` action added in home-assistant/core#173827. Adds an **Actions** section to the Tesla Fleet integration page describing the action, its fields, the seasons and periods structures, and the **Energy Product Settings** scope requirement.

Updated following review on the parent PR: the action no longer takes Tesla's raw `tariff_content_v2` object. It asks for the tariff in Home Assistant's own terms — name, utility, currency, an optional daily standing charge, and a list of seasons each holding rate periods — and builds the Tesla payload internally, so automations do not depend on Tesla's key names.

Includes two worked examples: a day/night tariff with a standing charge, and a seasonal tariff with export rates and weekday-only peak periods.

Points reviewers may want to check:

- A single season with no dates applies all year; multiple seasons each need all four date fields and may wrap the end of the year.
- `ALL` is reserved by Tesla and is rejected as a season name.
- A period name may be reused within a season to describe a split period, in which case every occurrence must carry the same rates.
- Period names become Tesla time-of-use labels, but the Tesla mobile app only renders `ON_PEAK`, `OFF_PEAK`, `PARTIAL_PEAK` and `SUPER_OFF_PEAK`.

This is the documentation counterpart that flips the integration's `docs-actions` quality-scale rule off `todo`.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#173827
