### PR TITLE
Whirlpool: document oven cook mode select

### DIFF
--- a/source/_integrations/whirlpool.markdown
+++ b/source/_integrations/whirlpool.markdown
@@ -97,7 +97,7 @@ The select platform provides the following entity for refrigerators:
 
 The select platform provides the following entity for ovens:
 
-- **Cook mode**: Sets the cook mode of an oven cavity, keeping the current target temperature. Selecting `Standby` turns the oven off by stopping the current cook. This replaces the deprecated oven cook mode sensor.
+- **Cook mode**: Sets the cook mode of an oven cavity, keeping the current target temperature. Selecting `Standby` turns the oven off by stopping the current cook.
 
 ### Sensor
 

--- a/source/_integrations/whirlpool.markdown
+++ b/source/_integrations/whirlpool.markdown
@@ -95,6 +95,10 @@ The select platform provides the following entity for refrigerators:
 
 - **Temperature level**: Sets the temperature level of the refrigerator. The available options are `-4 °C`, `-2 °C`, `0 °C`, `3 °C`, and `5 °C`.
 
+The select platform provides the following entity for ovens:
+
+- **Cook mode**: Sets the cook mode of an oven cavity, keeping the current target temperature. Selecting `Standby` turns the oven off by stopping the current cook. This replaces the deprecated oven cook mode sensor.
+
 ### Sensor
 
 The `whirlpool` sensor platform integrates Whirlpool Washer and Dryer systems into Home Assistant, allowing views of the machine state, time remaining, and the "wash & go" tank fill status as sensors for each device.


### PR DESCRIPTION
## Proposed change

Documents the new Whirlpool oven cook mode `select` entity added in home-assistant/core#173412 (one documentation PR per core PR, as requested there).

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/173412
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards