### PR TITLE
Ecovacs: migrate action to dedicated page

### DIFF
--- a/source/_actions/ecovacs.raw_get_positions.markdown
+++ b/source/_actions/ecovacs.raw_get_positions.markdown
@@ -39,13 +39,13 @@ This retrieves the raw position response for `vacuum.deebot_n8_plus`.
 
 ### Options in YAML
 
-This action has no additional options.
+This action has no additional YAML options beyond the target. Optionally, set `response_variable` to store the response.
 
 {% include actions/targets.md domain="vacuum" %}
 
 ## Response data
 
-The action returns a raw response with the position of the vacuum and charger. The exact response structure depends on the vacuum model and firmware.
+The action returns a raw response with the positions of the vacuum and charger. The exact response structure depends on the vacuum model and firmware.
 
 The response includes coordinates under `resp -> body -> data` like this:
 

--- a/source/_actions/ecovacs.raw_get_positions.markdown
+++ b/source/_actions/ecovacs.raw_get_positions.markdown
@@ -1,0 +1,89 @@
+---
+title: "Get raw positions"
+action: ecovacs.raw_get_positions
+domain: ecovacs
+description: "Retrieves a raw response containing the positions of the charger and the vacuum."
+---
+
+Use this action to retrieve the raw position response for an Ecovacs vacuum and its charger.
+
+{% include actions/ui_header.md %}
+
+To get raw positions from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Ecovacs vacuum.
+6. From the actions shown for that target, select **Get raw positions**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `ecovacs.raw_get_positions`. Store the result in a response variable so you can use it in later steps:
+
+{% example %}
+action: |
+  action: ecovacs.raw_get_positions
+  target:
+    entity_id: vacuum.deebot_n8_plus
+  response_variable: ecovacs_positions
+{% endexample %}
+
+This retrieves the raw position response for `vacuum.deebot_n8_plus`.
+
+### Options in YAML
+
+This action has no additional options.
+
+{% include actions/targets.md domain="vacuum" %}
+
+## Response data
+
+The action returns a raw response with the position of the vacuum and charger. The exact response structure depends on the vacuum model and firmware.
+
+The response includes coordinates under `resp -> body -> data` like this:
+
+```yaml
+vacuum.deebot_n8_plus:
+  ret: ok
+  resp:
+    header:
+      pri: 1
+      tzm: 480
+      ts: "1717748487712"
+      ver: 0.0.1
+      fwVer: 1.2.0
+      hwVer: 0.1.1
+    body:
+      code: 0
+      msg: ok
+      data:
+        deebotPos:
+          x: 1
+          y: 5
+          a: 85
+          invalid: 0
+        chargePos:
+          - x: 5
+            y: 9
+            a: 85
+            t: 1
+            invalid: 0
+        mid: "200465850"
+  id: 5o81
+  payloadType: j
+```
+
+## Good to know
+
+This action is mainly useful when you need the raw position data for troubleshooting or custom processing.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/ecovacs.markdown
+++ b/source/_integrations/ecovacs.markdown
@@ -146,53 +146,11 @@ Alternatively, you can use the `ecovacs_error` event to watch for errors. This e
 
 Finally, if a vacuum becomes unavailable (usually due to being idle and off its charger long enough for it to completely power off,) the vacuum's `status` attribute will change to `offline` until it is turned back on.
 
-### Getting device and chargers coordinates
+{% include integrations/actions.md %}
 
-The integration has a `raw_get_positions` action to retrieve device and chargers coordinates.
+### Getting device and charger coordinates
 
-Example:
-
-```yaml
-action: ecovacs.raw_get_positions
-target:
-  entity_id: vacuum.deebot_n8_plus
-```
-
-{% details "Action response example" %}
-The action returns a raw response with a list of coordinates available in `resp -> body -> data` like this:
-
-```yaml
-vacuum.deebot_n8_plus:
-  ret: ok
-  resp:
-    header:
-      pri: 1
-      tzm: 480
-      ts: "1717748487712"
-      ver: 0.0.1
-      fwVer: 1.2.0
-      hwVer: 0.1.1
-    body:
-      code: 0
-      msg: ok
-      data:
-        deebotPos:
-          x: 1
-          y: 5
-          a: 85
-          invalid: 0
-        chargePos:
-          - x: 5
-            y: 9
-            a: 85
-            t: 1
-            invalid: 0
-        mid: "200465850"
-  id: 5o81
-  payloadType: j
-```
-
-{% enddetails %}
+The [Get raw positions](/actions/ecovacs.raw_get_positions/) action retrieves device and charger coordinates.
 
 ## Self-hosted configuration
 

--- a/source/_integrations/ecovacs.markdown
+++ b/source/_integrations/ecovacs.markdown
@@ -148,13 +148,10 @@ Finally, if a vacuum becomes unavailable (usually due to being idle and off its 
 
 {% include integrations/actions.md %}
 
-### Getting device and charger coordinates
-
-The [Get raw positions](/actions/ecovacs.raw_get_positions/) action retrieves device and charger coordinates.
-
 ## Self-hosted configuration
 
 Depending on your setup of the self-hosted instance, you can connect to the server using the following settings:
+
 - `Username`: Enter the email address configured in your instance. If authentication is disabled, you can enter any valid email address.
 - `Password`: Enter the password configured in your instance. If authentication is disabled, you can enter any string (series of characters).
 - `REST URL`: http://`SELF_HOSTED_INSTANCE`:8007


### PR DESCRIPTION
## Proposed change
Moves Ecovacs raw position documentation to a dedicated action page.

Related epic: https://github.com/home-assistant/epics/issues/96

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue:
- Related epic: https://github.com/home-assistant/epics/issues/96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards