### PR TITLE
Document Teslemetry local Powerwall control

### DIFF
--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -61,12 +61,12 @@ By default, Teslemetry sends energy site commands through the cloud. If your ene
 
 ### Setting up local control
 
-Each Powerwall-capable energy site adds a **Set up local control** subentry to the Teslemetry {% term integration %}. Sites with only a wall connector or solar panels don't get this subentry, because local control only applies to Powerwall systems.
+Each Powerwall-capable energy site gets its own local control subentry, set up through its **Reconfigure** action. Sites with only a wall connector or solar panels don't get this subentry, because local control only applies to Powerwall systems.
 
 To pair your Powerwall or Backup Gateway:
 
 1. Go to {% my integrations title="**Settings** > **Devices & services**" %} and select the **Teslemetry** integration.
-2. On the energy site you want to pair, select **Set up local control**.
+2. On the energy site you want to pair, select the cogwheel {% icon "mdi:cog-outline" %}, and then select **Reconfigure**.
 3. Home Assistant registers an access key with your Energy Site. If the key hasn't been approved yet, flick the On/Off switch on your primary Powerwall off and back on to approve it, then continue in Home Assistant. You only need to do this once.
 4. Home Assistant automatically discovers and fills in your Powerwall system's local network address. Confirm the address, or edit it if needed, and enter its Wi-Fi password. Only the last 5 characters are needed - find them on the QR label behind the front cover of your Powerwall 3, or behind the Backup Gateway door on Powerwall 2.
 

--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -57,23 +57,23 @@ By default, Teslemetry sends energy site commands through the cloud. If your ene
 
 ### Requirements
 
-- A Powerwall 2 and gateway or Powerwall 3 that's reachable on your local network.
+- A Powerwall 2 or Powerwall 3 that's reachable on your local network.
 
 ### Setting up local control
 
-Each Powerwall-capable energy site adds a **Set up local control** subentry to the Teslemetry {% term integration %}. Sites with only a wall connector or solar panels don't get this subentry, because local control only applies to Powerwall gateways.
+Each Powerwall-capable energy site adds a **Set up local control** subentry to the Teslemetry {% term integration %}. Sites with only a wall connector or solar panels don't get this subentry, because local control only applies to Powerwall systems.
 
-To pair your Powerwall gateway:
+To pair your Powerwall or Backup Gateway:
 
 1. Go to {% my integrations title="**Settings** > **Devices & services**" %} and select the **Teslemetry** integration.
 2. On the energy site you want to pair, select **Set up local control**.
-3. Home Assistant registers an access key with your Energy Site. If the key hasn't been approved yet, flick the switch on the side of your primary Powerwall off and back on to approve it, then continue in Home Assistant. You only need to do this once.
-4. Enter the local network address of your Powerwall/gateway (if required) and its Wi-Fi password. Only the last 5 characters of the password printed on the inside of your Powerwall/gateway are needed.
+3. Home Assistant registers an access key with your Energy Site. If the key hasn't been approved yet, flick the On/Off switch on your primary Powerwall off and back on to approve it, then continue in Home Assistant. You only need to do this once.
+4. Home Assistant automatically discovers and fills in your Powerwall system's local network address. Confirm the address, or edit it if needed, and enter its Wi-Fi password. Only the last 5 characters are needed - find them on the QR label behind the front cover of your Powerwall 3, or behind the Backup Gateway door on Powerwall 2.
 
-Once paired, Home Assistant stores the gateway's address and password on the subentry and sends energy commands to it directly, falling back to the cloud automatically whenever the gateway can't be reached.
+Once paired, Home Assistant stores your Powerwall's address and password on the subentry and sends energy commands to it directly, falling back to the cloud automatically whenever your Powerwall can't be reached.
 
 {% note %}
-Removing the Teslemetry integration doesn't revoke the access key from your Powerwall gateway, so other apps or integrations using the same key keep working.
+Removing the Teslemetry integration doesn't revoke the access key from your Powerwall system, so other apps or integrations using the same key keep working.
 {% endnote %}
 
 ## Entities

--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -51,6 +51,31 @@ Vehicles delivered in 2024 and later will require a [virtual key](https://teslem
 
 {% include integrations/config_flow.md %}
 
+## Local Powerwall control
+
+By default, Teslemetry sends energy site commands through the cloud. If your energy site includes a Powerwall gateway, you can also pair Home Assistant with the gateway so it can send commands to it directly over your local network. Local commands are faster, and Home Assistant automatically falls back to the cloud any time the local connection isn't available, so your existing cloud-based energy entities keep working either way.
+
+### Requirements
+
+- A Powerwall gateway that's reachable on your local network.
+
+### Setting up local control
+
+Each Powerwall-capable energy site adds a **Set up local control** subentry to the Teslemetry {% term integration %}. Sites with only a wall connector or solar panels don't get this subentry, because local control only applies to Powerwall gateways.
+
+To pair your Powerwall gateway:
+
+1. Go to {% my integrations title="**Settings** > **Devices & services**" %} and select the **Teslemetry** integration.
+2. On the energy site you want to pair, select **Set up local control**.
+3. Home Assistant registers an access key with your Powerwall gateway. If the key hasn't been approved yet, flick the switch on the side of your primary Powerwall off and back on to approve it, then continue in Home Assistant. You only need to do this once.
+4. Enter the local network address of your Powerwall gateway and its Wi-Fi password. Only the last 5 characters of the password printed on the gateway are needed.
+
+Once paired, Home Assistant stores the gateway's address and password on the subentry and sends energy commands to it directly, falling back to the cloud automatically whenever the gateway can't be reached.
+
+{% note %}
+Removing the Teslemetry integration doesn't revoke the access key from your Powerwall gateway, so other apps or integrations using the same key keep working.
+{% endnote %}
+
 ## Entities
 
 These are the entities available in the Teslemetry integration. Not all entities are enabled by default, and not all values are always available.

--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -66,7 +66,7 @@ Each Powerwall-capable energy site gets its own local control subentry, set up t
 To pair your Powerwall or Backup Gateway:
 
 1. Go to {% my integrations title="**Settings** > **Devices & services**" %} and select the **Teslemetry** integration.
-2. On the energy site you want to pair, select the **Reconfigure** button (the cogwheel {% icon "mdi:cog-outline" %}).
+2. On the energy site you want to pair, select its **Reconfigure** button {% icon "mdi:cog-outline" %}.
 3. Home Assistant registers an access key with your Energy Site. If the key hasn't been approved yet, flick the On/Off switch on your primary Powerwall off and back on to approve it, then continue in Home Assistant. You only need to do this once.
 4. Home Assistant automatically discovers and fills in your Powerwall system's local network address. Confirm the address, or edit it if needed, and enter its Wi-Fi password. Only the last 5 characters are needed - find them on the QR label behind the front cover of your Powerwall 3, or behind the Backup Gateway door on Powerwall 2.
 

--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -61,12 +61,12 @@ By default, Teslemetry sends energy site commands through the cloud. If your ene
 
 ### Setting up local control
 
-Each Powerwall-capable energy site gets its own local control subentry, set up through its **Reconfigure** action. Sites with only a wall connector or solar panels don't get this subentry, because local control only applies to Powerwall systems.
+Each Powerwall-capable energy site gets its own local control subentry, set up through its **Reconfigure** button. Sites with only a wall connector or solar panels don't get this subentry, because local control only applies to Powerwall systems.
 
 To pair your Powerwall or Backup Gateway:
 
 1. Go to {% my integrations title="**Settings** > **Devices & services**" %} and select the **Teslemetry** integration.
-2. On the energy site you want to pair, select the cogwheel {% icon "mdi:cog-outline" %}, and then select **Reconfigure**.
+2. On the energy site you want to pair, select the **Reconfigure** button (the cogwheel {% icon "mdi:cog-outline" %}).
 3. Home Assistant registers an access key with your Energy Site. If the key hasn't been approved yet, flick the On/Off switch on your primary Powerwall off and back on to approve it, then continue in Home Assistant. You only need to do this once.
 4. Home Assistant automatically discovers and fills in your Powerwall system's local network address. Confirm the address, or edit it if needed, and enter its Wi-Fi password. Only the last 5 characters are needed - find them on the QR label behind the front cover of your Powerwall 3, or behind the Backup Gateway door on Powerwall 2.
 

--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -53,11 +53,11 @@ Vehicles delivered in 2024 and later will require a [virtual key](https://teslem
 
 ## Local Powerwall control
 
-By default, Teslemetry sends energy site commands through the cloud. If your energy site includes a Powerwall gateway, you can also pair Home Assistant with the gateway so it can send commands to it directly over your local network. Local commands are faster, and Home Assistant automatically falls back to the cloud any time the local connection isn't available, so your existing cloud-based energy entities keep working either way.
+By default, Teslemetry sends energy site commands through the cloud. If your energy site includes a Powerwall 2 or Powerwall 3, you can also pair Home Assistant so it can send commands to it directly over your local network. Local commands are faster, and Home Assistant automatically falls back to the cloud any time the local connection isn't available, so your existing cloud-based energy entities keep working either way.
 
 ### Requirements
 
-- A Powerwall gateway that's reachable on your local network.
+- A Powerwall 2 and gateway or Powerwall 3 that's reachable on your local network.
 
 ### Setting up local control
 
@@ -67,8 +67,8 @@ To pair your Powerwall gateway:
 
 1. Go to {% my integrations title="**Settings** > **Devices & services**" %} and select the **Teslemetry** integration.
 2. On the energy site you want to pair, select **Set up local control**.
-3. Home Assistant registers an access key with your Powerwall gateway. If the key hasn't been approved yet, flick the switch on the side of your primary Powerwall off and back on to approve it, then continue in Home Assistant. You only need to do this once.
-4. Enter the local network address of your Powerwall gateway and its Wi-Fi password. Only the last 5 characters of the password printed on the gateway are needed.
+3. Home Assistant registers an access key with your Energy Site. If the key hasn't been approved yet, flick the switch on the side of your primary Powerwall off and back on to approve it, then continue in Home Assistant. You only need to do this once.
+4. Enter the local network address of your Powerwall/gateway (if required) and its Wi-Fi password. Only the last 5 characters of the password printed on the inside of your Powerwall/gateway are needed.
 
 Once paired, Home Assistant stores the gateway's address and password on the subentry and sends energy commands to it directly, falling back to the cloud automatically whenever the gateway can't be reached.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the new local (LAN) Powerwall control option added in home-assistant/core#176328. A Powerwall 2 or Powerwall 3 site can be paired so Home Assistant sends its energy commands over the local network, which is faster and keeps working while the cloud is unreachable, with automatic fallback to the cloud.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/176328
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
