### PR TITLE
KNX date, datetime, time, number, text, select state restoration

### DIFF
--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -1274,9 +1274,7 @@ device_class:
 The KNX date platform allows you to send date values to the KNX bus and update its state from received telegrams. It can optionally respond to read requests from the KNX bus.
 
 {% note %}
-Date entities without a `state_address` will restore their last known state after Home Assistant was restarted.
-
-Dates that have a `state_address` configured request their current state from the KNX bus.
+Date entities restore their last known state after Home Assistant is restarted. Dates that have a `state_address` configured request their current state from the KNX bus according to their state updater configuration. Until the bus responds or the state is restored, the state is unknown if no previous state exists.
 {% endnote %}
 
 {% note %}
@@ -1339,9 +1337,7 @@ sync_state:
 The KNX datetime platform allows you to send datetime values to the KNX bus and update its state from received telegrams. It can optionally respond to read requests from the KNX bus.
 
 {% note %}
-Date entities without a `state_address` will restore their last known state after Home Assistant was restarted.
-
-DateTimes that have a `state_address` configured request their current state from the KNX bus.
+DateTime entities restore their last known state after Home Assistant is restarted. DateTimes that have a `state_address` configured request their current state from the KNX bus according to their state updater configuration. Until the bus responds or the state is restored, the state is unknown if no previous state exists.
 {% endnote %}
 
 {% note %}
@@ -1727,9 +1723,7 @@ data:
 The KNX number platform allows you to send generic numeric values to the KNX bus and update its state from received telegrams. It can optionally respond to read requests from the KNX bus.
 
 {% note %}
-Number entities without a `state_address` will restore their last known state after Home Assistant was restarted.
-
-Numbers that have a `state_address` configured request their current state from the KNX bus.
+Number entities restore their last known state after Home Assistant is restarted. Numbers that have a `state_address` configured request their current state from the KNX bus.
 {% endnote %}
 
 Number entities can be created from the frontend in the KNX panel or via YAML.
@@ -1843,9 +1837,7 @@ scene_number:
 The KNX select platform allows the user to define a list of values that can be selected via the frontend and can be used within conditions of automation. When a user selects a new item, the assigned generic raw payload is sent to the KNX bus. A received telegram updates the state of the select entity. It can optionally respond to read requests from the KNX bus.
 
 {% note %}
