### PR TITLE
Document energy dashboard customization

### DIFF
--- a/source/_dashboards/energy.markdown
+++ b/source/_dashboards/energy.markdown
@@ -18,6 +18,8 @@ You can add these cards using the visual card editor or by editing the YAML dire
 
 You can configure them on the {% my config_energy title="energy configuration page" %}.
 
+To show or hide cards on the built-in Energy dashboard, see [customizing the Energy dashboard](/docs/energy/#customizing-the-energy-dashboard).
+
 ## Energy date picker
 
 <p class='img'>

--- a/source/_docs/energy.markdown
+++ b/source/_docs/energy.markdown
@@ -12,6 +12,10 @@ The energy dashboard works with electricity, gas, and water. For each one, your 
 
 Home Assistant is open and works with hardware from many different brands, so you are not locked into one ecosystem. Any energy monitor, smart plug, solar inverter, or utility meter that integrates with Home Assistant can feed data into the energy dashboard.
 
+## Setting up the Energy dashboard
+
+To add energy data to the dashboard, start with the type of source or device you want to track:
+
 - [Integrate your energy use from the electricity grid](/docs/energy/electricity-grid/)
 - [Integrate your solar panels](/docs/energy/solar-panels/)
 - [Integrate your home batteries](/docs/energy/battery/)

--- a/source/_docs/energy.markdown
+++ b/source/_docs/energy.markdown
@@ -24,3 +24,31 @@ If you have a sensor that returns instantaneous power readings (W or kW), then t
 You can also configure power sensors alongside energy sensors in the Energy dashboard. Power inputs accept sensors with `state_class: measurement` and appropriate units (for example `W` or `kW`).
 
 <img src='/images/docs/energy/energy-overview.png' alt='Visual representation of how all different energy forms relate.' style='border: 0;box-shadow: none;'>
+
+## Customizing the Energy dashboard
+
+The Energy dashboard is generated from the energy sources and devices you configure. You can show or hide individual cards without changing your energy sources. This lets you keep the dashboard focused on the graphs and summaries you use most.
+
+Before you customize the dashboard, add at least one energy source or device. If no sources or devices are configured, the **Customize energy** dialog has no cards to show.
+
+To show or hide cards on the Energy dashboard:
+
+1. Go to {% my config_energy title="the energy settings page" %}.
+2. In the toolbar, select **Customize cards**.
+3. In the **Customize energy** dialog, expand a section, such as **Overview**, **Electricity**, **Gas**, **Water**, or **Now**.
+4. Turn the switch for each card on or off.
+5. Select **Save**.
+
+Your card selection applies to the Energy dashboard for the whole Home Assistant system, not only to your browser or user account. Cards that you keep visible continue to use the same energy data and date controls as before.
+
+### Cards that are not available
+
+Some cards in the **Customize energy** dialog might be unavailable. A card is unavailable when the energy source or device it needs is not configured. For example, a solar card needs a solar panel source.
+
+To make an unavailable card available, add the matching source or device on the energy settings page. The dialog only shows sections that have at least one card available for your current energy configuration.
+
+### Hidden dashboard tabs
+
+If you hide every card in an Energy dashboard tab, Home Assistant hides that tab. Home Assistant keeps at least one tab available, so the dashboard does not become empty.
+
+To show a hidden card or tab again, return to **Customize cards**, turn the card back on, and save your changes.

--- a/source/_docs/energy.markdown
+++ b/source/_docs/energy.markdown
@@ -8,9 +8,9 @@ Home Assistant turns your home into a clear, easy-to-read picture of how energy 
 
 {% my energy badge %} {% my config_energy badge %}
 
-The energy dashboard works with electricity, gas, and water. For each one, your usage is grouped into three simple types: what you consume, what you produce, and what you store. You can start with a single source, even just your electricity meter, and add more as you go. Every source you add makes the picture more complete.
+The Energy dashboard works with electricity, gas, and water. For each one, your usage is grouped into three simple types: what you consume, what you produce, and what you store. You can start with a single source, even just your electricity meter, and add more as you go. Every source you add makes the picture more complete.
 
-Home Assistant is open and works with hardware from many different brands, so you are not locked into one ecosystem. Any energy monitor, smart plug, solar inverter, or utility meter that integrates with Home Assistant can feed data into the energy dashboard.
+Home Assistant is open and works with hardware from many different brands, so you are not locked into one ecosystem. Any energy monitor, smart plug, solar inverter, or utility meter that integrates with Home Assistant can feed data into the Energy dashboard.
 
 ## Setting up the Energy dashboard
 

--- a/source/_docs/energy.markdown
+++ b/source/_docs/energy.markdown
@@ -37,7 +37,7 @@ Before you customize the dashboard, add at least one energy source or device. If
 
 To show or hide cards on the Energy dashboard:
 
-1. Go to {% my config_energy title="the energy settings page" %}.
+1. Go to {% my config_energy title="**Settings** > **Dashboards** > **Energy**" %}.
 2. In the toolbar, select **Customize cards**.
 3. In the **Customize energy** dialog, expand a section, such as **Overview**, **Electricity**, **Gas**, **Water**, or **Now**.
 4. Turn the switch for each card on or off.


### PR DESCRIPTION
## Proposed change

Document how to show or hide cards on the built-in Energy dashboard from the [energy settings page](https://www.home-assistant.io/docs/energy/).

This also adds a small heading to separate the setup links from the page introduction.

Preview: https://deploy-preview-46989--home-assistant-docs.netlify.app/docs/energy/#customizing-the-energy-dashboard

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/52362
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/home-assistant.io/issues/46453

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards