### PR TITLE
Update Mozilla TLS recommendations links to docs.tlsref.org

### DIFF
--- a/source/_integrations/imap.markdown
+++ b/source/_integrations/imap.markdown
@@ -72,7 +72,7 @@ Another way to process the `text` data, is to use the `imap.fetch` action. In th
 ### Selecting an alternate SSL cipher list or disabling SSL verification
 
 If the default IMAP server settings do not work, you might try to set an alternate SSL cipher list.
-The SSL cipher list option allows you to select the list of SSL ciphers to be accepted from this endpoint: `default` (_system default_), `modern` or `intermediate` (_inspired by [Mozilla Security/Server Side TLS](https://wiki.mozilla.org/Security/Server_Side_TLS)_).
+The SSL cipher list option allows you to select the list of SSL ciphers to be accepted from this endpoint: `default` (_system default_), `modern` or `intermediate` (_inspired by [Mozilla Security/Server Side TLS](https://docs.tlsref.org/server-side-tls.html)_).
 
 If you are using self signed certificates, you can turn off SSL verification.
 

--- a/source/_integrations/rest.markdown
+++ b/source/_integrations/rest.markdown
@@ -137,7 +137,7 @@ verify_ssl:
   type: boolean
   default: true
 ssl_cipher_list:
-  description: The list of SSL ciphers to be accepted from this endpoint. `python_default` (_default_), `modern` or `intermediate` (_inspired by [Mozilla Security/Server Side TLS](https://wiki.mozilla.org/Security/Server_Side_TLS)_).
+  description: The list of SSL ciphers to be accepted from this endpoint. `python_default` (_default_), `modern` or `intermediate` (_inspired by [Mozilla Security/Server Side TLS](https://docs.tlsref.org/server-side-tls.html)_).
   required: false
   type: string
   default: default


### PR DESCRIPTION
## Proposed change

The `rest` and `imap` docs still point at the outdated Mozilla wiki URL for server-side TLS recommendations (`https://wiki.mozilla.org/Security/Server_Side_TLS`).

This updates those links to the current guidelines site used by Home Assistant Core: https://docs.tlsref.org/server-side-tls.html

Related core PR: https://github.com/home-assistant/core/pull/176230

Note: the `http` docs on `next` already no longer include that URL.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in an existing page (`current` branch).
- [x] This change is related to an upcoming version of Home Assistant and will go into the upcoming release notes (`next` branch).

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/176230
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the [following](https://developers.home-assistant.io/docs/documenting/docs-backend-style#opening-a-pull-request) considerations:
  - I made a change that is related to an upcoming version of Home Assistant and will go into the upcoming release notes.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards