### PR TITLE
Document GitHub activity timestamp sensors

### DIFF
--- a/source/_integrations/github.markdown
+++ b/source/_integrations/github.markdown
@@ -108,12 +108,12 @@ The following timestamp sensors are provided for each tracked repository and are
 `timestamp` device class, which makes it possible to filter or sort repositories by
 recency — for example, to show only repositories with a release or issue in the last week.
 
-- **Latest commit committed**: When the latest commit on the default branch was committed
+- **Latest commit date**: When the latest commit on the default branch was committed
 - **Latest discussion created** / **updated**: When the latest discussion was opened / last updated
 - **Latest issue created** / **updated**: When the latest issue was opened / last updated
 - **Latest pull request created** / **updated**: When the latest pull request was opened / last updated
-- **Latest release published**: When the latest release was published
-- **Latest tag committed**: When the commit behind the latest tag was committed (not provided for annotated tags)
+- **Latest release date**: When the latest release was published
+- **Latest tag date**: When the commit behind the latest tag was committed (not provided for annotated tags)
 
 To use one of these sensors, go to {% my entities title="**Settings** > **Devices & services** > **Entities**" %} and select the entity. Select the cogwheel {% icon "mdi:cog-outline" %} and [enable it](/common-tasks/general/#to-enable-or-disable-a-single-entity).
 

--- a/source/_integrations/github.markdown
+++ b/source/_integrations/github.markdown
@@ -115,7 +115,7 @@ recency — for example, to show only repositories with a release or issue in th
 - **Latest release published**: When the latest release was published
 - **Latest tag committed**: When the commit behind the latest tag was committed (not provided for annotated tags)
 
-To use one of these sensors, go to {% my entities title="**Settings** > **Devices & services** > **Entities**" %} and select the entity. Select the cogwheel {% icon "mdi:cog-outline" %} and [enable it](https://www.home-assistant.io/common-tasks/general/#to-enable-or-disable-a-single-entity).
+To use one of these sensors, go to {% my entities title="**Settings** > **Devices & services** > **Entities**" %} and select the entity. Select the cogwheel {% icon "mdi:cog-outline" %} and [enable it](/common-tasks/general/#to-enable-or-disable-a-single-entity).
 
 ### Diagnostic entities
 
@@ -138,7 +138,7 @@ In addition to the entities for each tracked repository, the integration provide
 - **Public gists**: Shows the number of public gists on your account
 - **Public repositories**: Shows the number of public repositories on your account
 
-To use one of these sensors, go to {% my entities title="**Settings** > **Devices & services** > **Entities**" %} and select the entity. Select the cogwheel {% icon "mdi:cog-outline" %} and [enable it](https://www.home-assistant.io/common-tasks/general/#to-enable-or-disable-a-single-entity).
+To use one of these sensors, go to {% my entities title="**Settings** > **Devices & services** > **Entities**" %} and select the entity. Select the cogwheel {% icon "mdi:cog-outline" %} and [enable it](/common-tasks/general/#to-enable-or-disable-a-single-entity).
 
 ## Automation
 

--- a/source/_integrations/github.markdown
+++ b/source/_integrations/github.markdown
@@ -101,6 +101,22 @@ The sensor provides additional attributes for the latest tag:
 
 - `url`: A URL that will show you the commit the tag was created for on GitHub
 
+### Activity timestamps
+
+The following timestamp sensors are provided for each tracked repository and are
+**disabled by default**. Each exposes the relevant GitHub date as its state with a
+`timestamp` device class, which makes it possible to filter or sort repositories by
+recency — for example, to show only repositories with a release or issue in the last week.
+
+- **Latest commit committed**: When the latest commit on the default branch was committed
+- **Latest discussion created** / **updated**: When the latest discussion was opened / last updated
+- **Latest issue created** / **updated**: When the latest issue was opened / last updated
+- **Latest pull request created** / **updated**: When the latest pull request was opened / last updated
+- **Latest release published**: When the latest release was published
+- **Latest tag committed**: When the commit behind the latest tag was committed (not provided for annotated tags)
+
+To use one of these sensors, go to {% my entities title="**Settings** > **Devices & services** > **Entities**" %} and select the entity. Select the cogwheel {% icon "mdi:cog-outline" %} and [enable it](https://www.home-assistant.io/common-tasks/general/#to-enable-or-disable-a-single-entity).
+
 ### Diagnostic entities
 
 These entities are simpler diagnostic entities without any additional attributes:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the new activity timestamp sensors added to the GitHub integration in
home-assistant/core#175221. Adds an "Activity timestamps" section under Provided
entities describing the nine new (disabled-by-default) timestamp sensors and that
they can be used to filter or sort repositories by recency.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#175221
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
