### PR TITLE
Add hint about Paravirtualization interface for VirtualBox setups

### DIFF
--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -332,6 +332,7 @@ To create the virtual machine, follow the instructions for the hypervisor you us
        - **Base Memory**: Set to at least **2048 MB**, which is 2 GB.
        - **Number of CPUs**: Set to at least **2**.
        - **Use EFI**: Select the checkbox to use UEFI instead of legacy BIOS. Home Assistant requires UEFI to boot.
+       - If you are using **VirtualBox 6** set **Paravirtualization Interface** to **None**.
     5. Select **Next**.
     6. In the **Summary** step, review the settings and select **Finish**.
 

--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -332,7 +332,7 @@ To create the virtual machine, follow the instructions for the hypervisor you us
        - **Base Memory**: Set to at least **2048 MB**, which is 2 GB.
        - **Number of CPUs**: Set to at least **2**.
        - **Use EFI**: Select the checkbox to use UEFI instead of legacy BIOS. Home Assistant requires UEFI to boot.
-       - If you are using **VirtualBox 6** set **Paravirtualization Interface** to **None**.
+       - **Paravirtualization Interface**: If you use VirtualBox 6 or earlier and you have issues with time-based triggers, set this to **Legacy** or **None** in **Settings** > **System** > **Acceleration**.
     5. Select **Next**.
     6. In the **Summary** step, review the settings and select **Finish**.
 


### PR DESCRIPTION
Adding setting Paravirtualization interface to None for Virtualbox 6 and below.


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Instruct users to turn off Paravirtualization interface in Virtualbox 6 and below to prevent time trigger issues.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

See: https://github.com/home-assistant/home-assistant.io/issues/26479

https://community.home-assistant.io/t/time-trigger-automatons-fail-to-trigger-timely/301643/3

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #26479 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
