### PR TITLE
Add IP address and mDNS name diagnostic sensors to WattWächter Plus

### DIFF
--- a/source/_integrations/wattwaechter.markdown
+++ b/source/_integrations/wattwaechter.markdown
@@ -71,6 +71,8 @@ The following sensors are created with the diagnostic entity category and are di
 
 - **Wi-Fi signal (dBm)**: The wireless signal strength of the device.
 - **Wi-Fi SSID**: The wireless network name the device is connected to.
+- **IP address**: The local IP address of the device on your network.
+- **mDNS name**: The device's mDNS hostname.
 
 ## Data updates
 


### PR DESCRIPTION
## Proposed change

The WattWächter Plus integration provides two additional diagnostic sensors — IP address and mDNS name — alongside the already-documented Wi-Fi signal and Wi-Fi SSID sensors. This adds them to the "Diagnostic sensors" list so the documentation matches the provided functionality.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#177150
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
