### PR TITLE
Add port change warning for mobile apps

### DIFF
--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -30,7 +30,9 @@ Server port:
   description: |
     The port Home Assistant listens on. The default is `8123`.
 
-    Caution: If you use a [mobile app](https://companion.home-assistant.io/), after changing the Home Assistant port, you must also change it in your app's settings.
+    _Caution_: If you use the
+    [Home Assistant Companion app](https://companion.home-assistant.io/), update the Home Assistant URL
+    in the app after changing this port.
   required: true
 Listen addresses:
   description: The IP addresses Home Assistant binds to. Leave this empty to listen on all interfaces.

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -27,7 +27,10 @@ To change how Home Assistant serves its web interface, go to {% my network title
 
 {% options_ui %}
 Server port:
-  description: The port Home Assistant listens on. The default is `8123`.
+  description: |
+    The port Home Assistant listens on. The default is `8123`.
+
+    Caution: If you use a [mobile app](https://companion.home-assistant.io/), after changing the Home Assistant port, you must also change it in your app's settings.
   required: true
 Listen addresses:
   description: The IP addresses Home Assistant binds to. Leave this empty to listen on all interfaces.


### PR DESCRIPTION
## Proposed change

Inform users of the consequences of changing the HA port.

Follow-up for https://github.com/home-assistant/home-assistant.io/pull/46764#discussion_r3571621603

Related to https://github.com/home-assistant/home-assistant.io/issues/46761

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
