### PR TITLE
Document the vizio.send_text action

### DIFF
--- a/source/_actions/vizio.send_text.markdown
+++ b/source/_actions/vizio.send_text.markdown
@@ -1,0 +1,57 @@
+---
+title: "Send text"
+action: vizio.send_text
+domain: vizio
+description: "Types text into the on-screen field that currently has focus on a VIZIO SmartCast device."
+---
+
+The **Send text** action types text into whatever on-screen field currently has focus on your VIZIO SmartCast device — for example, an app's search box or a sign-in form. Characters are sent with the same keyboard encoding the official SmartCast app uses, so they arrive in order as regular keystrokes.
+
+Only ASCII characters are supported. This is also the most reliable way to enter digits (for example, PINs or channel numbers), because the remote's numeric key codes are not digit keys on SmartCast devices.
+
+{% include actions/ui_header.md %}
+
+To send text from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **VIZIO SmartCast: Send text**.
+6. Select the media player entity of your device as the target, and enter the **Text** to type.
+7. Select **Save**.
+
+This action targets the media player entity of your VIZIO SmartCast device.
+
+### Options in the UI
+
+{% options_ui %}
+Text:
+  description: The text to type. Only ASCII characters are supported.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `vizio.send_text`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: vizio.send_text
+  target:
+    entity_id: media_player.vizio_smartcast
+  data:
+    text: "stranger things"
+{% endexample %}
+
+This types "stranger things" into the search field that is open on the TV.
+
+### Options in YAML
+
+{% options_yaml %}
+text:
+  description: >
+    The text to type. Only ASCII characters are supported.
+  required: true
+  type: string
+{% endoptions_yaml %}

--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -215,6 +215,17 @@ pyvizio --ip=0 get-apps-list
 
 {% include integrations/actions.md %}
 
+### Action vizio.send_text
+
+Types text into the on-screen field that currently has focus on the device — for example, an app's search box or a sign-in form.
+
+| Data attribute | Optional | Description                                             |
+| -------------- | -------- | ------------------------------------------------------- |
+| `entity_id`    | no       | The media player entity to type on.                     |
+| `text`         | no       | The text to type. Only ASCII characters are supported.  |
+
+This is also the most reliable way to enter digits (for example, PINs or channel numbers), because the remote's numeric key codes are not digit keys on SmartCast devices.
+
 ## Remote
 
 The VIZIO SmartCast integration automatically creates a remote entity for each configured device (TVs and speakers). You can use it to send remote control commands via the `remote.send_command` action. Commands are case-insensitive. You can use either the native key name (for example, `vol_up`) or a human-friendly alias (for example, `volume_up`).

--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -215,17 +215,6 @@ pyvizio --ip=0 get-apps-list
 
 {% include integrations/actions.md %}
 
-### Action vizio.send_text
-
-Types text into the on-screen field that currently has focus on the device — for example, an app's search box or a sign-in form.
-
-| Data attribute | Optional | Description                                             |
-| -------------- | -------- | ------------------------------------------------------- |
-| `entity_id`    | no       | The media player entity to type on.                     |
-| `text`         | no       | The text to type. Only ASCII characters are supported.  |
-
-This is also the most reliable way to enter digits (for example, PINs or channel numbers), because the remote's numeric key codes are not digit keys on SmartCast devices.
-
 ## Remote
 
 The VIZIO SmartCast integration automatically creates a remote entity for each configured device (TVs and speakers). You can use it to send remote control commands via the `remote.send_command` action. Commands are case-insensitive. You can use either the native key name (for example, `vol_up`) or a human-friendly alias (for example, `volume_up`).


### PR DESCRIPTION
## Proposed change

Documents the new `vizio.send_text` action added in home-assistant/core#176563: typing ASCII text into the focused on-screen field on a SmartCast device, including the note that this is the reliable way to enter digits.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/176563
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][docs-standard].

[docs-standard]: https://developers.home-assistant.io/docs/documenting/standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)