### PR TITLE
Clarify choosing automation triggers

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -10,6 +10,14 @@ A trigger is what wakes an automation up. Until something triggers it, an automa
 
 Triggers can be almost anything that happens in your home or in Home Assistant itself. A motion sensor detecting movement. The sun going down. A specific time of day. A person arriving home. A button on a remote being pressed. Even a voice command spoken to Assist. You can give a single automation more than one trigger, and the automation will start as soon as _any_ of them fires.
 
+## Choosing a trigger
+
+When you add a trigger in the automation editor, Home Assistant shows triggers that match what you selected. For many devices and measurements, the best choice is the trigger named after the thing you want to happen. For example, select **Door opened** for a door sensor, **Temperature crossed threshold** for a temperature reading, or **Power crossed threshold** for a power reading.
+
+These specific triggers handle Home Assistant details for you. Measurement triggers, such as temperature and power triggers, compare compatible units automatically. For example, a temperature sensor can report in Fahrenheit while the trigger threshold is set in Celsius.
+
+General triggers, such as **State** and **Numeric state**, are still available. Use them when you need to watch an exact state, use an attribute, work with a trigger that does not have a more specific option, or edit existing YAML.
+
 ## Trigger ID
 
 All triggers can be assigned an optional `id`. If the ID is omitted, it will instead be set to the index of the trigger. The `id` can be referenced from [trigger conditions and actions](/docs/scripts/conditions/#trigger-condition). The `id` does not have to be unique for each trigger, and it can be used to group similar triggers for use later in the automation (such as several triggers of different types that should all turn some entity on).

--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -12,7 +12,7 @@ Triggers can be almost anything that happens in your home or in Home Assistant i
 
 ## Choosing a trigger
 
-When you add a trigger in the automation editor, Home Assistant shows triggers that match what you selected. For many devices and measurements, the best choice is the trigger named after the thing you want to happen. For example, select **Door opened** for a door sensor, **Temperature crossed threshold** for a temperature reading, or **Power crossed threshold** for a power reading.
+After you select **Add trigger** in the automation editor, Home Assistant shows triggers that match the target or type that you selected. For many devices and measurements, the best choice is the trigger named after the thing you want to happen. For example, select **Door opened** for a door sensor, **Temperature crossed threshold** for a temperature reading, or **Power crossed threshold** for a power reading.
 
 These specific triggers handle Home Assistant details for you. Measurement triggers, such as temperature and power triggers, compare compatible units automatically. For example, a temperature sensor can report in Fahrenheit while the trigger threshold is set in Celsius.
 

--- a/source/_triggers/numeric_state.markdown
+++ b/source/_triggers/numeric_state.markdown
@@ -8,7 +8,7 @@ related_triggers:
   - time
 ---
 
-The **Numeric state** trigger is a general trigger for reacting when a numeric value crosses a threshold. Use it when you need to watch an exact entity state or attribute value, or when the automation editor does not offer a trigger named after what you want to watch.
+The **Numeric state** trigger is a general trigger for reacting when a numeric value crosses a threshold. Use it when you need to watch an exact numeric state or attribute value, or when the automation editor does not offer a trigger named after what you want to watch.
 
 If the automation editor shows a trigger named after the measurement you care about, use that one instead. For example, use [Temperature crossed threshold](/triggers/temperature.crossed_threshold/) for temperature readings or [Power crossed threshold](/triggers/power.crossed_threshold/) for power readings. These triggers are easier to read later and can handle compatible units automatically.
 

--- a/source/_triggers/numeric_state.markdown
+++ b/source/_triggers/numeric_state.markdown
@@ -8,7 +8,9 @@ related_triggers:
   - time
 ---
 
-The **Numeric state** trigger is useful when you want an automation to react when a value crosses a threshold. Use it for temperatures, power readings, battery levels, humidity, and other values that matter only when they move above or below a threshold, or into a range.
+The **Numeric state** trigger is a general trigger for reacting when a numeric value crosses a threshold. Use it when you need to watch an exact entity state or attribute value, or when the automation editor does not offer a trigger named after what you want to watch.
+
+If the automation editor shows a trigger named after the measurement you care about, use that one instead. For example, use [Temperature crossed threshold](/triggers/temperature.crossed_threshold/) for temperature readings or [Power crossed threshold](/triggers/power.crossed_threshold/) for power readings. These triggers are easier to read later and can handle compatible units automatically.
 
 {% include triggers/ui_header.md %}
 
@@ -109,6 +111,7 @@ This trigger watches one or more entities selected in the UI options **Entity** 
 
 - This trigger fires when a value crosses a threshold. It does not keep firing while the value stays on the same side of the threshold.
 - If you set both **Above** and **Below**, the trigger fires when the value enters that range.
+- This trigger compares the raw numeric value you enter. It does not convert between units. For measurements with units, use a trigger named after that measurement when one is available.
 - If you use an entity in **Above** (`above`) or **Below** (`below`), Home Assistant compares the value of the watched entity against the value of that entity only when the watched entity updates.
 - If you use **For** (`for`), the timer resets if Home Assistant restarts or automations reload.
 - When you use `value_template`, the `state` variable is the [state object](/docs/configuration/state_object) for the entity you selected with `entity_id`.


### PR DESCRIPTION

## Proposed change

Clarifies how to choose automation triggers in the automation editor. This adds guidance to use triggers named after the device action or measurement when Home Assistant offers one, and explains that measurement-specific triggers can compare compatible units automatically.

It also repositions the Numeric state trigger as a general trigger and notes that it compares raw numeric values without converting units.

Related to [HA Discord comment](https://discord.com/channels/330944238910963714/1475552849835458691/1528744380956147822).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
