### PR TITLE
Document HomeKit climate accessory type option

### DIFF
--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -363,7 +363,7 @@ It is recommended to only edit a HomeKit instance in the UI that was created in 
 
 ### Climate accessory type
 
-Climate entities are exposed to HomeKit as one of two accessory types. Air conditioners and heat pumps, which offer two or more fan speeds or a swing mode that can be turned off, are listed as Heater Cooler accessories. This puts the mode, target temperature, heating and cooling thresholds, fan speed, and swing on one tile, matching how the device works. Everything else, such as a central thermostat, is exposed as a Thermostat accessory. A climate entity that controls a target humidity always stays a Thermostat, since the Heater Cooler accessory cannot control humidity.
+Climate entities are exposed to HomeKit as one of two accessory types. Air conditioners and heat pumps that offer two or more fan speeds or a swing mode that can be turned off are listed as Heater Cooler accessory type. This puts the mode, target temperature, heating and cooling thresholds, fan speed, and swing on one tile, matching how the device works. Everything else, such as a central thermostat, is exposed as a Thermostat accessory. A climate entity that controls a target humidity always stays a Thermostat, since the Heater Cooler accessory cannot control humidity.
 
 This choice is made automatically the first time an entity is added to HomeKit. Entities that were already exposed before this feature was introduced keep their Thermostat accessory, and you can switch them to the Heater Cooler accessory at any time.
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -365,7 +365,7 @@ It is recommended to only edit a HomeKit instance in the UI that was created in 
 
 Climate entities are exposed to HomeKit as one of two accessory types. Air conditioners and heat pumps, which expose two or more fan speeds or a swing mode, are exposed as a Heater Cooler accessory. This puts the mode, target temperature, thresholds, fan speed, and swing on one tile, matching how the device works. Everything else, such as a central thermostat, is exposed as a Thermostat accessory. A climate entity that controls a target humidity always stays a Thermostat, since the Heater Cooler accessory cannot control humidity.
 
-You do not need to configure anything for this to work. If you prefer a specific accessory type for an entity, set its `type` to `heater_cooler` or `thermostat` in the entity configuration:
+You do not need to configure anything for this to work. If you want full control and prefer a specific accessory type for an entity, set its `type` to `heater_cooler` or `thermostat` in the entity configuration:
 
 ```yaml
 # Example configuration.yaml entry
@@ -374,6 +374,8 @@ homekit:
     climate.living_room:
       type: heater_cooler
 ```
+
+The entity configuration is only available for HomeKit bridges set up in YAML. A bridge you created in the UI offers limited options, so to use this setting you need to move it to a YAML configuration.
 
 The accessory keeps its identifier, which is derived from the entity ID, so its room assignment and name are preserved when the accessory type changes. Any Home app scenes or automations that referenced the old controls may need to be recreated against the new tile.
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -375,7 +375,7 @@ homekit:
       type: heater_cooler
 ```
 
-Changing the accessory type for an entity you have already paired resets its configuration in the Home app, so any scenes, automations, or room assignments that referenced it need to be recreated.
+The accessory keeps its identifier, which is derived from the entity ID, so its room assignment and name are preserved when the accessory type changes. Any Home app scenes or automations that referenced the old controls may need to be recreated against the new tile.
 
 ### Accessory mode
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -363,7 +363,7 @@ It is recommended to only edit a HomeKit instance in the UI that was created in 
 
 ### Climate accessory type
 
-Climate entities are exposed to HomeKit as one of two accessory types. Air conditioners and heat pumps, which expose two or more fan speeds or a swing mode, are exposed as a Heater Cooler accessory. This puts the mode, target temperature, heating and cooling thresholds, fan speed, and swing on one tile, matching how the device works. Everything else, such as a central thermostat, is exposed as a Thermostat accessory. A climate entity that controls a target humidity always stays a Thermostat, since the Heater Cooler accessory cannot control humidity.
+Climate entities are exposed to HomeKit as one of two accessory types. Air conditioners and heat pumps, which expose two or more fan speeds or a swing mode that can be turned off, are exposed as a Heater Cooler accessory. This puts the mode, target temperature, heating and cooling thresholds, fan speed, and swing on one tile, matching how the device works. Everything else, such as a central thermostat, is exposed as a Thermostat accessory. A climate entity that controls a target humidity always stays a Thermostat, since the Heater Cooler accessory cannot control humidity.
 
 This choice is made automatically the first time an entity is added to HomeKit. Entities that were already exposed before this feature was introduced keep their Thermostat accessory, and you can switch them to the Heater Cooler accessory at any time.
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -365,7 +365,7 @@ It is recommended to only edit a HomeKit instance in the UI that was created in 
 
 Climate entities are exposed to HomeKit as one of two accessory types. Air conditioners and heat pumps, which expose two or more fan speeds or a swing mode, are exposed as a Heater Cooler accessory. This puts the mode, target temperature, heating and cooling thresholds, fan speed, and swing on one tile, matching how the device works. Everything else, such as a central thermostat, is exposed as a Thermostat accessory. A climate entity that controls a target humidity always stays a Thermostat, since the Heater Cooler accessory cannot control humidity.
 
-This choice is made automatically the first time an entity is added to HomeKit. Entities that were already exposed before this feature was introduced keep their Thermostat accessory, and a repair issue offers to switch eligible ones to the Heater Cooler accessory. You can accept the repair to switch, or dismiss it to keep the Thermostat.
+This choice is made automatically the first time an entity is added to HomeKit. Entities that were already exposed before this feature was introduced keep their Thermostat accessory, and you can switch them to the Heater Cooler accessory at any time.
 
 You can also pick the accessory type yourself at any time. For a bridge created in the UI, go to {% my integrations title="**Settings** > **Devices & services**" %}, select **Configure** on the HomeKit bridge, and choose **Thermostat** or **Heater Cooler** for each climate entity in the climate step. For a bridge set up in YAML, set the entity's `type` to `heater_cooler` or `thermostat` in `entity_config`:
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -222,7 +222,7 @@ homekit:
                   required: true
                   type: string
             type:
-              description: Only for `switch` and `fan` entities. Type of accessory to be created within HomeKit. Valid types for `switch` entities are `faucet`, `outlet`, `shower`, `sprinkler`, `switch` and `valve`. Valid types for `fan` entities are `fan` and `air_purifier`.
+              description: Only for `switch`, `fan`, and `climate` entities. Type of accessory to be created within HomeKit. Valid types for `switch` entities are `faucet`, `outlet`, `shower`, `sprinkler`, `switch` and `valve`. Valid types for `fan` entities are `fan` and `air_purifier`. Valid types for `climate` entities are `heater_cooler` and `thermostat`. For `climate` entities, the type is chosen automatically when you leave this unset.
               required: false
               type: string
               default: '`switch`'
@@ -360,6 +360,22 @@ The HomeKit Accessory Protocol Specification only allows a maximum of 150 unique
 If you create a HomeKit integration via the UI (for example, **Settings** > **Devices & services**), it must be configured via the UI **only**. While the UI currently offers limited configuration options, any attempt to configure a HomeKit instance created in the UI via the {% term "`configuration.yaml`" %} file will result in another instance of HomeKit running on a different port.
 
 It is recommended to only edit a HomeKit instance in the UI that was created in the UI, and likewise, only edit a HomeKit instance in YAML that was created in YAML.
+
+### Climate accessory type
+
+Climate entities are exposed to HomeKit as one of two accessory types. Air conditioners and heat pumps, which expose two or more fan speeds or a swing mode, are exposed as a Heater Cooler accessory. This puts the mode, target temperature, thresholds, fan speed, and swing on one tile, matching how the device works. Everything else, such as a central thermostat, is exposed as a Thermostat accessory. A climate entity that controls a target humidity always stays a Thermostat, since the Heater Cooler accessory cannot control humidity.
+
+You do not need to configure anything for this to work. If you prefer a specific accessory type for an entity, set its `type` to `heater_cooler` or `thermostat` in the entity configuration:
+
+```yaml
+# Example configuration.yaml entry
+homekit:
+  entity_config:
+    climate.living_room:
+      type: heater_cooler
+```
+
+Changing the accessory type for an entity you have already paired resets its configuration in the Home app, so any scenes, automations, or room assignments that referenced it need to be recreated.
 
 ### Accessory mode
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -365,7 +365,9 @@ It is recommended to only edit a HomeKit instance in the UI that was created in 
 
 Climate entities are exposed to HomeKit as one of two accessory types. Air conditioners and heat pumps, which expose two or more fan speeds or a swing mode, are exposed as a Heater Cooler accessory. This puts the mode, target temperature, heating and cooling thresholds, fan speed, and swing on one tile, matching how the device works. Everything else, such as a central thermostat, is exposed as a Thermostat accessory. A climate entity that controls a target humidity always stays a Thermostat, since the Heater Cooler accessory cannot control humidity.
 
-You do not need to configure anything for this to work. If you want full control and prefer a specific accessory type for an entity, set its `type` to `heater_cooler` or `thermostat` in the `entity_config` of your HomeKit YAML configuration:
+This choice is made automatically the first time an entity is added to HomeKit. Entities that were already exposed before this feature was introduced keep their Thermostat accessory, and a repair issue offers to switch eligible ones to the Heater Cooler accessory. You can accept the repair to switch, or dismiss it to keep the Thermostat.
+
+You can also pick the accessory type yourself at any time. For a bridge created in the UI, go to {% my integrations title="**Settings** > **Devices & services**" %}, select **Configure** on the HomeKit bridge, and choose **Thermostat** or **Heater Cooler** for each climate entity in the climate step. For a bridge set up in YAML, set the entity's `type` to `heater_cooler` or `thermostat` in `entity_config`:
 
 ```yaml
 # Example configuration.yaml entry
