### PR TITLE
Document ViCare DHW circulation schedule and operation mode support

### DIFF
--- a/source/_actions/vicare.set_circulation_schedule.markdown
+++ b/source/_actions/vicare.set_circulation_schedule.markdown
@@ -19,23 +19,38 @@ To set the circulation schedule from an automation or a script:
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the water heater entity you want to control.
 6. From the actions shown for that target, select **Viessmann ViCare: Set circulation schedule**.
-7. Enter the **Schedule**.
+7. For every day of the week, add the time slots you want. Days with no circulation still need to be included, just leave them empty.
 8. Select **Save**.
 
 ### Options in the UI
 
 {% options_ui %}
-Schedule:
-  description: >
-    A dictionary with one key per weekday (`mon` through `sun`). Each value
-    is a list of time slots for that day, with a maximum of 4 slots per
-    day. See [Good to know](#good-to-know) for the fields each slot needs.
+Monday:
+  description: The circulation slots for Monday. See [Good to know](#good-to-know) for the fields each slot needs.
+  required: true
+Tuesday:
+  description: The circulation slots for Tuesday.
+  required: true
+Wednesday:
+  description: The circulation slots for Wednesday.
+  required: true
+Thursday:
+  description: The circulation slots for Thursday.
+  required: true
+Friday:
+  description: The circulation slots for Friday.
+  required: true
+Saturday:
+  description: The circulation slots for Saturday.
+  required: true
+Sunday:
+  description: The circulation slots for Sunday.
   required: true
 {% endoptions_ui %}
 
 {% include actions/yaml_header.md %}
 
-In YAML, refer to this action as `vicare.set_circulation_schedule`. A basic example looks like this:
+In YAML, refer to this action as `vicare.set_circulation_schedule`. Each weekday field is a list of time slots for that day. A basic example looks like this:
 
 {% example %}
 action: |
@@ -43,18 +58,17 @@ action: |
   target:
     entity_id: water_heater.main_water_heater
   data:
-    schedule:
-      mon:
-        - start: "06:00"
-          end: "22:00"
-          mode: "on"
-          position: 0
-      tue: []
-      wed: []
-      thu: []
-      fri: []
-      sat: []
-      sun: []
+    monday:
+      - start_time: "06:00"
+        end_time: "22:00"
+        mode: "on"
+        position: 0
+    tuesday: []
+    wednesday: []
+    thursday: []
+    friday: []
+    saturday: []
+    sunday: []
 {% endexample %}
 
 This runs the circulation pump on Monday from 6:00 AM to 10:00 PM and turns it off for the rest of the week.
@@ -62,91 +76,97 @@ This runs the circulation pump on Monday from 6:00 AM to 10:00 PM and turns it o
 ### Options in YAML
 
 {% options_yaml %}
-schedule:
+monday:
   description: >
-    A dictionary with one key per weekday (`mon` through `sun`). Each value
-    is a list of time slots for that day, with a maximum of 4 slots per
-    day. See [Good to know](#good-to-know) for the fields each slot needs.
+    The circulation slots for Monday. See [Good to know](#good-to-know)
+    for the fields each slot needs.
   required: true
-  type: map
+  type: list
+tuesday:
+  description: >
+    The circulation slots for Tuesday.
+  required: true
+  type: list
+wednesday:
+  description: >
+    The circulation slots for Wednesday.
+  required: true
+  type: list
+thursday:
+  description: >
+    The circulation slots for Thursday.
+  required: true
+  type: list
+friday:
+  description: >
+    The circulation slots for Friday.
+  required: true
+  type: list
+saturday:
+  description: >
+    The circulation slots for Saturday.
+  required: true
+  type: list
+sunday:
+  description: >
+    The circulation slots for Sunday.
+  required: true
+  type: list
 {% endoptions_yaml %}
 
 {% include actions/targets.md domain="water_heater" %}
 
 ## Good to know
 
-Each time slot in the schedule is a mapping with the following keys:
+Each time slot in a day's list is a mapping with the following keys:
 
-- `start`: Required. The time the pump turns on, as `HH:MM`, on a 10-minute resolution, such as `06:00` or `06:10`.
-- `end`: Required. The time the pump turns off, as `HH:MM`, on a 10-minute resolution. Use `24:00` for midnight.
-- `mode`: Required. Always `on`.
+- `start_time`: Required. The time the pump turns on, as `HH:MM`, on a 10-minute resolution, such as `06:00` or `06:10`.
+- `end_time`: Required. The time the pump turns off, as `HH:MM`, on a 10-minute resolution. Use `24:00` for midnight.
+- `mode`: Required. The circulation mode for this slot. Which modes your device supports varies by model, for example `on`, `5/25-cycles`, or `5/10-cycles`. If you use a mode your device doesn't support, the action fails and the error message lists the modes it does support.
 - `position`: Required. The slot's position among the day's slots, starting at `0`.
 
-A day with no scheduled circulation must still be included in the schedule as an empty list, for example `tue: []`.
+All seven weekday fields are required on every call, even for days with no scheduled circulation. Use an empty list, for example `sunday: []`, for those days.
 
-The current schedule is available as the `circulation_schedule` attribute of the water heater {% term entity %}. Not all devices support a circulation pump. If yours doesn't, this attribute is absent.
+The maximum number of slots per day depends on your device. If you exceed it, the action fails and the error message includes your device's actual limit.
 
-A text {% term helper %} used to back up the schedule can hold at most 255 characters. A schedule with only a few time slots fits easily, but one with several slots on every day of the week may not. If the backup step runs into this limit, it fails and the schedule is left in place, so you won't lose your regular schedule, but the pump also won't turn off. To fit more, keep the helper's **Maximum length** at 255, the maximum a text helper supports.
+The current schedule is available as the `circulation_schedule` attribute of the water heater {% term entity %}. Not all devices support a circulation pump. If yours doesn't, this attribute is absent. Its field names (`mon` through `sun`, with `start`/`end` per slot) don't match this action's fields (`monday` through `sunday`, with `start_time`/`end_time`), so you can't pass its value straight back into this action — remap the keys first if you want to restore a saved schedule.
 
 {% include actions/try_it.md %}
 
 {% include actions/more_examples.md %}
 
-### Automation: Back up the schedule and turn off circulation when you leave
+### Automation: Turn off circulation when you leave
 
-This automation saves your current circulation schedule to a text helper and then clears the schedule, so the pump stays off while nobody is home. Pair it with the automation in the next section, which restores the saved schedule once someone gets back.
-
-This requires a text {% term helper %} to hold the backup. If you don't have one yet, go to {% my helpers title="**Settings** > **Devices & services** > **Helpers**" %}, select **Create helper** > **Text**, and set **Maximum length** to `255`. This example assumes the helper is named `input_text.circulation_schedule_backup`.
-
-- Trigger: everyone leaves home
-- Action: set the value of the text helper
-  - Target: the text helper you created
-  - Value: the current circulation schedule
-- Action: set the circulation schedule
-  - Target: the main water heater entity
-  - Schedule: no time slots on any day
+This automation stops the circulation pump as soon as everyone leaves home, so it doesn't run while nobody's there to use it.
 
 {% details "Show example YAML" %}
 
 {% example %}
 automation: |
-  alias: "Back up and turn off circulation pump when away"
+  alias: "Turn off circulation pump when away"
   triggers:
     - trigger: state
       entity_id: zone.home
       to: "0"
   actions:
-    - action: input_text.set_value
-      target:
-        entity_id: input_text.circulation_schedule_backup
-      data:
-        value: >-
-          {{ state_attr('water_heater.main_water_heater',
-             'circulation_schedule') | to_json }}
     - action: vicare.set_circulation_schedule
       target:
         entity_id: water_heater.main_water_heater
       data:
-        schedule:
-          mon: []
-          tue: []
-          wed: []
-          thu: []
-          fri: []
-          sat: []
-          sun: []
+        monday: []
+        tuesday: []
+        wednesday: []
+        thursday: []
+        friday: []
+        saturday: []
+        sunday: []
 {% endexample %}
 
 {% enddetails %}
 
 ### Automation: Restore the schedule when you get home
 
-This automation restores the schedule saved by the automation above once someone returns home.
-
-- Trigger: someone arrives home
-- Action: set the circulation schedule
-  - Target: the main water heater entity
-  - Schedule: the schedule stored in the text helper
+This automation puts a fixed weekly schedule back once someone returns. Adjust the times to match the hours you actually want the pump to run.
 
 {% details "Show example YAML" %}
 
@@ -162,9 +182,41 @@ automation: |
       target:
         entity_id: water_heater.main_water_heater
       data:
-        schedule: >-
-          {{ states('input_text.circulation_schedule_backup')
-             | from_json }}
+        monday:
+          - start_time: "06:00"
+            end_time: "22:00"
+            mode: "on"
+            position: 0
+        tuesday:
+          - start_time: "06:00"
+            end_time: "22:00"
+            mode: "on"
+            position: 0
+        wednesday:
+          - start_time: "06:00"
+            end_time: "22:00"
+            mode: "on"
+            position: 0
+        thursday:
+          - start_time: "06:00"
+            end_time: "22:00"
+            mode: "on"
+            position: 0
+        friday:
+          - start_time: "06:00"
+            end_time: "22:00"
+            mode: "on"
+            position: 0
+        saturday:
+          - start_time: "08:00"
+            end_time: "22:00"
+            mode: "on"
+            position: 0
+        sunday:
+          - start_time: "08:00"
+            end_time: "22:00"
+            mode: "on"
+            position: 0
 {% endexample %}
 
 {% enddetails %}

--- a/source/_actions/vicare.set_circulation_schedule.markdown
+++ b/source/_actions/vicare.set_circulation_schedule.markdown
@@ -86,15 +86,22 @@ A day with no scheduled circulation must still be included in the schedule as an
 
 The current schedule is available as the `circulation_schedule` attribute of the water heater {% term entity %}. Not all devices support a circulation pump. If yours doesn't, this attribute is absent.
 
+A text {% term helper %} used to back up the schedule can hold at most 255 characters. A schedule with only a few time slots fits easily, but one with several slots on every day of the week may not. If the backup step runs into this limit, it fails and the schedule is left in place, so you won't lose your regular schedule, but the pump also won't turn off. To fit more, keep the helper's **Maximum length** at 255, the maximum a text helper supports.
+
 {% include actions/try_it.md %}
 
 {% include actions/more_examples.md %}
 
-### Automation: Turn off the circulation pump while you're away
+### Automation: Back up the schedule and turn off circulation when you leave
 
-This automation clears the circulation schedule when everyone leaves home, then you can pair it with a second automation that restores your regular schedule when someone returns.
+This automation saves your current circulation schedule to a text helper and then clears the schedule, so the pump stays off while nobody is home. Pair it with the automation in the next section, which restores the saved schedule once someone gets back.
+
+This requires a text {% term helper %} to hold the backup. If you don't have one yet, go to {% my helpers title="**Settings** > **Devices & services** > **Helpers**" %}, select **Create helper** > **Text**, and set **Maximum length** to `255`. This example assumes the helper is named `input_text.circulation_schedule_backup`.
 
 - Trigger: everyone leaves home
+- Action: set the value of the text helper
+  - Target: the text helper you created
+  - Value: the current circulation schedule
 - Action: set the circulation schedule
   - Target: the main water heater entity
   - Schedule: no time slots on any day
@@ -103,12 +110,19 @@ This automation clears the circulation schedule when everyone leaves home, then 
 
 {% example %}
 automation: |
-  alias: "Turn off circulation pump when away"
+  alias: "Back up and turn off circulation pump when away"
   triggers:
     - trigger: state
       entity_id: zone.home
       to: "0"
   actions:
+    - action: input_text.set_value
+      target:
+        entity_id: input_text.circulation_schedule_backup
+      data:
+        value: >-
+          {{ state_attr('water_heater.main_water_heater',
+             'circulation_schedule') | to_json }}
     - action: vicare.set_circulation_schedule
       target:
         entity_id: water_heater.main_water_heater
@@ -121,6 +135,36 @@ automation: |
           fri: []
           sat: []
           sun: []
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Restore the schedule when you get home
+
+This automation restores the schedule saved by the automation above once someone returns home.
+
+- Trigger: someone arrives home
+- Action: set the circulation schedule
+  - Target: the main water heater entity
+  - Schedule: the schedule stored in the text helper
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Restore circulation schedule when home"
+  triggers:
+    - trigger: state
+      entity_id: zone.home
+      from: "0"
+  actions:
+    - action: vicare.set_circulation_schedule
+      target:
+        entity_id: water_heater.main_water_heater
+      data:
+        schedule: >-
+          {{ states('input_text.circulation_schedule_backup')
+             | from_json }}
 {% endexample %}
 
 {% enddetails %}

--- a/source/_actions/vicare.set_circulation_schedule.markdown
+++ b/source/_actions/vicare.set_circulation_schedule.markdown
@@ -1,0 +1,130 @@
+---
+title: "Set circulation schedule"
+action: vicare.set_circulation_schedule
+domain: vicare
+description: "Sets the DHW circulation pump weekly schedule."
+related_actions:
+  - vicare.set_vicare_mode
+---
+
+Use this action to configure the weekly schedule of the domestic hot water (<abbr title="domestic hot water">DHW</abbr>) circulation pump on your Viessmann device. The circulation pump keeps hot water moving through your pipes so it reaches the tap faster, at the cost of extra energy use, so most people only run it during the hours they actually need instant hot water.
+
+{% include actions/ui_header.md %}
+
+To set the circulation schedule from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the water heater entity you want to control.
+6. From the actions shown for that target, select **Viessmann ViCare: Set circulation schedule**.
+7. Enter the **Schedule**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Schedule:
+  description: >
+    A dictionary with one key per weekday (`mon` through `sun`). Each value
+    is a list of time slots for that day, with a maximum of 4 slots per
+    day. See [Good to know](#good-to-know) for the fields each slot needs.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `vicare.set_circulation_schedule`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: vicare.set_circulation_schedule
+  target:
+    entity_id: water_heater.main_water_heater
+  data:
+    schedule:
+      mon:
+        - start: "06:00"
+          end: "22:00"
+          mode: "on"
+          position: 0
+      tue: []
+      wed: []
+      thu: []
+      fri: []
+      sat: []
+      sun: []
+{% endexample %}
+
+This runs the circulation pump on Monday from 6:00 AM to 10:00 PM and turns it off for the rest of the week.
+
+### Options in YAML
+
+{% options_yaml %}
+schedule:
+  description: >
+    A dictionary with one key per weekday (`mon` through `sun`). Each value
+    is a list of time slots for that day, with a maximum of 4 slots per
+    day. See [Good to know](#good-to-know) for the fields each slot needs.
+  required: true
+  type: map
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="water_heater" %}
+
+## Good to know
+
+Each time slot in the schedule is a mapping with the following keys:
+
+- `start`: Required. The time the pump turns on, as `HH:MM`, on a 10-minute resolution, such as `06:00` or `06:10`.
+- `end`: Required. The time the pump turns off, as `HH:MM`, on a 10-minute resolution. Use `24:00` for midnight.
+- `mode`: Required. Always `on`.
+- `position`: Required. The slot's position among the day's slots, starting at `0`.
+
+A day with no scheduled circulation must still be included in the schedule as an empty list, for example `tue: []`.
+
+The current schedule is available as the `circulation_schedule` attribute of the water heater {% term entity %}. Not all devices support a circulation pump. If yours doesn't, this attribute is absent.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: Turn off the circulation pump while you're away
+
+This automation clears the circulation schedule when everyone leaves home, then you can pair it with a second automation that restores your regular schedule when someone returns.
+
+- Trigger: everyone leaves home
+- Action: set the circulation schedule
+  - Target: the main water heater entity
+  - Schedule: no time slots on any day
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Turn off circulation pump when away"
+  triggers:
+    - trigger: state
+      entity_id: zone.home
+      to: "0"
+  actions:
+    - action: vicare.set_circulation_schedule
+      target:
+        entity_id: water_heater.main_water_heater
+      data:
+        schedule:
+          mon: []
+          tue: []
+          wed: []
+          thu: []
+          fri: []
+          sat: []
+          sun: []
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -88,9 +88,9 @@ Ventilation units are displayed as fans and enable the change of speed and use o
 
 Represents the domestic hot water controls of your device.
 
-{% note %}
-It is not possible to turn on/off water heating via the water heater {% term integration %} since this would conflict with the operation modes of the heating integration. Therefore, the operation mode of that integration is just available as an attribute and cannot be modified.
-{% endnote %}
+On devices that support it, you can turn domestic hot water on or off directly from this {% term entity %}. Turning it off does not affect space heating on devices that also heat your home.
+
+If your device has a circulation pump, its weekly schedule is available as the `circulation_schedule` attribute of this {% term entity %}. Use the [Set circulation schedule](/actions/vicare.set_circulation_schedule/) action to change it.
 
 ### Sensor
 
@@ -112,7 +112,7 @@ Select entities allow configuring the domestic hot water (<abbr title="domestic 
 
 ## Climate and water heater control
 
-The ViCare integration also provides the standard [climate](/integrations/climate/) and [water_heater](/integrations/water_heater/) actions. The ViCare integration provides `set_temperature`, `set_hvac_mode`, and `set_preset_mode` for climate entities, and `set_temperature` for the water heater. A few of these behave in ViCare-specific ways.
+The ViCare integration also provides the standard [climate](/integrations/climate/) and [water_heater](/integrations/water_heater/) actions. The ViCare integration provides `set_temperature`, `set_hvac_mode`, and `set_preset_mode` for climate entities, and `set_temperature` and, on devices that support it, `set_operation_mode` for the water heater. A few of these behave in ViCare-specific ways.
 
 ### Setting the temperature
 
@@ -129,6 +129,10 @@ The ViCare integration maps the Home Assistant HVAC modes to Viessmann operation
 ### Setting the preset mode
 
 The `climate.set_preset_mode` action supports the *eco* and *comfort* preset modes. These are identical to the respective Viessmann programs and are only active temporarily for 8 hours. Eco mode reduces the target temperature by 3°C, whereas Comfort mode sets the target temperature to a configurable value. Consult your heating device manual for more information.
+
+### Setting the water heater operation mode
+
+On devices that support it, the `water_heater.set_operation_mode` action turns domestic hot water `on` or `off`. If your device also heats your home, turning domestic hot water off keeps space heating running instead of disabling it entirely.
 
 ## Troubleshooting
 

--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -88,7 +88,7 @@ Ventilation units are displayed as fans and enable the change of speed and use o
 
 Represents the domestic hot water controls of your device.
 
-On devices that support it, you can turn domestic hot water on or off directly from this {% term entity %}. Turning it off does not affect space heating on devices that also heat your home.
+On devices that support it, you can set the domestic hot water operation mode directly from this {% term entity %}. Both the entity's state and its available modes mirror your device's own operating modes, such as `dhw`, `heating`, `dhw_and_heating`, or `standby`, rather than a simple on/off. Modes that include domestic hot water (for example `dhw` or `dhw_and_heating`) don't disable space heating on devices that also heat your home.
 
 If your device has a circulation pump, its weekly schedule is available as the `circulation_schedule` attribute of this {% term entity %}. Use the [Set circulation schedule](/actions/vicare.set_circulation_schedule/) action to change it.
 
@@ -132,7 +132,7 @@ The `climate.set_preset_mode` action supports the *eco* and *comfort* preset mod
 
 ### Setting the water heater operation mode
 
-On devices that support it, the `water_heater.set_operation_mode` action turns domestic hot water `on` or `off`. If your device also heats your home, turning domestic hot water off keeps space heating running instead of disabling it entirely.
+On devices that support it, the `water_heater.set_operation_mode` action sets the mode to one of the values listed in the entity's `operation_list`, which mirrors your device's own operating modes (for example `dhw`, `heating`, `dhw_and_heating`, or `standby`) rather than a simple on/off. Which modes are available depends on your device's circuit; on a device that also heats your home, use a mode like `dhw_and_heating` to keep both running, or `heating` to run space heating without domestic hot water.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Proposed change

Documents the new `vicare.set_circulation_schedule` action and water heater operation mode support added in home-assistant/core#177282.

- Adds `source/_actions/vicare.set_circulation_schedule.markdown` documenting the new action.
- Updates `source/_integrations/vicare.markdown`:
  - Removes the outdated note saying DHW can't be turned on/off from the water heater entity.
  - Documents the new `circulation_schedule` state attribute.
  - Documents the new `water_heater.set_operation_mode` support and how it interacts with space heating.

## Type of change

- [x] Adding new / missing documentation

## Additional information

- This PR is related to core PR: home-assistant/core#177282

## Checklist

- [x] The documentation follows the Home Assistant documentation standards.