### PR TITLE
Document Nintendo parental controls PIN action

### DIFF
--- a/source/_actions/nintendo_parental_controls.update_pin_code.markdown
+++ b/source/_actions/nintendo_parental_controls.update_pin_code.markdown
@@ -1,0 +1,134 @@
+---
+title: "Update PIN Code"
+action: nintendo_parental_controls.update_pin_code
+domain: nintendo_parental_controls
+description: "Updates the PIN code for a Nintendo Switch."
+---
+
+The **Update PIN Code** action changes the parental controls override PIN for a Nintendo Switch.
+
+This is useful when you want an automation or script to change the PIN at a specific time or after something else happens in Home Assistant.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, entity, or label. Instead, you select the Nintendo Switch to update through the **Device** option.
+
+{% include actions/ui_header.md %}
+
+To update the PIN from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Update PIN Code**.
+6. Select what you want to control. This action does not use **By target** because the Nintendo Switch is selected in the **Device** option.
+7. Choose the **Device**, then enter the new **PIN**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: The Nintendo Switch to update.
+  required: true
+PIN:
+  description: The new PIN code. Enter a 4- to 8-digit PIN between 0000 and 99999999.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `nintendo_parental_controls.update_pin_code`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: nintendo_parental_controls.update_pin_code
+  data:
+    device_id: 1b4a46c6d0f3406c80d275f5b0c6483b
+    pin: "1234"
+{% endexample %}
+
+This changes the parental controls override PIN for the selected Nintendo Switch to `1234`.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: >
+    The ID of the Nintendo Switch device to update.
+  required: true
+  type: string
+pin:
+  description: >
+    The new PIN code. Enter a 4- to 8-digit PIN between 0000 and
+    99999999.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- The **Device** option must be a Nintendo Switch device from the Nintendo Switch Parental Controls integration.
+- The PIN must contain only digits and be 4 to 8 digits long.
+- When changing the PIN, Nintendo sends you an email automatically. Home Assistant cannot disable this email. The email does not contain the PIN.
+- Entering this PIN on the Nintendo Switch bypasses all parental control restrictions.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: Change the PIN from a toggle helper
+
+This automation changes the PIN when a user-created toggle {% term helper %} turns on. Create this helper separately before using the example.
+
+- **Trigger**: A toggle helper turns on
+- **Action**: Update PIN Code
+  - **Device**: The Nintendo Switch to update
+  - **PIN**: `5678`
+
+{% details "YAML example for changing the PIN from a toggle helper" %}
+
+{% example %}
+automation: |
+  alias: "Change Nintendo Switch PIN from helper"
+  triggers:
+    - trigger: state
+      entity_id: input_boolean.change_switch_pin
+      to: "on"
+  actions:
+    - action: nintendo_parental_controls.update_pin_code
+      data:
+        device_id: 1b4a46c6d0f3406c80d275f5b0c6483b
+        pin: "5678"
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Restore the usual PIN each evening
+
+This automation restores the usual PIN at 9:00 PM each day.
+
+- **Trigger**: Time is 9:00 PM
+- **Action**: Update PIN Code
+  - **Device**: The Nintendo Switch to update
+  - **PIN**: `1234`
+
+{% details "YAML example for restoring the usual PIN each evening" %}
+
+{% example %}
+automation: |
+  alias: "Restore Nintendo Switch PIN in the evening"
+  triggers:
+    - trigger: time
+      at: "21:00:00"
+  actions:
+    - action: nintendo_parental_controls.update_pin_code
+      data:
+        device_id: 1b4a46c6d0f3406c80d275f5b0c6483b
+        pin: "1234"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/nintendo_parental_controls.update_pin_code.markdown
+++ b/source/_actions/nintendo_parental_controls.update_pin_code.markdown
@@ -19,10 +19,9 @@ To update the PIN from an automation or a script:
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
-5. From the search box, search for and select **Update PIN Code**.
-6. Select what you want to control. This action does not use **By target** because the Nintendo Switch is selected in the **Device** option.
-7. Choose the **Device**, then enter the new **PIN**.
-8. Select **Save**.
+5. From the search box, search for and select **Nintendo Switch parental controls: Update PIN code**.
+6. Choose the **Device**, then enter the new **PIN**.
+7. Select **Save**.
 
 ### Options in the UI
 

--- a/source/_actions/nintendo_parental_controls.update_pin_code.markdown
+++ b/source/_actions/nintendo_parental_controls.update_pin_code.markdown
@@ -79,8 +79,10 @@ pin:
 
 This automation changes the PIN when a user-created toggle {% term helper %} turns on. Create this helper separately before using the example.
 
-- **Trigger**: A toggle helper turns on
-- **Action**: Update PIN Code
+- **Trigger**: State
+  - **Target**: Change switch pin (input boolean)
+  - **To**: On
+- **Action**: Nintendo Switch parental controls: Update PIN code
   - **Device**: The Nintendo Switch to update
   - **PIN**: `5678`
 
@@ -106,8 +108,9 @@ automation: |
 
 This automation restores the usual PIN at 9:00 PM each day.
 
-- **Trigger**: Time is 9:00 PM
-- **Action**: Update PIN Code
+- **Trigger**: Time
+  - **At time**: `9:00:00` PM
+- **Action**: Nintendo Switch parental controls: Update PIN code
   - **Device**: The Nintendo Switch to update
   - **PIN**: `1234`
 

--- a/source/_integrations/nintendo_parental_controls.markdown
+++ b/source/_integrations/nintendo_parental_controls.markdown
@@ -86,8 +86,9 @@ The **Nintendo Switch Parental Controls** integration provides the following ent
   - **Device class**: `duration`
 
 #### Switch
+
 - **Suspend software**
-  - **Description**: Enable to automatically suspend running software when the Bedtime alarm is reached or the maximum screen time is exceeded. Turn off to allow software to continue running past these limits. 
+  - **Description**: Enable to automatically suspend running software when the Bedtime alarm is reached or the maximum screen time is exceeded. Turn off to allow software to continue running past these limits.
 
 #### Time
 
@@ -97,17 +98,6 @@ The **Nintendo Switch Parental Controls** integration provides the following ent
   - **Description**: The time that bedtime should end. Set to 00:00 to disable. Accepts values between 05:00 and 09:00 for the bedtime end time.
 
 {% include integrations/actions.md %}
-
-### Action: Update pin code
-
-The `nintendo_parental_controls.update_pin_code` action allows you to change the parental controls override PIN of a specified device. When entering this PIN on the Switch, all parental control restrictions can be bypassed.
-
-- **Data attribute**: `device_id`
-  - **Description**: The ID of the device to change the PIN on.
-  - **Optional**: No
-- **Data attribute**: `pin`
-  - **Description**: The new PIN is to be set between 1000 and 99999999.
-  - **Optional**: No
 
 ## Known limitations
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Migrates the Nintendo Switch parental controls PIN update action from inline integration documentation to the split action page format.

Adds PIN-related automation examples to the new action page.

Follow-up to https://github.com/home-assistant/home-assistant.io/pull/45195

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/169865
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
