### PR TITLE
Add 'show_add_event' option to calendar card

### DIFF
--- a/source/_dashboards/calendar.markdown
+++ b/source/_dashboards/calendar.markdown
@@ -46,6 +46,10 @@ theme:
   required: false
   description: Override the used theme for this card with any loaded theme. For more information about themes, see the [frontend documentation](/integrations/frontend/).
   type: string
+show_addfab:
+  required: false
+  description: Show a button to create a new event. There has to be at least one mutable calendar.
+  type: boolean
 {% endconfiguration %}
 
 ### Examples

--- a/source/_dashboards/calendar.markdown
+++ b/source/_dashboards/calendar.markdown
@@ -57,7 +57,7 @@ add_event_style:
   type: string
 add_event_size:
   required: false
-  description: "The of the add event button. Options are `small`, `medium`, and `large`. Note that the size is ignored when the style is set to `header`."
+  description: "The size of the add event button. Options are `small`, `medium`, and `large`. Note that the size is ignored when the style is set to `header`."
   type: string
 {% endconfiguration %}
 

--- a/source/_dashboards/calendar.markdown
+++ b/source/_dashboards/calendar.markdown
@@ -55,10 +55,12 @@ add_event_style:
   required: false
   description: "The layout and position of the add event button within the card. Options are `header`, `below`, and `on_top`."
   type: string
+  default: below
 add_event_size:
   required: false
   description: "The size of the add event button. Options are `small`, `medium`, and `large`. Note that the size is ignored when the style is set to `header`."
   type: string
+  default: small
 {% endconfiguration %}
 
 ### Examples

--- a/source/_dashboards/calendar.markdown
+++ b/source/_dashboards/calendar.markdown
@@ -48,7 +48,7 @@ theme:
   type: string
 show_addfab:
   required: false
-  description: Show a button to create a new event. There has to be at least one mutable calendar.
+  description: Show a button to create a new event. You need at least one calendar that allows you to create events.
   type: boolean
 {% endconfiguration %}
 

--- a/source/_dashboards/calendar.markdown
+++ b/source/_dashboards/calendar.markdown
@@ -50,6 +50,7 @@ show_addfab:
   required: false
   description: Show a button to create a new event. You need at least one calendar that allows you to create events.
   type: boolean
+  default: false
 {% endconfiguration %}
 
 ### Examples

--- a/source/_dashboards/calendar.markdown
+++ b/source/_dashboards/calendar.markdown
@@ -46,11 +46,19 @@ theme:
   required: false
   description: Override the used theme for this card with any loaded theme. For more information about themes, see the [frontend documentation](/integrations/frontend/).
   type: string
-show_addfab:
+show_add_event:
   required: false
   description: Show a button to create a new event. You need at least one calendar that allows you to create events.
   type: boolean
   default: false
+add_event_style:
+  required: false
+  description: "The layout and position of the add event button within the card. Options are `header`, `below`, and `on_top`."
+  type: string
+add_event_size:
+  required: false
+  description: "The of the add event button. Options are `small`, `medium`, and `large`. Note that the size is ignored when the style is set to `header`."
+  type: string
 {% endconfiguration %}
 
 ### Examples


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
This PR adds a new configuration option to the Lovelace Calendar Card (hui-calendar-card), allowing users to toggle the visibility of the Add Event Floating Action Button (FAB).



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/53055
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
