### PR TITLE
Add ViCare troubleshooting for Client not registered

### DIFF
--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -152,9 +152,10 @@ When adding the integration, you get this error in the browser:
 
 The Client ID sent to Viessmann does not match a client in the developer portal. This usually happens after you have set up ViCare before: Home Assistant keeps your old Client ID as an application credential and reuses it automatically, even after you remove the integration. To enter a new Client ID, delete the stored one first:
 
-1. Go to **Settings** > **Devices & services** > **⋮** (top right) > **Application credentials**.
-2. Delete the **Viessmann ViCare** entry.
-3. Add the integration again and enter the **Client ID** from your current client in the [Viessmann developer portal](https://app.developer.viessmann-climatesolutions.com).
+1. Go to {% my integrations title="**Settings** > **Devices & services**" %}.
+2. In the top right corner, select the three dots {% icon "mdi:dots-vertical" %} menu and select **Application credentials**.
+3. Select the **Viessmann ViCare** credential, select the three dots {% icon "mdi:dots-vertical" %} menu and select **Delete**.
+4. Add the integration again and enter the **Client ID** from your current client in the [Viessmann developer portal](https://app.developer.viessmann-climatesolutions.com).
 
 ### GATEWAY_OFFLINE
 

--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -142,6 +142,20 @@ When adding or re-authenticating the integration, you get this error in the brow
 
 Set the **Redirect URIs** on your API client in the [Viessmann developer portal](https://app.developer.viessmann-climatesolutions.com) to exactly `https://my.home-assistant.io/redirect/oauth`, save (it may take up to an hour to become active), and try again.
 
+### Client not registered
+
+When adding the integration, you get this error in the browser:
+
+```text
+{"error":"invalid_request", "error_description":"Client not registered."}
+```
+
+The Client ID sent to Viessmann does not match a client in the developer portal. This usually happens after you have set up ViCare before: Home Assistant keeps your old Client ID as an application credential and reuses it automatically, even after you remove the integration. To enter a new Client ID, delete the stored one first:
+
+1. Go to **Settings** > **Devices & services** > **⋮** (top right) > **Application credentials**.
+2. Delete the **Viessmann ViCare** entry.
+3. Add the integration again and enter the **Client ID** from your current client in the [Viessmann developer portal](https://app.developer.viessmann-climatesolutions.com).
+
 ### GATEWAY_OFFLINE
 
 The ViCare API tends to lose contact with the gateway from time to time. This will be logged in Home Assistant with:

--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -155,7 +155,7 @@ The Client ID sent to Viessmann does not match a client in the developer portal.
 1. Go to {% my integrations title="**Settings** > **Devices & services**" %}.
 2. In the top right corner, select the three dots {% icon "mdi:dots-vertical" %} menu and select **Application credentials**.
 3. Select the **Viessmann ViCare** credential, select the three dots {% icon "mdi:dots-vertical" %} menu and select **Delete**.
-4. Add the integration again and enter the **Client ID** from your current client in the [Viessmann developer portal](https://app.developer.viessmann-climatesolutions.com).
+4. Add the integration again. Setup now prompts for the application credentials again; enter the **Client ID** from your current client in the [Viessmann developer portal](https://app.developer.viessmann-climatesolutions.com).
 
 ### GATEWAY_OFFLINE
 


### PR DESCRIPTION
## Proposed change

Add a troubleshooting entry for the `Client not registered` error when re-adding ViCare. Home Assistant stores the Client ID as an application credential and reuses it automatically, even after the integration is removed, so an outdated Client ID keeps being sent to Viessmann and setup fails before the credential prompt. The entry explains how to delete the stored credential and enter the current Client ID.

Follow-up to #46563; addresses the case reported in #46562 (comment).

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: related to #46562

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