@@ -374,8 +376,6 @@ homekit:
     climate.living_room:
       type: heater_cooler
 ```
-
-The entity configuration is only available for HomeKit bridges set up in YAML. A bridge you created in the UI offers limited options, so to use this setting you need to move it to a YAML configuration.
 
 The accessory keeps its identifier, which is derived from the entity ID, so its room assignment and name are preserved when the accessory type changes. Any Home app scenes or automations that referenced the old controls may need to be recreated against the new tile.
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -225,7 +225,7 @@ homekit:
               description: Only for `switch`, `fan`, and `climate` entities. Type of accessory to be created within HomeKit. Valid types for `switch` entities are `faucet`, `outlet`, `shower`, `sprinkler`, `switch` and `valve`. Valid types for `fan` entities are `fan` and `air_purifier`. Valid types for `climate` entities are `heater_cooler` and `thermostat`. For `climate` entities, the type is chosen automatically when you leave this unset.
               required: false
               type: string
-              default: '`switch`'
+              default: "`switch` for `switch` entities, `fan` for `fan` entities, and chosen automatically for `climate` entities"
             stream_count:
               description: Only for `camera` entities. The number of simultaneous streams the camera can support.
               required: false
@@ -363,9 +363,9 @@ It is recommended to only edit a HomeKit instance in the UI that was created in 
 
 ### Climate accessory type
 
-Climate entities are exposed to HomeKit as one of two accessory types. Air conditioners and heat pumps, which expose two or more fan speeds or a swing mode, are exposed as a Heater Cooler accessory. This puts the mode, target temperature, thresholds, fan speed, and swing on one tile, matching how the device works. Everything else, such as a central thermostat, is exposed as a Thermostat accessory. A climate entity that controls a target humidity always stays a Thermostat, since the Heater Cooler accessory cannot control humidity.
+Climate entities are exposed to HomeKit as one of two accessory types. Air conditioners and heat pumps, which expose two or more fan speeds or a swing mode, are exposed as a Heater Cooler accessory. This puts the mode, target temperature, heating and cooling thresholds, fan speed, and swing on one tile, matching how the device works. Everything else, such as a central thermostat, is exposed as a Thermostat accessory. A climate entity that controls a target humidity always stays a Thermostat, since the Heater Cooler accessory cannot control humidity.
 
-You do not need to configure anything for this to work. If you want full control and prefer a specific accessory type for an entity, set its `type` to `heater_cooler` or `thermostat` in the entity configuration:
+You do not need to configure anything for this to work. If you want full control and prefer a specific accessory type for an entity, set its `type` to `heater_cooler` or `thermostat` in the `entity_config` of your HomeKit YAML configuration:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -363,7 +363,7 @@ It is recommended to only edit a HomeKit instance in the UI that was created in 
 
 ### Climate accessory type
 
-Climate entities are exposed to HomeKit as one of two accessory types. Air conditioners and heat pumps, which expose two or more fan speeds or a swing mode that can be turned off, are exposed as a Heater Cooler accessory. This puts the mode, target temperature, heating and cooling thresholds, fan speed, and swing on one tile, matching how the device works. Everything else, such as a central thermostat, is exposed as a Thermostat accessory. A climate entity that controls a target humidity always stays a Thermostat, since the Heater Cooler accessory cannot control humidity.
+Climate entities are exposed to HomeKit as one of two accessory types. Air conditioners and heat pumps, which offer two or more fan speeds or a swing mode that can be turned off, are listed as Heater Cooler accessories. This puts the mode, target temperature, heating and cooling thresholds, fan speed, and swing on one tile, matching how the device works. Everything else, such as a central thermostat, is exposed as a Thermostat accessory. A climate entity that controls a target humidity always stays a Thermostat, since the Heater Cooler accessory cannot control humidity.
 
 This choice is made automatically the first time an entity is added to HomeKit. Entities that were already exposed before this feature was introduced keep their Thermostat accessory, and you can switch them to the Heater Cooler accessory at any time.
 


### PR DESCRIPTION
## Proposed change

Documents the HomeKit bridge's native Heater Cooler accessory for climate entities and the new per-entity `type` override.

Climate entities added to HomeKit for the first time are exposed as a Heater Cooler accessory when they have two or more fan speeds or a swing mode that can be turned off, and as a Thermostat accessory otherwise; anything that controls a target humidity stays a Thermostat. Entities that were already exposed keep their Thermostat and can be switched at any time. The accessory type can be picked per entity in the bridge options for UI bridges, or with `type: heater_cooler` or `type: thermostat` in `entity_config` for YAML bridges.

Adds a "Climate accessory type" section under Considerations and extends the `type` configuration variable to cover climate entities.

Documentation for home-assistant/core#148231.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation standards.


