### PR TITLE
Document `update_entity`'s debounce

### DIFF
--- a/source/_includes/common-tasks/define_custom_polling.md
+++ b/source/_includes/common-tasks/define_custom_polling.md
@@ -16,3 +16,5 @@ To add the automation:
    - Add the entities you want to poll to the **Entity** field. The `homeassistant.update_entity` action only supports targeting by entity. Selecting an area, device, or label is not supported.
    ![Update entity](/images/screenshots/custom_polling_02.png)
 4. Save your new automation to poll for data.
+
+Note that that `update_entity` has a 10-second debounce, which means that entities can not be updated more frequently than once every ten seconds through this method.

--- a/source/_includes/common-tasks/define_custom_polling.md
+++ b/source/_includes/common-tasks/define_custom_polling.md
@@ -17,4 +17,4 @@ To add the automation:
    ![Update entity](/images/screenshots/custom_polling_02.png)
 4. Save your new automation to poll for data.
 
-Note that that `update_entity` has a 10-second debounce, which means that entities can not be updated more frequently than once every ten seconds through this method.
+Note that `homeassistant.update_entity` has a 10-second debounce, which means that entities cannot be updated more frequently than once every ten seconds through this method.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

I was trying to make my HomeWizard P1 meter update more frequently than once every ten seconds, but the suggested route in the docs doesn't work because `update_entity` appears to debounce its calls.

See also, among others, issues like home-assistant/core#164275


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Related discussion: home-assistant/core#164275

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - => I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
