### PR TITLE
Update denon_rs232.markdown with tuner controls

### DIFF
--- a/source/_integrations/denon_rs232.markdown
+++ b/source/_integrations/denon_rs232.markdown
@@ -36,6 +36,7 @@ For supported receivers, you can use Home Assistant to:
 - Change the volume
 - Mute and unmute the main zone
 - Select the input source
+- Select a tuner preset or FM frequency
 
 ### Zones
 
@@ -50,3 +51,29 @@ The available zones depend on your receiver model.
 ### Source selection
 
 The available input sources depend on the receiver model you select during setup.
+
+### Selecting tuner presets and frequencies
+
+On the main zone, you can tune the receiver to a stored tuner preset or directly to
+an FM frequency. This works from the media browser, which lists the tuner presets, or
+by calling the `media_player.play_media` action with a `media_content_type` of `channel`.
+
+The `media_content_id` can be a preset name from `A1` through `G8`:
+```yaml
+action: media_player.play_media
+target:
+  entity_id: media_player.denon_avr
+data:
+  media_content_type: channel
+  media_content_id: "A1"
+```
+
+It can also be tuned to an FM frequency between `8750` (87.50 MHz) and `10800` (108.0 MHz):
+```yaml
+action: media_player.play_media
+target:
+  entity_id: media_player.denon_avr
+data:
+  media_content_type: channel
+  media_content_id: "9870"
+```

--- a/source/_integrations/denon_rs232.markdown
+++ b/source/_integrations/denon_rs232.markdown
@@ -54,9 +54,7 @@ The available input sources depend on the receiver model you select during setup
 
 ### Selecting tuner presets and frequencies
 
-On the main zone, you can tune the receiver to a stored tuner preset or directly to
-an FM frequency. This works from the media browser, which lists the tuner presets, or
-by calling the `media_player.play_media` action with a `media_content_type` of `channel`.
+On the main zone, you can tune the receiver to a stored tuner preset or directly to an FM frequency. This works from the media browser, which lists the tuner presets, or by calling the `media_player.play_media` action with a `media_content_type` of `channel`.
 
 The `media_content_id` can be a preset name from `A1` through `G8`:
 ```yaml

--- a/source/_integrations/denon_rs232.markdown
+++ b/source/_integrations/denon_rs232.markdown
@@ -66,7 +66,7 @@ data:
   media_content_id: "A1"
 ```
 
-It can also be tuned to an FM frequency between `8750` (87.50 MHz) and `10800` (108.0 MHz):
+It can also be tuned to an FM frequency between `8750` (87.50 MHz) and `10800` (108.00 MHz):
 ```yaml
 action: media_player.play_media
 target:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
A pending PR for the integration ([#176610](https://github.com/home-assistant/core/pull/176610)) adds tuner controls. This adds a new section explaining setting the tuner to a particular preset or frequency.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: [#176610](https://github.com/home-assistant/core/pull/176610)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
