### PR TITLE
Correct System Monitor network sensor units (MiB and MB/s)

### DIFF
--- a/source/_integrations/systemmonitor.markdown
+++ b/source/_integrations/systemmonitor.markdown
@@ -44,12 +44,12 @@ One sensor per discovered network interface will be created
 
 - **IPv4 address**: The IPv4 address assigned to the network interface
 - **IPv6 address**: The IPv6 address assigned to the network interface
-- **Network in**: Total bytes received on the network interface
-- **Network out**: Total bytes sent from the network interface
+- **Network in**: Total data received on the network interface (MiB)
+- **Network out**: Total data sent from the network interface (MiB)
 - **Packets in**: Number of packets received on the network interface
 - **Packets out**: Number of packets sent from the network interface
-- **Network throughput in**: Current inbound network speed (bytes per second)
-- **Network throughput out**: Current outbound network speed (bytes per second)
+- **Network throughput in**: Current inbound network speed (MB/s)
+- **Network throughput out**: Current outbound network speed (MB/s)
 
 ### Pressure Stall Information (PSI)
 


### PR DESCRIPTION
## Proposed change

The **Network** section of the System Monitor integration page described the network data sensors in bytes, but the integration reports them in different units:

- **Network in** / **Network out** use `UnitOfInformation.MEBIBYTES` (MiB); the value function returns `round(counter / 1024**2, 1)`.
- **Network throughput in** / **out** use `UnitOfDataRate.MEGABYTES_PER_SECOND` (MB/s); the throughput function returns `(counter - value) / 1000**2 / seconds`.

The previous "bytes" and "bytes per second" wording was off by roughly six orders of magnitude, so a threshold, template, or alert written against the documented units would be wrong. This updates the four affected bullets to state the actual units (MiB and MB/s), which also match what the sensors show in the UI. The Packets bullets are counts and are unchanged.

Source of truth in core (`homeassistant/components/systemmonitor/sensor.py`): the `network_in`/`network_out` descriptions set `native_unit_of_measurement=UnitOfInformation.MEBIBYTES`, and `throughput_network_in`/`throughput_network_out` set `native_unit_of_measurement=UnitOfDataRate.MEGABYTES_PER_SECOND`.

## Type of change

- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Checklist

- [x] This PR uses the correct branch (`current`), for a change to existing documentation.
- [x] The documentation follows the Home Assistant documentation standards.
