### PR TITLE
Document UniFi option to ignore private (randomized) MAC addresses

### DIFF
--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -115,6 +115,8 @@ Time in seconds from last seen until considered away:
   description: "Number of seconds since last seen before a client is considered away. Defaults to `300` seconds."
 Disable UniFi Network wired bug logic:
   description: "Disable the workaround for a UniFi Network bug that sometimes reports wired clients as wireless."
+Ignore Wi-Fi clients with private (randomized) MAC addresses:
+  description: "Skip Wi-Fi clients that connect with a private (randomized) MAC address, so no entities are created for them. Wired clients are not affected, and clients you select under **Create entities from network clients** are still included. Disabled by default."
 Network access controlled clients:
   description: "Select clients whose network access you want to control via switches by adding their MAC addresses."
 Allow control of DPI restriction groups:
@@ -154,7 +156,7 @@ This platform allows you to detect presence by looking at devices connected to a
 
 If tracked devices continue to show "Home" when not connected/present and show connected in the UniFi Controller, disable 802.11r Fast Roaming. When enabled, various UniFi Controller versions have been observed to fail to declare clients disconnected.
 
-Presence detection is not compatible with Client MAC Address Randomization, enabled by default on most modern SmartPhones. This feature will need to be disabled within the client device settings, usually under the settings for the specific network.
+Presence detection is not compatible with Client MAC Address Randomization, enabled by default on most modern SmartPhones. This feature will need to be disabled within the client device settings, usually under the settings for the specific network. If you would rather not track these devices at all, turn on **Ignore Wi-Fi clients with private (randomized) MAC addresses** in the integration options. Home Assistant then skips these clients instead of creating device trackers that never come back.
 
 Presence detection depends on accurate time configuration between Home Assistant and the UniFi Network application.
 

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -116,7 +116,7 @@ Time in seconds from last seen until considered away:
 Disable UniFi Network wired bug logic:
   description: "Disable the workaround for a UniFi Network bug that sometimes reports wired clients as wireless."
 Ignore Wi-Fi clients with private (randomized) MAC addresses:
-  description: "Skip Wi-Fi clients that connect with a private (randomized) MAC address, so no entities are created for them. Wired clients are not affected, and clients you select under **Create entities from network clients** are still included. Disabled by default."
+  description: "Skip Wi-Fi clients that connect with a locally administered MAC address (like private or randomized Wi-Fi addresses), so no entities are created for them. Wired clients are not affected, and clients you select under **Create entities from network clients** are still included. Disabled by default."
 Network access controlled clients:
   description: "Select clients whose network access you want to control via switches by adding their MAC addresses."
 Allow control of DPI restriction groups:


### PR DESCRIPTION
## Proposed change

Documents the new opt-in UniFi Network option added in home-assistant/core#174503, which stops the integration creating entities for Wi-Fi clients that connect with a private (randomized) MAC address.

- Adds the option to the **Configuration options** list.
- Rewrites the presence detection note about MAC address randomization. It previously said presence detection "is not compatible with Client MAC Address Randomization" and only offered "turn the feature off on every device". It now explains why tracking breaks and covers both ways to handle it, including the new option.

## Type of change

- [x] Document existing feature (new feature in an existing integration)

## Additional information

- Related core PR: https://github.com/home-assistant/core/pull/174503
- Related discussion: https://github.com/orgs/home-assistant/discussions/4118

## Checklist

- [x] This PR targets the `next` branch, since it documents a feature that has not been released yet.
