### PR TITLE
Document ScorpionTrack speed sensor

### DIFF
--- a/source/_integrations/scorpiontrack.markdown
+++ b/source/_integrations/scorpiontrack.markdown
@@ -1,6 +1,6 @@
 ---
 title: ScorpionTrack
-description: Instructions on how to integrate ScorpionTrack shared vehicle locations into Home Assistant.
+description: Instructions on how to integrate ScorpionTrack shared vehicle locations and speeds into Home Assistant.
 ha_category:
   - Device tracker
 ha_release: 2026.8
@@ -8,6 +8,7 @@ ha_iot_class: Cloud Polling
 ha_domain: scorpiontrack
 ha_platforms:
   - device_tracker
+  - sensor
 ha_config_flow: true
 ha_integration_type: hub
 ha_codeowners:
@@ -15,9 +16,9 @@ ha_codeowners:
 ha_quality_scale: bronze
 ---
 
-The **ScorpionTrack** {% term integration %} lets Home Assistant follow vehicles that have been shared through a public ScorpionTrack location-share link.
+The **ScorpionTrack** {% term integration %} lets Home Assistant follow the location and speed of vehicles that have been shared through a public ScorpionTrack location-share link.
 
-This integration is intentionally focused on the share-link workflow. It does not use your private ScorpionTrack account credentials. Instead, it reads the shared vehicle feed exposed by ScorpionTrack and creates `device_tracker` entities from that data, which appear on the Home Assistant map.
+This integration is intentionally focused on the share-link workflow. It does not use your private ScorpionTrack account credentials. Instead, it reads the shared vehicle feed exposed by ScorpionTrack and creates location and speed entities from that data. The vehicle location appears on the Home Assistant map.
 
 ## Prerequisites
 
@@ -47,9 +48,14 @@ Share URL or token:
 
 ## Supported functionality
 
-The **ScorpionTrack** integration creates one {% term "device tracker" %} for each vehicle included in the share.
+The **ScorpionTrack** integration creates one device for each vehicle included in the share. Each device provides:
 
-Each tracker represents the vehicle directly on the Home Assistant map and in zone logic, using the latest GPS location reported through the ScorpionTrack share. The tracker name uses the vehicle registration when available, and otherwise falls back to the vehicle name from the ScorpionTrack share.
+- A {% term "device tracker" %} entity that represents the vehicle on the Home Assistant map and in zone logic, using the latest GPS location reported through the ScorpionTrack share
+- A **Speed** sensor entity that shows the latest vehicle speed reported through the share
+
+The tracker name uses the vehicle registration when available, and otherwise falls back to the vehicle name from the ScorpionTrack share.
+
+The **Speed** sensor initially uses the unit selected for the ScorpionTrack share. You can choose a different display unit in the entity settings.
 
 ## Data updates
 

--- a/source/_integrations/scorpiontrack.markdown
+++ b/source/_integrations/scorpiontrack.markdown
@@ -3,6 +3,7 @@ title: ScorpionTrack
 description: Instructions on how to integrate ScorpionTrack shared vehicle locations and speeds into Home Assistant.
 ha_category:
   - Device tracker
+  - Sensor
 ha_release: 2026.8
 ha_iot_class: Cloud Polling
 ha_domain: scorpiontrack

--- a/source/_integrations/scorpiontrack.markdown
+++ b/source/_integrations/scorpiontrack.markdown
@@ -17,7 +17,7 @@ ha_codeowners:
 ha_quality_scale: bronze
 ---
 
-The **ScorpionTrack** {% term integration %} lets Home Assistant follow the location and speed of vehicles that have been shared through a public ScorpionTrack location-share link.
+The **ScorpionTrack** {% term integration %} lets Home Assistant follow the location and speed of vehicles that have been shared through a public ScorpionTrack shared-location link.
 
 This integration is intentionally focused on the share-link workflow. It does not use your private ScorpionTrack account credentials. Instead, it reads the shared vehicle feed exposed by ScorpionTrack and creates location and speed entities from that data. The vehicle location appears on the Home Assistant map.
 
@@ -51,8 +51,8 @@ Share URL or token:
 
 The **ScorpionTrack** integration creates one device for each vehicle included in the share. Each device provides:
 
-- A {% term "device tracker" %} entity that represents the vehicle on the Home Assistant map and in zone logic, using the latest GPS location reported through the ScorpionTrack share
-- A **Speed** sensor entity that shows the latest vehicle speed reported through the share
+- A {% term "device tracker" %} entity that represents the vehicle on the Home Assistant map and in zone logic, using the latest GPS location reported through the ScorpionTrack share.
+- A **Speed** sensor entity that shows the latest vehicle speed reported through the share.
 
 The tracker name uses the vehicle registration when available, and otherwise falls back to the vehicle name from the ScorpionTrack share.
 

--- a/source/_integrations/scorpiontrack.markdown
+++ b/source/_integrations/scorpiontrack.markdown
@@ -59,7 +59,7 @@ The **Speed** sensor initially uses the unit selected for the ScorpionTrack shar
 
 ## Data updates
 
-The **ScorpionTrack** integration {% term polling polls %} ScorpionTrack every 2 minutes for the latest shared vehicle position.
+The **ScorpionTrack** integration {% term polling polls %} ScorpionTrack every 2 minutes for the latest location and speed of each shared vehicle.
 
 ## Known limitations
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

I am updating the ScorpionTrack page for the new Speed sensor. The page explains that its initial display unit follows the share's unit preference, that the unit can be changed in the entity settings, and that location and speed continue to update every two minutes.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/177032
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards