### PR TITLE
Update `linksys_smart` integration docs

### DIFF
--- a/source/_integrations/linksys_smart.markdown
+++ b/source/_integrations/linksys_smart.markdown
@@ -6,7 +6,7 @@ ha_category:
 ha_iot_class: Local Polling
 ha_release: 0.48
 ha_codeowners:
-  - "@jmalcic"
+  - '@jmalcic'
 ha_domain: linksys_smart
 ha_config_flow: true
 ha_ssdp: true
@@ -20,7 +20,7 @@ The **Linksys Smart Wi-Fi** {% term integration %} tracks devices connected to a
 
 ## Prerequisites
 
-For certain devices, before adding this integration, you may need to disable the "Access via wireless" option in the **Local Management Access** section of your router's administration page. If this option is not disabled, the integration may not authenticate correctly because the router expects only a password, but the integration sends both a username and a password. Not all devices require this option to be disabled.
+For certain devices, before adding this integration, you may need to disable the **Access via wireless** option in the **Local Management Access** section of your router's administration page. If this option is not disabled, the integration may not authenticate correctly because the router expects only a password, but the integration sends both a username and a password. Not all devices require this option to be disabled.
 
 ## Supported devices
 
@@ -64,7 +64,7 @@ The integration polls your Linksys router every 30 seconds for the list of conne
 
 ### Cannot connect to the router
 
-Make sure Home Assistant can reach your router on the network. Try opening `http://<your-router-ip>` in a browser from the same network segment as Home Assistant.
+Make sure Home Assistant can reach your router on the network. Try opening your router's admin page (for example, `http://192.168.1.1`) in a browser from the same network segment as Home Assistant.
 
 ### Invalid credentials
 
@@ -72,7 +72,7 @@ If Home Assistant reports an authentication error, verify your router admin pass
 
 ### Authentication fails even with the correct password
 
-If the integration cannot authenticate even after entering the correct password, check that the "Access via wireless" option is disabled in the **Local Management Access** section of your router's administration page. See [Prerequisites](#prerequisites) for details.
+If the integration cannot authenticate even after entering the correct password, check that the **Access via wireless** option is disabled in the **Local Management Access** section of your router's administration page. See [Prerequisites](#prerequisites) for details.
 
 ## Removing the integration
 

--- a/source/_integrations/linksys_smart.markdown
+++ b/source/_integrations/linksys_smart.markdown
@@ -9,11 +9,9 @@ ha_codeowners:
   - "@jmalcic"
 ha_domain: linksys_smart
 ha_config_flow: true
-ha_ssdp: true
 ha_platforms:
   - device_tracker
 ha_integration_type: hub
-ha_quality_scale: bronze
 ---
 
 The **Linksys Smart Wi-Fi** {% term integration %} tracks devices connected to a Linksys Smart Wi-Fi router, so you can use device presence in your automations and dashboards.
