### PR TITLE
Update victron_gx update intervals for the auto update frequency profile

### DIFF
--- a/source/_integrations/victron_gx.markdown
+++ b/source/_integrations/victron_gx.markdown
@@ -91,7 +91,7 @@ On success, the integration reloads automatically.
 
 ## Data updates
 
-Entities are updated only when new values are received from the device, but no more frequently than every 30 seconds.
+Entities are updated only when new values are received from the device. Power and current entities are updated at most every 5 seconds; all other entities at most every 30 seconds.
 
 ## Supported functionality
 
@@ -174,7 +174,7 @@ Configurable time-of-day settings, such as:
 
 ## Known limitations
 
-- The integration receives updates through MQTT push, but limits entity updates to at most once every 30 seconds. This means rapidly changing values may appear with a short delay.
+- The integration receives updates through MQTT push, but limits entity updates: power and current values are updated at most once every 5 seconds, all other values at most once every 30 seconds. This means rapidly changing values may appear with a short delay.
 
 ## Examples
 


### PR DESCRIPTION
## Proposed change

The `victron_gx` integration is switching from a fixed 30-second update throttle to the `victron-mqtt` library's `"auto"` update-frequency profile (home-assistant/core#176633): power and current entities are now updated at most every 5 seconds, while all other entities keep the 30-second cadence.

This updates the two places in the integration page that state a flat 30-second limit — the **Data updates** section and the **Known limitations** section — to describe the new per-metric-type intervals.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#176633
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
