### PR TITLE
Update features_position description in tile.markdown

### DIFF
--- a/source/_dashboards/tile.markdown
+++ b/source/_dashboards/tile.markdown
@@ -101,7 +101,7 @@ features:
   type: list
 features_position:
   required: false
-  description: Position of the features on the tile card. Can be `bottom` or `inline`. When set to `inline`, the first feature is displayed next to the name and any remaining features are displayed below it. `inline` is not compatible with the `vertical` option.
+  description: Position of the features on the tile card. Can be `bottom` or `inline`. When set to `inline`, the first feature is displayed next to the name and any remaining features are displayed below it, two per row. A feature that is alone on a row takes the full width. `inline` is not compatible with the `vertical` option.
   type: string
   default: bottom
 

--- a/source/_dashboards/tile.markdown
+++ b/source/_dashboards/tile.markdown
@@ -101,7 +101,7 @@ features:
   type: list
 features_position:
   required: false
-  description: Position of the features on the tile card. Can be `bottom` or `inline`. Only the first feature will be displayed when the option is set to `inline`. `inline` is not compatible with the `vertical` option.
+  description: Position of the features on the tile card. Can be `bottom` or `inline`. When set to inline, the first feature is displayed next to the name and any remaining features are displayed below it. `inline` is not compatible with the `vertical` option.
   type: string
   default: bottom
 

--- a/source/_dashboards/tile.markdown
+++ b/source/_dashboards/tile.markdown
@@ -101,7 +101,7 @@ features:
   type: list
 features_position:
   required: false
-  description: Position of the features on the tile card. Can be `bottom` or `inline`. When set to inline, the first feature is displayed next to the name and any remaining features are displayed below it. `inline` is not compatible with the `vertical` option.
+  description: Position of the features on the tile card. Can be `bottom` or `inline`. When set to `inline`, the first feature is displayed next to the name and any remaining features are displayed below it. `inline` is not compatible with the `vertical` option.
   type: string
   default: bottom
 


### PR DESCRIPTION
## Proposed change

The tile card's `features_position` option is documented as showing only the
first feature when set to `inline`. With home-assistant/frontend#53310 the
first feature is displayed next to the name and any remaining features are
displayed below it, so this description no longer matches the behaviour.

This updates the description of `features_position` on the tile card page.
The note about `inline` not being compatible with `vertical` is unchanged.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/53310
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards](https://developers.home-assistant.io/docs/documenting/standards).