### PR TITLE
Document KNX weather entity UI configuration

### DIFF
--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -2068,6 +2068,10 @@ sync_state:
 
 The KNX weather platform is used as an interface to KNX weather stations.
 
+Weather entities can be created from the frontend in the KNX panel or via YAML.
+
+{% details "Configuration of KNX weather entities via YAML" %}
+
 To use your KNX weather station in your installation, add the following lines to your top-level [KNX Integration](/integrations/knx) configuration key in your {% term "`configuration.yaml`" %}:
 
 ```yaml
@@ -2164,6 +2168,8 @@ sync_state:
   type: [boolean, string, integer]
   default: true
 {% endconfiguration %}
+
+{% enddetails %}
 
 ## Value types
 


### PR DESCRIPTION
## Proposed change

Document that KNX weather entities can now be configured from the frontend in the KNX panel, in addition to YAML. This aligns the Weather section with the other UI-configurable KNX platforms (binary sensor, climate, cover, etc.):

- Adds the "Weather entities can be created from the frontend in the KNX panel or via YAML." line after the platform description.
- Moves the existing YAML example and configuration block into a collapsible `{% details "Configuration of KNX weather entities via YAML" %}` section.

The UI-only options (the day/night `invert` toggle and DPT 1.024 filtering on the day/night address) are self-describing through the panel's own inline labels and descriptions, consistent with how the other platforms are documented, so no additional YAML options are added.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#177186
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
