### PR TITLE
Document new state attributes for Tankerkoenig Status sensor

### DIFF
--- a/source/_integrations/tankerkoenig.markdown
+++ b/source/_integrations/tankerkoenig.markdown
@@ -79,6 +79,17 @@ This integrations provides a set of {% term "Binary sensor" %} and {% term Senso
 As the data of [tankerkoenig.de](https://www.tankerkoenig.de/) is based on data from the German market transparency office for fuels (_[Markttransparenzstelle für Kraftstoffe](https://www.bundeskartellamt.de/DE/Aufgaben/MarkttransparenzstelleFuerKraftstoffe/MTS-K_Infotext/mts-k_node.html) MTS-K_), only the three base fuel types `Diesel`, `Super`, and `Super E10` are available.
 {% endnote %}
 
+## State attributes
+
+The following state attributes are available for the `Status` binary sensor in addition to the standard ones:
+
+| Attribute | Description |
+| --- | --- |
+| opening_times | List of opening time periods, each with `start`, `end`, and `text`. |
+| whole_day | `true` if the station is open 24 hours a day. |
+| latitude | Latitude of the station (_only available if "Show stations on map" is enabled_). |
+| longitude | Longitude of the station (_only available if "Show stations on map" is enabled_). |
+
 ## Usage examples
 
 ### Show current fuel price only when station is opened

--- a/source/_integrations/tankerkoenig.markdown
+++ b/source/_integrations/tankerkoenig.markdown
@@ -85,10 +85,10 @@ The following state attributes are available for the `Status` binary sensor in a
 
 | Attribute | Description |
 | --- | --- |
-| opening_times | List of opening time periods, each with `start`, `end`, and `text`. |
-| whole_day | `true` if the station is open 24 hours a day. |
-| latitude | Latitude of the station (_only available if "Show stations on map" is enabled_). |
-| longitude | Longitude of the station (_only available if "Show stations on map" is enabled_). |
+| `opening_times` | A list of opening time periods, each with `start`, `end`, and `text`. |
+| `whole_day` | `true` if the station is open 24 hours a day. |
+| `latitude` | Latitude of the station (only available if **Show stations on map** is enabled). |
+| `longitude` | Longitude of the station (only available if **Show stations on map** is enabled). |
 
 ## Usage examples
 


### PR DESCRIPTION
## Proposed change

Documents the `opening_times` and `whole_day` state attributes being added to the Tankerkoenig `Status` binary sensor, and adds the previously-undocumented `latitude`/`longitude` attributes.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#173021
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards