### PR TITLE
Add iZone removal instructions

### DIFF
--- a/source/_integrations/izone.markdown
+++ b/source/_integrations/izone.markdown
@@ -142,3 +142,9 @@ logger:
 This will help you to find network connection issues.
 
 {% include integrations/actions.md %}
+
+## Removing the integration
+
+This integration follows standard integration removal.
+
+{% include integrations/remove_device_service.md %}


### PR DESCRIPTION
## Proposed change

Add the standard **Removing the integration** section to the iZone docs page.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in an existing page and I have not made stylistic changes that don't fit the rest of the documentation.
- [ ] Another page addition / improvement that needs review.

## Additional information

- Link to parent pull request:
- Link to parent pull request in the frontend or architecture repo:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This change has been tested on a live system.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
