### PR TITLE
Add estimated arrival sensor to Picnic

### DIFF
--- a/source/_integrations/picnic.markdown
+++ b/source/_integrations/picnic.markdown
@@ -40,7 +40,7 @@ This integration provides the following sensors. Some sensors are disabled by de
 | Last order total price         | The total price of the last order. |
 | Next delivery ETA start        | Start of the ETA window of the next delivery, will get more precise if the driver is underway. |
 | Next delivery ETA end          | End of the ETA window of the next delivery. |
-| Next delivery estimated arrival | Precise estimated arrival of the next delivery, based on the live position of the delivery vehicle. Only available shortly before the delivery, `unknown` otherwise. |
+| Estimated arrival of next delivery | Precise estimated arrival time of the next delivery, based on the live position of the delivery vehicle. Only available shortly before the delivery, `unknown` otherwise. |
 | Next delivery slot start       | Start of the next delivery's delivery slot. |
 | Next delivery slot end         | End of the next delivery's delivery slot. |
 

--- a/source/_integrations/picnic.markdown
+++ b/source/_integrations/picnic.markdown
@@ -40,6 +40,7 @@ This integration provides the following sensors. Some sensors are disabled by de
 | Last order total price         | The total price of the last order. |
 | Next delivery ETA start        | Start of the ETA window of the next delivery, will get more precise if the driver is underway. |
 | Next delivery ETA end          | End of the ETA window of the next delivery. |
+| Next delivery estimated arrival | Precise estimated arrival of the next delivery, based on the live position of the delivery vehicle. Only available shortly before the delivery, `unknown` otherwise. |
 | Next delivery slot start       | Start of the next delivery's delivery slot. |
 | Next delivery slot end         | End of the next delivery's delivery slot. |
 


### PR DESCRIPTION
## Proposed change

Documents the new **Next delivery estimated arrival** sensor for the Picnic integration: the precise position-based arrival estimate, only available shortly before the delivery (`unknown` otherwise). One row added to the existing Sensors table.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/176295

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][docs-standard].

[docs-standard]: https://developers.home-assistant.io/docs/documenting/standards