@@ -68,7 +66,7 @@ Make sure Home Assistant can reach your router on the network. Try opening `http
 
 ### Invalid credentials
 
-If Home Assistant reports an authentication error, verify your router admin password in the router's administration page. If you recently changed your router password, go to {% my integrations title="**Settings** > **Devices & services**" %}, select the Linksys Smart Wi-Fi integration, and select **Re-authenticate** to update the credentials.
+If Home Assistant reports an authentication error, verify your router admin password in the router's administration page. If your credentials have changed, remove the integration and add it again with the updated password.
 
 ### Authentication fails even with the correct password
 

--- a/source/_integrations/linksys_smart.markdown
+++ b/source/_integrations/linksys_smart.markdown
@@ -5,46 +5,75 @@ ha_category:
   - Presence detection
 ha_iot_class: Local Polling
 ha_release: 0.48
+ha_codeowners:
+  - "@jmalcic"
 ha_domain: linksys_smart
+ha_config_flow: true
+ha_ssdp: true
 ha_platforms:
   - device_tracker
-ha_integration_type: integration
-related:
-  - docs: /docs/configuration/
-    title: Configuration file
-ha_quality_scale: legacy
+ha_integration_type: hub
+ha_quality_scale: bronze
 ---
 
-The **Linksys Smart Wi-Fi** {% term integration %} offers presence detection by looking at connected devices to a Linksys Smart Wi-Fi based router.
+The **Linksys Smart Wi-Fi** {% term integration %} tracks devices connected to a Linksys Smart Wi-Fi router, so you can use device presence in your automations and dashboards.
 
-Tested routers:
+## Prerequisites
+
+For certain devices, before adding this integration, you may need to disable the "Access via wireless" option in the **Local Management Access** section of your router's administration page. If this option is not disabled, the integration may not authenticate correctly because the router expects only a password, but the integration sends both a username and a password. Not all devices require this option to be disabled.
+
+## Supported devices
+
+The following routers are known to work with this integration:
 
 - Linksys WRT3200ACM MU-MIMO Gigabit Wi-Fi Wireless Router
 - Linksys WRT1900ACS Dual-band Wi-Fi Router
 - Linksys EA6900 AC1900 Dual-Band Wi-Fi Router
 - Linksys EA8300 Max-Stream AC2200 Tri-Band Wi-Fi Router
-
-## Setup
-
-For this {% term integration %} to work correctly, it is necessary to disable the "Access via wireless" feature in the Local Management Access section of the router administration page. If "Access via wireless" is not disabled, a connectivity conflict arises because the Home Assistant integration is trying to pass userid and password, but the router is only expecting a password.
+- Linksys Velop MX4200
 
 ## Configuration
 
-To use a Linksys Smart Wi-Fi Router in your Home Assistant installation, add the following to your {% term "`configuration.yaml`" %} file.
-{% include integrations/restart_ha_after_config_inclusion.md %}
+{% include integrations/config_flow.md %}
 
-```yaml
-# Example configuration.yaml entry
-device_tracker:
-  - platform: linksys_smart
-    host: 192.168.1.1
-```
+{% configuration_basic %}
+Host:
+  description: "The hostname or IP address of your Linksys router, for example `192.168.1.1`. If your router was discovered automatically, this is pre-filled."
+Username:
+  description: "The admin username for your Linksys router. This field is optional on many router models where it defaults to `admin`."
+Password:
+  description: "The admin password for your Linksys router."
+{% endconfiguration_basic %}
 
-{% configuration %}
-host:
-  description: The hostname or IP address of your router, e.g., `192.168.1.1`.
-  required: true
-  type: string
-{% endconfiguration %}
+## Supported functionality
 
-See the [device tracker integration page](/integrations/device_tracker/) for instructions how to configure the people to be tracked.
+### Device tracker entities
+
+The integration creates a {% term "device tracker" %} {% term entity %} for each device that has been seen connected to your router. Each entity reflects whether the device is currently connected and provides the following attributes:
+
+- **IP address**: The current IP address of the device
+- **Hostname**: The hostname of the device as reported by the router
+
+You can link these entities to people in Home Assistant to track presence at home. See the [device tracker integration page](/integrations/device_tracker/) for instructions.
+
+## Data updates
+
+The integration polls your Linksys router every 30 seconds for the list of connected devices.
+
+## Troubleshooting
+
+### Cannot connect to the router
+
+Make sure Home Assistant can reach your router on the network. Try opening `http://<your-router-ip>` in a browser from the same network segment as Home Assistant.
+
+### Invalid credentials
+
+If Home Assistant reports an authentication error, verify your router admin password in the router's administration page. If you recently changed your router password, go to {% my integrations title="**Settings** > **Devices & services**" %}, select the Linksys Smart Wi-Fi integration, and select **Re-authenticate** to update the credentials.
+
+### Authentication fails even with the correct password
+
+If the integration cannot authenticate even after entering the correct password, check that the "Access via wireless" option is disabled in the **Local Management Access** section of your router's administration page. See [Prerequisites](#prerequisites) for details.
+
+## Removing the integration
+
+{% include integrations/remove_device_service.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

This PR updates the  `linksys_smart` integration docs to reflect its migration in the parent PR: the integration is moving from legacy `DeviceScanner` to `ScannerEntity`, and in particular that means it's configured in the UI rather than via the legacy `configuration.yaml`. The migration is also a chance to fix an issue on newer router firmware where authentication is required, so a password now needs to be provided through the UI.

### Changes

- Updated integration metadata: added `ha_codeowners`, `ha_config_flow: true`, `ha_ssdp: true`, changed `ha_integration_type` from `integration` to `hub`, and upgraded `ha_quality_scale` from `legacy` to `bronze`
- Added Linksys Velop MX4200 to the list of supported devices
- Moved the setup note about "Access via wireless" to a new **Prerequisites** section, with softened language noting that not all devices require this change
- Replaced YAML-only configuration with a UI config flow setup (`{% include integrations/config_flow.md %}`) and a `{% configuration_basic %}` block documenting the Host, Username, and Password fields
- Added a **Supported functionality** section documenting the device tracker entities and their attributes (IP address, hostname)
- Added a **Data updates** section noting the 30-second polling interval
- Added a **Troubleshooting** section with three entries: cannot connect to router, invalid credentials, and authentication failing even with the correct password
- Added a **Removing the integration** section using the standard include snippet

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/175059
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
