### PR TITLE
Update Imou Open Platform documentation links

### DIFF
--- a/source/_integrations/imou.markdown
+++ b/source/_integrations/imou.markdown
@@ -17,7 +17,7 @@ ha_integration_type: hub
 ha_quality_scale: bronze
 ---
 
-The **Imou** {% term integration %} connects to the [Imou Open Platform](https://open.imoulife.com/) using your App ID and App secret. Devices linked to your platform account are discovered automatically. Channel devices expose **Live view SD** and **Live view HD** camera entities, and supported actions are exposed as button entities in Home Assistant.
+The **Imou** {% term integration %} connects to the [Imou Open Platform](https://open.imoulife.com?article_id=XsrQM4GMK7wP4t93) using your App ID and App secret. Devices linked to your platform account are discovered automatically. Channel devices expose **Live view SD** and **Live view HD** camera entities, and supported actions are exposed as button entities in Home Assistant.
 
 ## Supported devices
 
@@ -29,7 +29,7 @@ Add or remove devices in the Imou Open Platform or Imou app; new devices are pic
 
 Before using the Imou integration, create an Imou Open Platform application:
 
-1. Visit [Imou Open Platform](https://open.imoulife.com/).
+1. Visit [Imou Open Platform](https://open.imoulife.com?article_id=XsrQM4GMK7wP4t93).
 2. Register or log in to your Imou account, then open the **Control board**.
 3. Go to **App Information** to obtain an **App ID** and **App secret**.
 4. Add your Imou devices in the Imou Open Platform or Imou mobile app so they appear on your account.


### PR DESCRIPTION
## Proposed change

Update the Imou Open Platform homepage links in the integration introduction and prerequisites sections to the URL specified by Imou Open Platform (`article_id=XsrQM4GMK7wP4t93`). Other Imou documentation links (`/price`, `/book/...`) are unchanged.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - [x] I made a change to the existing documentation and used the `current` branch.
  - [ ] I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards