### PR TITLE
Document Renault charge schedule action

### DIFF
--- a/source/_integrations/renault.markdown
+++ b/source/_integrations/renault.markdown
@@ -56,7 +56,7 @@ In some situations, some of the features may require a subscription such as the 
 
 ## Charging schedule action
 
-For vehicles that report charge schedules, use the **Get charge schedules** action to retrieve the current charging schedules. The response includes the number of schedules, the number of active schedules, and the configured days with their start time and duration.
+For vehicles that report charge schedules, use the **Get charge schedules** action to retrieve the current charging schedules. The response includes the number of schedules, the number of active schedules, and the configured days with their local `HH:MM` start time and duration.
 
 ## Battery charge limits
 

--- a/source/_integrations/renault.markdown
+++ b/source/_integrations/renault.markdown
@@ -35,7 +35,7 @@ This integration provides the following platforms:
 - Device tracker - to track location of your car.
 - Numbers - to set battery charge limits (minimum and target charge levels for electric vehicles).
 - Selectors - to change the charge mode.
-- Sensors - such as battery level, outside temperature, odometer, estimated range, charging rate, charging schedule details, and tyre pressure.
+- Sensors - such as battery level, outside temperature, odometer, estimated range, charging rate, and tyre pressure.
 
 {% include integrations/config_flow.md %}
 
@@ -54,13 +54,9 @@ All vehicles linked to the account should then get added as devices, with sensor
 
 In some situations, some of the features may require a subscription such as the *Pack EV Remote Control* and/or the *Pack Smart Navigation* subscription.
 
-## Charging schedule attributes
+## Charging schedule action
 
-For vehicles that report charge schedules, the **Charging mode** sensor includes extra attributes:
-
-- `schedule_count`: Number of charge schedules reported by the vehicle.
-- `active_schedule_count`: Number of active charge schedules.
-- `active_schedules`: Details of the active charge schedules, including configured days, `start_time`, and `duration`.
+For vehicles that report charge schedules, use the **Get charge schedules** action to retrieve the current charging schedules. The response includes the number of schedules, the number of active schedules, and the configured days with their start time and duration.
 
 ## Battery charge limits
 

--- a/source/_integrations/renault.markdown
+++ b/source/_integrations/renault.markdown
@@ -35,7 +35,7 @@ This integration provides the following platforms:
 - Device tracker - to track location of your car.
 - Numbers - to set battery charge limits (minimum and target charge levels for electric vehicles).
 - Selectors - to change the charge mode.
-- Sensors - such as battery level, outside temperature, odometer, estimated range, charging rate, and tyre pressure.
+- Sensors - such as battery level, outside temperature, odometer, estimated range, charging rate, charging schedule details, and tyre pressure.
 
 {% include integrations/config_flow.md %}
 
@@ -53,6 +53,14 @@ Kamereon account id:
 All vehicles linked to the account should then get added as devices, with sensors added as linked entity.
 
 In some situations, some of the features may require a subscription such as the *Pack EV Remote Control* and/or the *Pack Smart Navigation* subscription.
+
+## Charging schedule attributes
+
+For vehicles that report charge schedules, the **Charging mode** sensor includes extra attributes:
+
+- `schedule_count`: Number of charge schedules reported by the vehicle.
+- `active_schedule_count`: Number of active charge schedules.
+- `active_schedules`: Details of the active charge schedules, including configured days, `start_time`, and `duration`.
 
 ## Battery charge limits
 


### PR DESCRIPTION
## Proposed change

Document the Renault charge schedule response action proposed in home-assistant/core#176920.

The **Get charge schedules** action retrieves charge schedule details on demand, including schedule counts and configured days.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/176920
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

