### PR TITLE
Document reply-to message ID for Telegram bot events

### DIFF
--- a/source/_integrations/telegram_bot.markdown
+++ b/source/_integrations/telegram_bot.markdown
@@ -202,6 +202,9 @@ notify:
 ## Event entity
 
 The **Telegram bot** integration provides an {% term event %} {% term entity %} which represents the state of the last message sent or received. It also provides several event attributes that can be used in automations.
+For received messages that are replies to another message, the optional
+`reply_to_message_id` attribute contains the `message_id` of the message being
+replied to. It is not present when the message is not a reply.
 
 ### Event: Attachment received
 
@@ -228,6 +231,7 @@ from_first: "<first name of the sender>"
 from_last: "<last name of the sender>"
 id: "<message id>"
 message_thread_id: "<message thread id>"
+reply_to_message_id: "<id of the message being replied to, if applicable>"
 text: "<caption of the file, if available>"
 user_id: "<id of the sender>"
 ```
@@ -332,6 +336,7 @@ from_first: "<first name of the sender>"
 from_last: "<last name of the sender>"
 id: "<message id>"
 message_thread_id: "<message thread id>"
+reply_to_message_id: "<id of the message being replied to, if applicable>"
 user_id: "<id of the sender>"
 ```
 
@@ -377,6 +382,7 @@ from_first: "<first name of the sender>"
 from_last: "<last name of the sender>"
 id: "<message id>"
 message_thread_id: "<message thread id>"
+reply_to_message_id: "<id of the message being replied to, if applicable>"
 text: "<the text received>"
 user_id: "<id of the sender>"
 ```

--- a/source/_integrations/telegram_bot.markdown
+++ b/source/_integrations/telegram_bot.markdown
@@ -202,9 +202,7 @@ notify:
 ## Event entity
 
 The **Telegram bot** integration provides an {% term event %} {% term entity %} which represents the state of the last message sent or received. It also provides several event attributes that can be used in automations.
-For received messages that are replies to another message, the optional
-`reply_to_message_id` attribute contains the `message_id` of the message being
-replied to. It is not present when the message is not a reply.
+For received messages that are replies to another message, the optional `reply_to_message_id` attribute contains the message ID (`id`) of the message being replied to. It is not present when the message is not a reply.
 
 ### Event: Attachment received
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document the `reply_to_message_id` attribute for incoming Telegram bot events.
The attribute contains the `message_id` of the Telegram message being replied
to and is available for attachment, command, and text events when applicable.

Related core PR: home-assistant/core#177175


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
