### PR TITLE
Add pressure tank units to Gardena Bluetooth documentation

### DIFF
--- a/source/_integrations/gardena_bluetooth.markdown
+++ b/source/_integrations/gardena_bluetooth.markdown
@@ -30,7 +30,7 @@ ha_integration_type: device
 
 The **Gardena Bluetooth** {% term integration %} allows users to integrate their Gardena Bluetooth devices into Home Assistant.
 
-See device section for support information: [water control](#water-control), [irrigation valves](#irrigation-valves), [lawn mowers](#lawn-mowers), [garden pumps](#gard-pumps), [aqua contours](#aqua-contours).
+See device section for support information: [water control](#water-control), [irrigation valves](#irrigation-valves), [lawn mowers](#lawn-mowers), [garden pumps](#gard-pumps), [pressure tank units](#pressure-tank-units), [aqua contours](#aqua-contours).
 
 {% include integrations/config_flow.md %}
 
@@ -77,6 +77,13 @@ Gardena Bluetooth lawn mowers are currently not supported due to custom protocol
 
 - Garden Pump ([9058-61](https://www.gardena.com/int/products/pumps/watering-pumps/garden-pump-6300-silentcomfort/970645301.html))
 - Garden Pump ([9059-61](https://www.gardena.com/int/products/pumps/watering-pumps/garden-pump-6500-silentcomfort/970645501.html))
+
+## Pressure tank units
+
+- Pressure Tank Unit 5600 SilentComfort ([9067-20](https://www.gardena.com/int/products/pumps/domestic-water-supply-pumps/pressure-tank-unit-5600-silentcomfort/970646301.html))
+- Pressure Tank Unit 6300 SilentComfort ([9068-20](https://www.gardena.com/int/products/pumps/domestic-water-supply-pumps/pressure-tank-unit-6300-silentcomfort/970646501.html))
+
+In addition to the pump controls, pressure tank units provide sensors for the current tank pressure and the water temperature.
 
 ## Aqua Contours
 

--- a/source/_integrations/gardena_bluetooth.markdown
+++ b/source/_integrations/gardena_bluetooth.markdown
@@ -30,7 +30,7 @@ ha_integration_type: device
 
 The **Gardena Bluetooth** {% term integration %} allows users to integrate their Gardena Bluetooth devices into Home Assistant.
 
-See device section for support information: [water control](#water-control), [irrigation valves](#irrigation-valves), [lawn mowers](#lawn-mowers), [garden pumps](#gard-pumps), [pressure tank units](#pressure-tank-units), [aqua contours](#aqua-contours).
+See the device sections for support information: [water control](#water-control), [irrigation valves](#irrigation-valves), [lawn mowers](#lawn-mowers), [garden pumps](#gard-pumps), [pressure tank units](#pressure-tank-units), [aqua contours](#aqua-contours).
 
 {% include integrations/config_flow.md %}
 
@@ -83,7 +83,7 @@ Gardena Bluetooth lawn mowers are currently not supported due to custom protocol
 - Pressure Tank Unit 5600 SilentComfort ([9067-20](https://www.gardena.com/int/products/pumps/domestic-water-supply-pumps/pressure-tank-unit-5600-silentcomfort/970646301.html))
 - Pressure Tank Unit 6300 SilentComfort ([9068-20](https://www.gardena.com/int/products/pumps/domestic-water-supply-pumps/pressure-tank-unit-6300-silentcomfort/970646501.html))
 
-In addition to the pump controls, pressure tank units provide sensors for the current tank pressure and the water temperature.
+In addition to the pump controls, pressure tank units provide sensors for the current tank pressure and water temperature.
 
 ## Aqua Contours
 


### PR DESCRIPTION
## Proposed change

Documents support for Gardena **pressure tank units** (SilentComfort domestic water supply series) in the Gardena Bluetooth integration:

- Adds a "Pressure tank units" device section listing the Pressure Tank Unit 5600 SilentComfort (9067-20) and 6300 SilentComfort (9068-20).
- Mentions the new tank pressure and water temperature sensors added in the parent PR.
- Adds the new section to the device overview links at the top of the page.

Support for these devices already exists in the integration (they are handled as `ProductType.PRESSURE_TANKS`); the parent PR adds the tank pressure and water temperature sensor entities, verified against a physical 9067-20 device.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/176798
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
