### PR TITLE
Document Crave portable speaker support for vizio

### DIFF
--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -12,8 +12,10 @@ ha_codeowners:
 ha_domain: vizio
 ha_zeroconf: true
 ha_platforms:
+  - binary_sensor
   - media_player
   - remote
+  - sensor
 ha_integration_type: device
 ---
 
@@ -186,6 +188,17 @@ data:
 ```
 
 {% include integrations/actions.md %}
+
+### Crave portable speakers
+
+Battery-powered VIZIO Crave portable speakers (Crave Go, Crave 360, and Crave Pro) are supported as speakers. When a speaker is set up, the integration automatically detects whether it is a Crave model — no extra configuration is needed. Speakers that were set up before this detection existed are re-checked the next time the integration loads.
+
+Crave speakers additionally provide two diagnostic entities:
+
+- **Battery**: the current battery level as a percentage.
+- **Charging**: on while the battery is charging. A fully charged speaker is no longer drawing charge and reports off, so use the battery level to tell when it is full.
+
+Both show as `unknown` while the speaker is turned off.
 
 ## VIZIO SmartCast automation examples
 


### PR DESCRIPTION
## Proposed change

Documents the new VIZIO Crave portable speaker support added in home-assistant/core#176567: automatic Crave model detection for speaker entries and the two new diagnostic sensors (battery level and charging status). Adds `sensor` to the integration's platforms list.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/176567
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][docs-standard].

[docs-standard]: https://developers.home-assistant.io/docs/documenting/standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)
