### PR TITLE
Remove name field from Waze Travel Time examples

### DIFF
--- a/source/_integrations/waze_travel_time.markdown
+++ b/source/_integrations/waze_travel_time.markdown
@@ -70,7 +70,6 @@ template:
 
 In this example, we use a device_tracker entity ID as the origin and the sensor created above as the destination.
 
-  - Name: "Me to some destination"
   - Origin: `device_tracker.myphone`
   - Destination: `sensor.dest_address`
   - Region: "US"
@@ -79,14 +78,12 @@ In this example, we use a device_tracker entity ID as the origin and the sensor 
 
 In this example we are using the entity ID of a zone as the origin and the friendly name of a zone as the destination.
 
-  - Name: "Home to Eddie's house"
   - Origin: `zone.home`
   - Destination: "Eddies House"
   - Region: "US"
 
 #### Tracking entity in imperial units
 
-  - Name: "Somewhere in New York"
   - Origin: `person.paulus`
   - Destination: "725 5th Ave, New York, NY 10022, USA"
   - Region: "US"
@@ -95,7 +92,6 @@ In this example we are using the entity ID of a zone as the origin and the frien
 
 #### Avoiding toll, subscription
 
-  - Name: "Westerscheldetunnel"
   - Origin: "51.330436, 3.802043"
   - Destination: "51.445677, 3.749929"
   - Region: "EU"


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The name field is removed from the Waze Travel Time config flow in home-assistant/core#176791, as part of home-assistant/core#168966. This removes the Name lines from the example configurations on the integration page so they match the setup dialog again.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#176791
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