-Select entities without a `state_address` will restore their last known state after Home Assistant was restarted.
-
-Selects that have a `state_address` configured request their current state from the KNX bus.
+Select entities restore their last known state after Home Assistant is restarted. Selects that have a `state_address` configured request their current state from the KNX bus according to their state updater configuration. Until the bus responds or the state is restored, the state is unknown if no previous state exists.
 {% endnote %}
 
 ```yaml
@@ -2087,9 +2079,7 @@ The optional `state_address` can be used to inform Home Assistant about state ch
 The KNX text platform allows you to send text values to the KNX bus and update its state from received telegrams. It can optionally respond to read requests from the KNX bus.
 
 {% note %}
-Text entities without a `state_address` will restore their last known state after Home Assistant was restarted.
-
-Texts that have a `state_address` configured request their current state from the KNX bus.
+Text entities restore their last known state after Home Assistant is restarted. Texts that have a `state_address` configured request their current state from the KNX bus.
 {% endnote %}
 
 Text entities can be created from the frontend in the KNX panel or via YAML.
@@ -2146,9 +2136,7 @@ mode:
 The KNX time platform allows you to send time values to the KNX bus and update its state from received telegrams. It can optionally respond to read requests from the KNX bus.
 
 {% note %}
-Time entities without a `state_address` will restore their last known state after Home Assistant was restarted.
-
-Times that have a `state_address` configured request their current state from the KNX bus.
+Time entities restore their last known state after Home Assistant is restarted. Times that have a `state_address` configured request their current state from the KNX bus according to their state updater configuration. Until the bus responds or the state is restored, the state is unknown if no previous state exists.
 {% endnote %}
 
 {% note %}

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -1273,9 +1273,7 @@ device_class:
 
 The KNX date platform allows you to send date values to the KNX bus and update its state from received telegrams. It can optionally respond to read requests from the KNX bus.
 
-{% note %}
-Date entities restore their last known state after Home Assistant is restarted. Dates that have a `state_address` configured request their current state from the KNX bus according to their state updater configuration. Until the bus responds or the state is restored, the state is unknown if no previous state exists.
-{% endnote %}
+Date entities restore their last known state after Home Assistant is restarted. Dates that have a `state_address` configured request their current state from the KNX bus according to their state updater configuration.
 
 {% note %}
 DPT 11.001 covers the range 1990 to 2089. Year values outside of this range are not allowed.
@@ -1336,9 +1334,7 @@ sync_state:
 
 The KNX datetime platform allows you to send datetime values to the KNX bus and update its state from received telegrams. It can optionally respond to read requests from the KNX bus.
 
-{% note %}
-DateTime entities restore their last known state after Home Assistant is restarted. DateTimes that have a `state_address` configured request their current state from the KNX bus according to their state updater configuration. Until the bus responds or the state is restored, the state is unknown if no previous state exists.
-{% endnote %}
+DateTime entities restore their last known state after Home Assistant is restarted. DateTimes that have a `state_address` configured request their current state from the KNX bus according to their state updater configuration.
 
 {% note %}
 System timezone is used as DPT 19.001 doesn't provide timezone information.
@@ -1722,9 +1718,7 @@ data:
 
 The KNX number platform allows you to send generic numeric values to the KNX bus and update its state from received telegrams. It can optionally respond to read requests from the KNX bus.
 
-{% note %}
 Number entities restore their last known state after Home Assistant is restarted. Numbers that have a `state_address` configured request their current state from the KNX bus.
-{% endnote %}
 
 Number entities can be created from the frontend in the KNX panel or via YAML.
 
@@ -1836,9 +1830,7 @@ scene_number:
 
 The KNX select platform allows the user to define a list of values that can be selected via the frontend and can be used within conditions of automation. When a user selects a new item, the assigned generic raw payload is sent to the KNX bus. A received telegram updates the state of the select entity. It can optionally respond to read requests from the KNX bus.
 
-{% note %}
-Select entities restore their last known state after Home Assistant is restarted. Selects that have a `state_address` configured request their current state from the KNX bus according to their state updater configuration. Until the bus responds or the state is restored, the state is unknown if no previous state exists.
-{% endnote %}
+Select entities restore their last known state after Home Assistant is restarted. Selects that have a `state_address` configured request their current state from the KNX bus according to their state updater configuration.
 
 ```yaml
 # Example configuration.yaml entry
@@ -2078,9 +2070,7 @@ The optional `state_address` can be used to inform Home Assistant about state ch
 
 The KNX text platform allows you to send text values to the KNX bus and update its state from received telegrams. It can optionally respond to read requests from the KNX bus.
 
-{% note %}
 Text entities restore their last known state after Home Assistant is restarted. Texts that have a `state_address` configured request their current state from the KNX bus.
-{% endnote %}
 
 Text entities can be created from the frontend in the KNX panel or via YAML.
 
@@ -2135,9 +2125,7 @@ mode:
 
 The KNX time platform allows you to send time values to the KNX bus and update its state from received telegrams. It can optionally respond to read requests from the KNX bus.
 
-{% note %}
-Time entities restore their last known state after Home Assistant is restarted. Times that have a `state_address` configured request their current state from the KNX bus according to their state updater configuration. Until the bus responds or the state is restored, the state is unknown if no previous state exists.
-{% endnote %}
+Time entities restore their last known state after Home Assistant is restarted. Times that have a `state_address` configured request their current state from the KNX bus according to their state updater configuration.
 
 {% note %}
 The `day` field of the time telegram will always be set to 0 (`no day`).


### PR DESCRIPTION
## Proposed change

Follow-up to #46822 (KNX switch state restoration), documenting home-assistant/core#176413.

That core PR extends the same unconditional state-restoration pattern already applied to the KNX `switch` platform to six more KNX platforms: `date`, `datetime`, `time`, `number`, `text`, and `select`. Previously these platforms only restored their last known state when no `state_address` was configured. Now they restore it unconditionally, bridging the gap between startup and the first bus read response so entities no longer briefly show `unknown` (or, in the case of `number`, an uninitialized value) after a restart when a `state_address` is set.

This PR updates the relevant notes in `source/_integrations/knx.markdown` for these platforms to match the wording already used for `switch`, and fixes a pre-existing copy/paste issue in the `datetime` section that referred to "Date entities" instead of "DateTime entities".

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/176413
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards