### PR TITLE
Correct Flux color temperature accepted range to 40000 K

### DIFF
--- a/source/_integrations/flux.markdown
+++ b/source/_integrations/flux.markdown
@@ -23,7 +23,7 @@ During the day (in between `start_time` and `sunset_time`), it will fade the lig
 
 The value of `sunset_time` is automatically calculated based on the location specified in your [Home Assistant configuration](/docs/configuration/basic).
 
-The color temperature is specified in kelvin, and accepted values are between 1000 and 4000 kelvin. Lower values will seem more red, while higher will look more white.
+The color temperature is specified in kelvin, and accepted values are between 1000 and 40000 kelvin. Lower values will seem more red, while higher will look more white.
 
 If you want to update at variable intervals, you can leave the switch turned off and use automation rules that use the `switch.<name>_update` action whenever you want the lights updated, where `<name>` equals the `name:` property in the switch configuration.
 


### PR DESCRIPTION
## Proposed change

The Flux integration docs state that the accepted color temperature range is "between 1000 and 4000 kelvin", but the code validates all three color-temperature options (`start_colortemp`, `sunset_colortemp`, `stop_colortemp`) with `vol.Range(min=1000, max=40000)` in [`homeassistant/components/flux/switch.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/flux/switch.py). A user following the docs would wrongly believe a value like 6500 K is out of range.

This updates the documented upper bound to 40000 K to match the code. (The `4000` values elsewhere on the page are the *default* `start_colortemp`/`stop_colortemp`, which are unaffected.)

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- Documentation only; corrects the stated accepted range to match `vol.Range(min=1000, max=40000)` in the integration code.

## Checklist

- [x] This change is fixing an incorrectly documented value (verified against the integration code).

Disclosure: this fix was prepared with AI assistance (Claude) and verified by me against the integration source.
