### PR TITLE
Revert "Add onboarding survey redirect"

### DIFF
--- a/source/_redirects
+++ b/source/_redirects
@@ -37,7 +37,6 @@ layout: null
 
 # Design & User research
 /join-chat-design https://discord.com/channels/330944238910963714/1475553148847526123
-/surveys/onboarding https://usabi.li/do/i39njudc3tl7/ksqzg8
 
 # Older development pages
 /developers https://developers.home-assistant.io


### PR DESCRIPTION
Reverts home-assistant/home-assistant.io#46969

Using OHF shortlink instead of home-assistant.io redirect.