### PR TITLE
Update Anova codeowners

### DIFF
--- a/source/_integrations/anova.markdown
+++ b/source/_integrations/anova.markdown
@@ -8,6 +8,7 @@ ha_config_flow: true
 ha_release: 2023.5
 ha_codeowners:
   - '@Lash-L'
+  - '@rhys-saldanha'
 ha_domain: anova
 ha_integration_type: hub
 ha_platforms:


### PR DESCRIPTION
Adds `@rhys-saldanha` as codeowner for the Anova integration, to match the update in home-assistant/core#175146.