### PR TITLE
Document KNX cover state restore and assumed state

### DIFF
--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -1047,6 +1047,7 @@ swing_horizontal_state_address:
 ### Cover
 
 The KNX cover platform is used as an interface to KNX covers.
+Intermediate positions of covers are calculated based on the configured `travelling_time_down` and `travelling_time_up` values once a second when moving. A received position from the KNX bus takes precedence over the calculated position.
 
 {% note %}
 Unlike most KNX devices, Home Assistant defines 0% as closed and 100% as fully open in regards to covers. The corresponding value inversion is done internally by the KNX integration.
@@ -1056,7 +1057,7 @@ Home Assistant will, by default, `close` a cover by moving it in the `DOWN` dire
 
 Cover entities restore their last known position and tilt angle after Home Assistant is restarted. Covers that have a `position_state_address` or `angle_state_address` configured request their current state from the KNX bus according to their state updater configuration.
 
-A restored position is reported as an assumed state until the cover receives a position from the KNX bus or is moved. Covers with a `position_state_address` leave the assumed state once the bus reports their position. Covers without one leave it the first time they are moved, as their position is only calculated from the configured `travelling_time_down` and `travelling_time_up` instead of read from the bus.
+A restored position is reported as an assumed state until the cover receives a position from the KNX bus or is moved.
 
 Cover entities can be created from the frontend in the KNX panel or via YAML.
 

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -1056,7 +1056,7 @@ Home Assistant will, by default, `close` a cover by moving it in the `DOWN` dire
 
 Cover entities restore their last known position and tilt angle after Home Assistant is restarted. Covers that have a `position_state_address` or `angle_state_address` configured request their current state from the KNX bus according to their state updater configuration.
 
-When no `position_state_address` is configured, the position can't be read from the KNX bus. It is only calculated from the configured `travelling_time_down` and `travelling_time_up`, so the cover reports an assumed state.
+A restored position is reported as an assumed state until the cover receives a position from the KNX bus or is moved. Covers without a `position_state_address` can't read their position from the bus, so their position is only calculated from the configured `travelling_time_down` and `travelling_time_up` and stays assumed.
 
 Cover entities can be created from the frontend in the KNX panel or via YAML.
 

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -1056,7 +1056,7 @@ Home Assistant will, by default, `close` a cover by moving it in the `DOWN` dire
 
 Cover entities restore their last known position and tilt angle after Home Assistant is restarted. Covers that have a `position_state_address` or `angle_state_address` configured request their current state from the KNX bus according to their state updater configuration.
 
-A restored position is reported as an assumed state until the cover receives a position from the KNX bus or is moved. Covers without a `position_state_address` can't read their position from the bus, so their position is only calculated from the configured `travelling_time_down` and `travelling_time_up` and stays assumed.
+A restored position is reported as an assumed state until the cover receives a position from the KNX bus or is moved. Covers with a `position_state_address` leave the assumed state once the bus reports their position. Covers without one leave it the first time they are moved, as their position is only calculated from the configured `travelling_time_down` and `travelling_time_up` instead of read from the bus.
 
 Cover entities can be created from the frontend in the KNX panel or via YAML.
 

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -1054,6 +1054,10 @@ Unlike most KNX devices, Home Assistant defines 0% as closed and 100% as fully o
 Home Assistant will, by default, `close` a cover by moving it in the `DOWN` direction in the KNX nomenclature, and `open` a cover by moving it in the `UP` direction.
 {% endnote %}
 
+Cover entities restore their last known position and tilt angle after Home Assistant is restarted. Covers that have a `position_state_address` or `angle_state_address` configured request their current state from the KNX bus according to their state updater configuration.
+
+When no `position_state_address` is configured, the position can't be read from the KNX bus. It is only calculated from the configured `travelling_time_down` and `travelling_time_up`, so the cover reports an assumed state.
+
 Cover entities can be created from the frontend in the KNX panel or via YAML.
 
 {% details "Configuration of KNX cover entities via YAML" %}


### PR DESCRIPTION
## Proposed change

Documents the new KNX cover state behavior added in home-assistant/core#177216.

KNX covers now restore their last known position and tilt angle after a Home Assistant restart. Covers with a `position_state_address` or `angle_state_address` still request their current state from the KNX bus. Covers without a `position_state_address` can't read their position back from the bus — it is only calculated from the configured travel times — so those covers now report an assumed state.

This adds a short paragraph to the Cover section of the KNX integration page, matching the restore-behavior notes already present for the other KNX platforms (date, number, switch, etc.).

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#177216
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
