### PR TITLE
Add Xiaomi Smart Standing Fan 2 Pro (dmaker.fan.p33) to xiaomi_miio

### DIFF
--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -1145,7 +1145,7 @@ Clean mode and Motor speed can only be set when the device is turned on.
 | Child Lock | Turn on/off the Child Lock |
 | LED        | Turn on/off the LED        |
 
-### Tower Fan/Standing Fan 2/Standing Fan Pro (dmaker.fan.p9, dmaker.fan.p10, dmaker.fan.p11, dmaker.fan.p18, dmaker.fan.p33)
+### Tower Fan/Standing Fan 2/Standing Fan 2 Pro/Standing Fan Pro (dmaker.fan.p9, dmaker.fan.p10, dmaker.fan.p11, dmaker.fan.p18, dmaker.fan.p33)
 
 - Power (on, off)
 - Operation modes (Normal, Nature)

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -319,6 +319,7 @@ The list includes device name, model number (if available), and model.
 - **Standing Fan 2**: `dmaker.fan.p10`
 - **Standing Fan Pro**: `dmaker.fan.p11`
 - **Standing Fan 2**: `dmaker.fan.p18`
+- **Standing Fan 2 Pro**: `dmaker.fan.p33`
 - **Standing Fan 3**: `zhimi.fan.za5`
 
 - Power (on, off)
@@ -1144,7 +1145,7 @@ Clean mode and Motor speed can only be set when the device is turned on.
 | Child Lock | Turn on/off the Child Lock |
 | LED        | Turn on/off the LED        |
 
-### Tower Fan/Standing Fan 2/Standing Fan Pro (dmaker.fan.p9, dmaker.fan.p10, dmaker.fan.p11, dmaker.fan.p18)
+### Tower Fan/Standing Fan 2/Standing Fan Pro (dmaker.fan.p9, dmaker.fan.p10, dmaker.fan.p11, dmaker.fan.p18, dmaker.fan.p33)
 
 - Power (on, off)
 - Operation modes (Normal, Nature)

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -1145,7 +1145,15 @@ Clean mode and Motor speed can only be set when the device is turned on.
 | Child Lock | Turn on/off the Child Lock |
 | LED        | Turn on/off the LED        |
 
-### Tower Fan/Standing Fan 2/Standing Fan 2 Pro/Standing Fan Pro (dmaker.fan.p9, dmaker.fan.p10, dmaker.fan.p11, dmaker.fan.p18, dmaker.fan.p33)
+### Tower Fan/Standing Fan 2/Standing Fan 2 Pro/Standing Fan Pro
+
+Supported models:
+
+- `dmaker.fan.p9`
+- `dmaker.fan.p10`
+- `dmaker.fan.p11`
+- `dmaker.fan.p18`
+- `dmaker.fan.p33`
 
 - Power (on, off)
 - Operation modes (Normal, Nature)


### PR DESCRIPTION
## Proposed change

Documents support for the **Xiaomi Smart Standing Fan 2 Pro** (`dmaker.fan.p33`) in the `xiaomi_miio` integration. Adds the model to the supported-devices list and to the shared fan feature section (Tower Fan/Standing Fan 2/Standing Fan Pro), which it mirrors exactly.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#176700
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
