### PR TITLE
Add mise-en-place config file for Ruby version

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[settings]
+idiomatic_version_file_enable_tools = ["ruby"]


### PR DESCRIPTION
## Proposed change

Adds config file for [mise-en-place](https://mise.jdx.dev/), a modern version manager, to point it to the Ruby version defined in `.ruby-version`, so it doesn't introduce a mainteinance burden.

This can be used when [building the docs site manually](https://developers.home-assistant.io/docs/documenting/#manual-environment).

Confirmed working on current Fedora.

Follow-up dev docs update: https://github.com/home-assistant/developers.home-assistant/pull/3258

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
