### PR TITLE
Add Ridder HortiMaX Pro (HortOS) integration

### DIFF
--- a/source/_integrations/hortimax.markdown
+++ b/source/_integrations/hortimax.markdown
@@ -19,8 +19,8 @@ The **Ridder HortiMaX Pro** {% term integration %} reads measurements from
 [Ridder](https://www.ridder.com/) greenhouse process controllers through the
 HortOS Automation API.
 
-A HortiMaX Pro controller runs the climate, irrigation, screening and lighting
-of a greenhouse. This integration makes everything the controller measures —
+A HortiMaX Pro controller runs the climate, irrigation, screening, and
+lighting of a greenhouse. This integration makes everything the controller measures —
 air and pipe temperatures, humidity, vent and screen positions, irrigation
 volumes, weather station readings, gas and electricity use — available in Home
 Assistant as sensors.
@@ -31,7 +31,7 @@ HortiMaX Pro.
 
 {% important %}
 This is a community-built integration. It is not an official Ridder product,
-it is not certified by Ridder, and Ridder does not support it.
+is not certified by Ridder, and Ridder does not support it.
 
 Ridder's support covers the HortOS Automation API itself. Anything about this
 integration is a matter for the Home Assistant community.
@@ -48,9 +48,9 @@ using them is separate from installing this integration.
 
 {% configuration_basic %}
 API key:
-  description: "The API key for the HortOS Automation API, which gives access to every controller of your organisation."
+  description: "The API key for the HortOS Automation API, which gives access to every controller in your organization."
 API base URL:
-  description: "Leave this at the default to use the HortOS cloud API. Change it only if you run HortOS on-premise, in which case enter the address of that server."
+  description: "Leave this at the default to use the HortOS cloud API. Change it only if you run HortOS on premises, in which case enter the address of that server."
 {% endconfiguration_basic %}
 
 One config entry covers a whole organisation, so all controllers your API key
@@ -106,8 +106,9 @@ per key; if you use the same key elsewhere, the two can interfere.
 
 ### A sensor is missing
 
-Readouts that could not be classified are created disabled. Open the device
-page, select **+ x entities not shown**, and enable the sensor you need.
+Readouts that could not be classified are disabled by default. Open the device
+page, select the line that shows how many entities are hidden (for example,
+**+ 12 entities not shown**), and then enable the sensor you need.
 
 If a readout is missing entirely, the controller is not reporting it through
 the API. Check in HortiMaX Pro whether the source is enabled.

--- a/source/_integrations/hortimax.markdown
+++ b/source/_integrations/hortimax.markdown
@@ -98,6 +98,9 @@ value does not change keeps its previous timestamp for up to five minutes.
 - The integration talks to the HortOS cloud API. An on-premises HortOS server
   cannot be addressed directly yet, which only matters if your organization has
   no cloud endpoint.
+- If your API key reaches several controllers and one of them becomes
+  unreachable, the entities of all of them go unavailable until the next
+  successful update, not just those of the failing controller.
 
 ## Troubleshooting
 

--- a/source/_integrations/hortimax.markdown
+++ b/source/_integrations/hortimax.markdown
@@ -53,7 +53,7 @@ API base URL:
   description: "Leave this at the default to use the HortOS cloud API. Change it only if you run HortOS on premises, in which case enter the address of that server."
 {% endconfiguration_basic %}
 
-One config entry covers a whole organisation, so all controllers your API key
+One config entry covers a whole organization, so all controllers your API key
 can reach are added at once.
 
 ## Devices and entities
@@ -66,8 +66,9 @@ The integration mirrors the two levels of the HortOS data model:
   its controller.
 - Each **readout** of a source becomes a sensor.
 
-A single controller commonly reports several hundred readouts. Readouts whose
-meaning is understood get a device class, a unit and a sensible display
+A controller reports a few dozen distinct readouts per source, which
+multiplies into several hundred sensors once every source is counted. Readouts
+whose meaning is understood get a device class, a unit and a sensible display
 precision. Readouts that are internal status or override codes are created
 **disabled**, so a controller does not flood your instance with entities that
 mean nothing outside HortiMaX Pro. You can enable any of them from the device
@@ -79,9 +80,9 @@ device.
 
 ## Data updates
 
-The integration polls the HortOS API once a minute per controller. HortOS
-itself refreshes an unchanged readout at most every five minutes, so a value
-that is not moving may keep the same timestamp for a while.
+The integration polls the HortOS API once a minute per controller, which
+matches how often a controller publishes changed readouts. A readout whose
+value does not change keeps its previous timestamp for up to five minutes.
 
 ## Known limitations
 
@@ -93,8 +94,9 @@ that is not moving may keep the same timestamp for a while.
 - Some readouts are encoded as numbers that index a lookup table the API does
   not expose, for example a weather status code. Wind direction is decoded
   into a bearing; the remaining coded readouts are shown as the raw number.
-- Readout names come from the controller and are in English, regardless of
-  the language of your Home Assistant instance.
+- Sensor names are derived from the readout identifiers the controller
+  reports, and are in English regardless of the language of your Home
+  Assistant instance.
 
 ## Troubleshooting
 

--- a/source/_integrations/hortimax.markdown
+++ b/source/_integrations/hortimax.markdown
@@ -49,8 +49,6 @@ using them is separate from installing this integration.
 {% configuration_basic %}
 API key:
   description: "The API key for the HortOS Automation API, which gives access to every controller in your organization."
-API base URL:
-  description: "Leave this at the default to use the HortOS cloud API. Change it only if you run HortOS on premises, in which case enter the address of that server."
 {% endconfiguration_basic %}
 
 One config entry covers a whole organization, so all controllers your API key
@@ -97,6 +95,9 @@ value does not change keeps its previous timestamp for up to five minutes.
 - Sensor names are derived from the readout identifiers the controller
   reports, and are in English regardless of the language of your Home
   Assistant instance.
+- The integration talks to the HortOS cloud API. An on-premises HortOS server
+  cannot be addressed directly yet, which only matters if your organization has
+  no cloud endpoint.
 
 ## Troubleshooting
 

--- a/source/_integrations/hortimax.markdown
+++ b/source/_integrations/hortimax.markdown
@@ -1,0 +1,130 @@
+---
+title: Ridder HortiMaX Pro
+description: Instructions on how to integrate Ridder HortiMaX Pro greenhouse controllers into Home Assistant.
+ha_category:
+  - Sensor
+ha_release: 2026.8
+ha_iot_class: Cloud Polling
+ha_config_flow: true
+ha_codeowners:
+  - '@wildekek'
+ha_domain: hortimax
+ha_platforms:
+  - sensor
+ha_integration_type: hub
+ha_quality_scale: bronze
+---
+
+The **Ridder HortiMaX Pro** {% term integration %} reads measurements from
+[Ridder](https://www.ridder.com/) greenhouse process controllers through the
+HortOS Automation API.
+
+A HortiMaX Pro controller runs the climate, irrigation, screening and lighting
+of a greenhouse. This integration makes everything the controller measures —
+air and pipe temperatures, humidity, vent and screen positions, irrigation
+volumes, weather station readings, gas and electricity use — available in Home
+Assistant as sensors.
+
+The integration is **read-only**: it never writes setpoints or otherwise
+changes how the controller runs the greenhouse. Growing decisions stay in
+HortiMaX Pro.
+
+{% important %}
+This is a community-built integration. It is not an official Ridder product,
+it is not certified by Ridder, and Ridder does not support it.
+
+Ridder's support covers the HortOS Automation API itself. Anything about this
+integration is a matter for the Home Assistant community.
+{% endimportant %}
+
+## Prerequisites
+
+You need an API key for the HortOS Automation API. Request one from your
+Ridder account manager; it is not something you can generate yourself in the
+HortiMaX Pro interface. The API key and the API are Ridder's; obtaining and
+using them is separate from installing this integration.
+
+{% include integrations/config_flow.md %}
+
+{% configuration_basic %}
+API key:
+  description: "The API key for the HortOS Automation API, which gives access to every controller of your organisation."
+API base URL:
+  description: "Leave this at the default to use the HortOS cloud API. Change it only if you run HortOS on-premise, in which case enter the address of that server."
+{% endconfiguration_basic %}
+
+One config entry covers a whole organisation, so all controllers your API key
+can reach are added at once.
+
+## Devices and entities
+
+The integration mirrors the two levels of the HortOS data model:
+
+- Each **controller** becomes a device.
+- Each **source** inside a controller — a weather station, a ventilation
+  group, a valve group, a screen, a meter — becomes its own device, linked to
+  its controller.
+- Each **readout** of a source becomes a sensor.
+
+A single controller commonly reports several hundred readouts. Readouts whose
+meaning is understood get a device class, a unit and a sensible display
+precision. Readouts that are internal status or override codes are created
+**disabled**, so a controller does not flood your instance with entities that
+mean nothing outside HortiMaX Pro. You can enable any of them from the device
+page if you know what a particular code means.
+
+Sensors whose identifier ends in `ActualSetting` report a configured setpoint
+rather than a measurement, and are shown in the diagnostic section of their
+device.
+
+## Data updates
+
+The integration polls the HortOS API once a minute per controller. HortOS
+itself refreshes an unchanged readout at most every five minutes, so a value
+that is not moving may keep the same timestamp for a while.
+
+## Known limitations
+
+- The HortOS Automation API is still evolving, and Ridder does not guarantee
+  backward compatibility for community integrations. An API change can
+  therefore rename, alter, or remove sensors between releases.
+- The integration is read-only. There is no way to change a setpoint from
+  Home Assistant, by design.
+- Some readouts are encoded as numbers that index a lookup table the API does
+  not expose, for example a weather status code. Wind direction is decoded
+  into a bearing; the remaining coded readouts are shown as the raw number.
+- Readout names come from the controller and are in English, regardless of
+  the language of your Home Assistant instance.
+
+## Troubleshooting
+
+### The integration cannot connect
+
+Check that the API key is still valid and that the HortOS API is reachable
+from your Home Assistant instance. The API allows 100 requests per 15 seconds
+per key; if you use the same key elsewhere, the two can interfere.
+
+### A sensor is missing
+
+Readouts that could not be classified are created disabled. Open the device
+page, select **+ x entities not shown**, and enable the sensor you need.
+
+If a readout is missing entirely, the controller is not reporting it through
+the API. Check in HortiMaX Pro whether the source is enabled.
+
+### Where to ask for help
+
+Ridder supports the HortOS Automation API, not this integration. Take
+questions about the API — including how to obtain an API key or why a
+controller reports a particular value — to your Ridder account manager.
+
+For the integration itself, use the Home Assistant
+[community forum](https://community.home-assistant.io/) or the issue tracker
+linked in the sidebar of this page.
+
+## Removing the integration
+
+This integration follows standard integration removal. No extra steps are
+required.
+
+{% include integrations/remove_device_service.md %}


### PR DESCRIPTION
## Proposed change

Documentation for the new **Ridder HortiMaX Pro** (`hortimax`) integration, which reads greenhouse process controllers through the Ridder HortOS Automation API. Read-only: it exposes what the controller measures as sensors and never writes setpoints.

The page covers the Bronze docs rules — high-level description, prerequisites, installation via config flow, configuration parameters, data updates, known limitations, troubleshooting and removal.

Ridder has reviewed the plan to publish and asked that the integration be positioned as a community initiative rather than an official or certified product, with their support boundary at the API layer. The page states that in an `{% important %}` callout below the introduction, routes support questions in a "Where to ask for help" section, and notes under known limitations that the API is still evolving without a backward-compatibility guarantee for community integrations.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#177247
- Link to parent pull request in the Brands repository: home-assistant/brands#10844
- This PR fixes or closes issue: fixes #

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting).
- [x] The documentation follows the Home Assistant documentation [standards](https://developers.home-assistant.io/docs/documenting/standards).