### PR TITLE
Remove unsupported fields from MQTT lawn mower and lock examples

### DIFF
--- a/source/_integrations/lawn_mower.mqtt.markdown
+++ b/source/_integrations/lawn_mower.mqtt.markdown
@@ -19,7 +19,7 @@ To use an MQTT lawn mower in your installation, add the following to your {% ter
 # Example configuration.yaml entry
 mqtt:
   - lawn_mower:
-      command_topic: topic
+      start_mowing_command_topic: topic
       name: "Test Lawn Mower"
 ```
 

--- a/source/_integrations/lock.mqtt.markdown
+++ b/source/_integrations/lock.mqtt.markdown
@@ -320,7 +320,6 @@ mqtt:
       state_locking: "LOCKING"
       state_unlocking: "UNLOCKING"
       state_jammed: "MOTOR_JAMMED"
-      state_ok: "MOTOR_OK"
       optimistic: false
       qos: 1
       retain: true


### PR DESCRIPTION
## Proposed change

The first example on the MQTT lawn mower page uses a generic `command_topic`, which the lawn mower schema does not support - it only has the action-specific `dock_command_topic`, `pause_command_topic` and `start_mowing_command_topic`. Replaced it with `start_mowing_command_topic` so the example is valid, matching the example further down the page.

The full configuration example on the MQTT lock page sets `state_ok`, which does not exist in the lock schema (only `state_jammed` and the lock/unlock states are configurable). Removed that line.

Copying either example as-is currently gives you a config that fails validation.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #46917

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
