### PR TITLE
Bluetooth: document AppArmor fix for Container Bluetooth connections

### DIFF
--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -111,6 +111,49 @@ If `NET_ADMIN` and `NET_RAW` capabilities are missing:
 
 {% enddetails %}
 
+{% details "Bluetooth connections fail on hosts that use AppArmor" %}
+
+On host systems that use [AppArmor](https://apparmor.net/), such as Ubuntu and Debian, Bluetooth scanning can work while connecting to a device or sending commands to it fails. Even when your container has the correct capabilities and access to the D-Bus socket, the default AppArmor profile that Docker applies can block the container from sending certain D-Bus messages to BlueZ. This affects device connections and write operations, while scanning continues to work.
+
+You might see the following symptoms:
+
+- Scanning finds nearby Bluetooth devices, and the adapter is detected.
+- The D-Bus socket is available inside the container.
+- Connecting to a device or sending commands to it fails.
+- An error appears in your logs: "An AppArmor policy prevents this sender from sending this message to this recipient".
+
+To resolve this, run the container without the default AppArmor profile.
+
+**Docker Compose:**
+```yaml
+security_opt:
+  - apparmor=unconfined
+```
+
+**Docker run:**
+```bash
+docker run --security-opt apparmor=unconfined ...
+```
+
+Combined with the required capabilities and the D-Bus socket, a typical configuration for local Bluetooth looks like this:
+
+```yaml
+network_mode: host
+volumes:
+  - /run/dbus:/run/dbus:ro
+cap_add:
+  - NET_ADMIN
+  - NET_RAW
+security_opt:
+  - apparmor=unconfined
+```
+
+{% note %}
+The `apparmor=unconfined` option disables the default AppArmor profile for the whole container, which is broader than allowing only D-Bus communication with BlueZ. If you want to keep AppArmor active, you can create a custom AppArmor profile that permits the container to communicate with BlueZ over D-Bus.
+{% endnote %}
+
+{% enddetails %}
+
 {% details "Switching from dbus-daemon to dbus-broker" %}
 
 Follow [the instructions](https://github.com/bus1/dbus-broker/wiki) to switch to dbus-broker.

--- a/source/_integrations/bluetooth.markdown
+++ b/source/_integrations/bluetooth.markdown
@@ -103,17 +103,18 @@ For most systems, the D-Bus socket is in `/run/dbus`. You need to make the socke
 **What happens without these capabilities:**
 
 If `NET_ADMIN` and `NET_RAW` capabilities are missing:
-- Your Bluetooth will operate in a degraded mode with limited functionality
-- Automatic adapter recovery is unavailable - your adapters cannot be reset when they stop responding
-- Connection parameters and management API commands will fail
-- Raw advertising data will be missing, causing unreliable updates for your devices
-- An error will appear in your logs: "Missing required permissions for Bluetooth management"
+
+- Your Bluetooth will operate in a degraded mode with limited functionality.
+- Automatic adapter recovery is unavailable, so your adapters cannot be reset when they stop responding.
+- Connection parameters and management API commands will fail.
+- Raw advertising data will be missing, causing unreliable updates for your devices.
+- An error will appear in your logs: "Missing required permissions for Bluetooth management".
 
 {% enddetails %}
 
 {% details "Bluetooth connections fail on hosts that use AppArmor" %}
 
-On host systems that use [AppArmor](https://apparmor.net/), such as Ubuntu and Debian, Bluetooth scanning can work while connecting to a device or sending commands to it fails. Even when your container has the correct capabilities and access to the D-Bus socket, the default AppArmor profile that Docker applies can block the container from sending certain D-Bus messages to BlueZ. This affects device connections and write operations, while scanning continues to work.
+On host systems that use [AppArmor](https://apparmor.net/), such as Ubuntu and Debian, Bluetooth can behave inconsistently: scanning keeps working, but connecting to a device or sending commands to it fails. Even when your container has the correct capabilities and access to the D-Bus socket, the default AppArmor profile that Docker applies can block the container from sending certain D-Bus messages to BlueZ. As a result, device connections and write operations fail while scanning continues to work.
 
 You might see the following symptoms:
 


### PR DESCRIPTION
## Proposed change

Adds a troubleshooting section to the Bluetooth integration page for Home Assistant Container installations running on hosts that use AppArmor (such as Ubuntu and Debian).

### The problem

On these hosts, Bluetooth scanning works while connecting to a device or sending commands to it (GATT write) fails, even when the container already has:

- `network_mode: host`
- access to the D-Bus socket (`/run/dbus`)
- the `NET_ADMIN` and `NET_RAW` capabilities

The adapter is detected and BLE scanning succeeds, but connection and write operations fail. The logs show:

```
An AppArmor policy prevents this sender from sending this message to this recipient
```

The default AppArmor profile that Docker applies (`docker-default`) blocks the container from sending certain D-Bus messages to `org.bluez`, even though the Linux capabilities and socket access are correct. Because scanning keeps working, the cause is hard to spot.

### The fix

Running the container without the default AppArmor profile restores GATT communication:

```yaml
security_opt:
  - apparmor=unconfined
```

The new section documents the symptoms, the fix for both Docker Compose and `docker run`, a full example configuration, and a note that a custom AppArmor profile is the more restrictive alternative.

Tested on Ubuntu 24.04.

### Verifying the fix

You can confirm the container can talk to BlueZ over the system D-Bus by introspecting `org.bluez` from inside the container:

```bash
docker exec -it homeassistant dbus-send \
  --system \
  --dest=org.bluez \
  --type=method_call \
  /org/bluez \
  org.freedesktop.DBus.Introspectable.Introspect
```

With the AppArmor restriction in place, this fails with the AppArmor policy error. After adding `security_opt: apparmor=unconfined`, it returns the introspection XML.

## Type of change

- [x] Document existing feature (existing content, but new missing information)

## Additional information

- This PR only changes documentation.