### PR TITLE
Fix remark list item indent option

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -7,7 +7,7 @@ const remarkrc = {
     emphasis: "_",
     fence: "`",
     incrementListMarker: true,
-    listItemIndent: 1,
+    listItemIndent: "one",
     strong: "*",
   },
   plugins: [


### PR DESCRIPTION
## Proposed change

Update the remark configuration to use `listItemIndent: "one"` instead of `listItemIndent: 1`.

The current remark dependency stack rejects the numeric value with this error:

`Cannot serialize items with '1' for options.listItemIndent, expected 'tab', 'one', or 'mixed'`

`"one"` is the supported equivalent for the existing setting.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
