### PR TITLE
Document state trigger any state option

### DIFF
--- a/source/_triggers/state.markdown
+++ b/source/_triggers/state.markdown
@@ -108,7 +108,7 @@ This trigger watches one or more entities:
 
 - If you do not set any of **From**, **To**, `not_from`, or `not_to`, this trigger fires on all state changes. It also fires when only an attribute changes.
 - If you set one of the options **From** (`from`), **To** (`to`), `not_from`, or `not_to`, attribute-only changes do not fire the trigger.
-- In the UI, **Any state (ignoring attribute changes)** for **From** or **To** matches any previous or new state value, but only when the entity state changes. In YAML, this is shown as `from: null` or `to: null`. This is useful for sensors that update attributes often, while their main state changes less often.
+- In the UI, **Any state (ignoring attribute changes)** for **From** or **To** means “match any state, but only when the state changes.” In YAML, this appears as `from: null` or `to: null` (the key is present, but the value is empty), which prevents attribute-only changes from firing. This is useful for sensors that update attributes often while their main state changes less often.
 - You cannot combine the options `from` with `not_from`, or `to` with `not_to`.
 - If you use the **For** (`for`) option, the timer resets if Home Assistant restarts or automations reload.
 

--- a/source/_triggers/state.markdown
+++ b/source/_triggers/state.markdown
@@ -108,6 +108,7 @@ This trigger watches one or more entities:
 
 - If you do not set any of **From**, **To**, `not_from`, or `not_to`, this trigger fires on all state changes. It also fires when only an attribute changes.
 - If you set one of the options **From** (`from`), **To** (`to`), `not_from`, or `not_to`, attribute-only changes do not fire the trigger.
+- In the UI, **Any state (ignoring attribute changes)** for **From** or **To** matches any previous or new state value, but only when the entity state changes. In YAML, this is shown as `from: null` or `to: null`. This is useful for sensors that update attributes often, while their main state changes less often.
 - You cannot combine the options `from` with `not_from`, or `to` with `not_to`.
 - If you use the **For** (`for`) option, the timer resets if Home Assistant restarts or automations reload.
 
@@ -171,6 +172,37 @@ automation: |
         entity_id: notify.my_device
       data:
         message: "Sam has arrived home."
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: send a notification when a sensor value stops changing
+
+If you want to know when a sensor value has not changed for a period, use **Any state (ignoring attribute changes)** for **To** and set **For** to the amount of time you want to wait.
+
+- **Trigger**: State
+  - **Entity**: Power sensor (`sensor.current_power`)
+  - **To**: Any state (ignoring attribute changes)
+  - **For**: 30 minutes
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for a sensor value that stops changing" %}
+
+{% example %}
+automation: |
+  alias: "Notify me when power stops updating"
+  triggers:
+    - trigger: state
+      entity_id: sensor.current_power
+      to: null
+      for: "00:30:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "The power sensor value has not changed for 30 minutes."
 {% endexample %}
 
 {% enddetails %}

--- a/source/_triggers/state.markdown
+++ b/source/_triggers/state.markdown
@@ -108,7 +108,7 @@ This trigger watches one or more entities:
 
 - If you do not set any of **From**, **To**, `not_from`, or `not_to`, this trigger fires on all state changes. It also fires when only an attribute changes.
 - If you set one of the options **From** (`from`), **To** (`to`), `not_from`, or `not_to`, attribute-only changes do not fire the trigger.
-- In the UI, **Any state (ignoring attribute changes)** for **From** or **To** means “match any state, but only when the state changes.” In YAML, this appears as `from: null` or `to: null` (the key is present, but the value is empty), which prevents attribute-only changes from firing. This is useful for sensors that update attributes often while their main state changes less often.
+- In the UI, **Any state (ignoring attribute changes)** for **From** or **To** means "match any state, but only when the state changes." In YAML, this appears as `from: null` or `to: null` (the key is present, but the value is empty), which prevents attribute-only changes from firing. This is useful for sensors that update attributes often while their main state changes less often.
 - You cannot combine the options `from` with `not_from`, or `to` with `not_to`.
 - If you use the **For** (`for`) option, the timer resets if Home Assistant restarts or automations reload.
 

--- a/source/_triggers/state.markdown
+++ b/source/_triggers/state.markdown
@@ -71,11 +71,11 @@ entity_id:
   required: true
   type: [string, list]
 from:
-  description: The starting state or starting attribute value to match. You can use one state or a list of states.
+  description: The starting state or starting attribute value to match. You can use one state, a list of states, or `null` to match any starting state while ignoring attribute-only changes.
   required: false
   type: [string, list]
 to:
-  description: The new state or new attribute value to match. You can use one state or a list of states.
+  description: The new state or new attribute value to match. You can use one state, a list of states, or `null` to match any new state while ignoring attribute-only changes.
   required: false
   type: [string, list]
 not_from:


### PR DESCRIPTION
## Proposed change

Documents how **Any state (ignoring attribute changes)** in the State trigger maps to `from: null` or `to: null` in YAML.

Adds a small example that shows how to send a notification when a sensor value has not changed for a period while ignoring attribute-only updates.

Related to [HA Discord thread](https://discord.com/channels/330944238910963714/1529754798998425670).

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
