### PR TITLE
bosch_shc: add missing documentation sections

### DIFF
--- a/source/_integrations/bosch_shc.markdown
+++ b/source/_integrations/bosch_shc.markdown
@@ -79,6 +79,14 @@ To start the client registration, press and hold the button on the controller un
 
 Get a reminder if a shutter contact stays open for too long, so an open window doesn't go unnoticed.
 
+- **Trigger**: State
+  - **Entity**: Front door (binary sensor)
+  - **To**: On
+  - **For**: `00:10:00`
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+  - **Message**: `The front door has been open for 10 minutes.`
+
 {% details "YAML example for an open-door reminder" %}
 
 {% example %}
@@ -103,6 +111,10 @@ automation: |
 ### Automation: Close covers automatically at sunset
 
 Combine the cover platform with a sun trigger to close your shutters as it gets dark.
+
+- **Trigger**: Sunset
+- **Action**: Close cover
+  - **Target**: Living room shutter
 
 {% details "YAML example for closing covers at sunset" %}
 

--- a/source/_integrations/bosch_shc.markdown
+++ b/source/_integrations/bosch_shc.markdown
@@ -59,11 +59,13 @@ The sensor platform allows you to monitor the states of your temperature, humidi
 
 ### Switch
 
-The switch platform allows you to control your outlets and light switches. Switches are added for each of the following devices:
+The switch platform allows you to control your outlets, light switches, and select camera functions. Switches are added for each of the following devices:
 
 - Light Switch
 - Smart Plug
 - Smart Plug Compact
+- Camera Eyes
+- Camera 360
 
 ## Client registration
 
@@ -129,7 +131,7 @@ If the connection to the controller drops, for example because of a network hicc
 ## Known limitations
 
 - The integration only works on your local network. Controlling your Bosch Smart Home devices from outside your home requires a VPN or a similar way to reach your home network.
-- Devices you pair with the controller after setting up the integration don't appear automatically. {% my integrations title="**Settings** > **Devices & services**" %}, select the Bosch SHC integration, and reload it to pick up new devices.
+- Devices you pair with the controller after setting up the integration don't appear automatically. Go to {% my integrations title="**Settings** > **Devices & services**" %}, select **Bosch SHC**, and select **Reload** to pick up new devices.
 - If your controller's client certificate expires or its network details change, remove the integration and set it up again to generate a new certificate.
 
 ## Troubleshooting

--- a/source/_integrations/bosch_shc.markdown
+++ b/source/_integrations/bosch_shc.markdown
@@ -24,6 +24,7 @@ ha_integration_type: hub
 ---
 
 The **Bosch SHC** {% term integration %} allows you to connect your [Bosch Smart Home Controller](https://www.bosch-smarthome.com) to Home Assistant to control and monitor your Bosch Smart Home devices.
+Use case: combine your door and window contacts with your covers and switches to build a home security and comfort setup that reacts to what's actually happening in your home.
 
 There is currently support for the following device types within Home Assistant:
 
@@ -67,3 +68,86 @@ The switch platform allows you to control your outlets and light switches. Switc
 ## Client registration
 
 To start the client registration, press and hold the button on the controller until the LED starts flashing. During configuration, a client SSL cert/key pair is generated and registered on the controller. For this step, the system password of your controller is needed, which was created upon initial setup of the controller.
+
+## Bosch SHC automation examples
+
+{% include docs/paste_yaml_tip.md %}
+
+### Automation: Notify when a door or window is left open
+
+Get a reminder if a shutter contact stays open for too long, so an open window doesn't go unnoticed.
+
+{% details "YAML example for an open-door reminder" %}
+
+{% example %}
+automation: |
+  alias: "Front door left open"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.front_door
+      to: "on"
+      for:
+        minutes: 10
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "The front door has been open for 10 minutes."
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Close covers automatically at sunset
+
+Combine the cover platform with a sun trigger to close your shutters as it gets dark.
+
+{% details "YAML example for closing covers at sunset" %}
+
+{% example %}
+automation: |
+  alias: "Close shutters at sunset"
+  triggers:
+    - trigger: sun
+      event: sunset
+  actions:
+    - action: cover.close_cover
+      target:
+        entity_id: cover.living_room_shutter
+{% endexample %}
+
+{% enddetails %}
+
+## Data updates
+
+The Bosch Smart Home Controller pushes state changes to Home Assistant as they happen, over a persistent local connection. This means entities update in near real time and Home Assistant doesn't need to regularly check in with the controller for most of them.
+
+Camera-related switches are the exception: they're checked periodically instead, since the controller doesn't push their state changes.
+
+If the connection to the controller drops, for example because of a network hiccup or a controller restart, Home Assistant reconnects automatically once the controller is reachable again.
+
+## Known limitations
+
+- The integration only works on your local network. Controlling your Bosch Smart Home devices from outside your home requires a VPN or a similar way to reach your home network.
+- Devices you pair with the controller after setting up the integration don't appear automatically. {% my integrations title="**Settings** > **Devices & services**" %}, select the Bosch SHC integration, and reload it to pick up new devices.
+- If your controller's client certificate expires or its network details change, remove the integration and set it up again to generate a new certificate.
+
+## Troubleshooting
+
+### The integration can't connect to the controller
+
+Make sure the IP address of the controller is correct and reachable from your Home Assistant instance. Check your router or the controller's settings if you're unsure of its current address.
+
+### Setup fails with a pairing error
+
+The controller only accepts new client registrations while it's in pairing mode. Press and hold the button on the controller until the LED starts flashing, then try adding the integration again.
+
+### Setup fails with a session or authentication error
+
+This usually means the system password you entered doesn't match the one set up in the Bosch Smart Home app, or the client certificate was rejected. Double-check the password, and remove and re-add the integration if the problem continues.
+
+## Removing the integration
+
+{% include integrations/remove_device_service.md %}
+
+Removing the integration doesn't delete the client certificate and key files it created on your Home Assistant instance. If you no longer need them, remove them from the `bosch_shc` folder in your Home Assistant configuration directory.


### PR DESCRIPTION
## Proposed change

The Bosch SHC integration page (`source/_integrations/bosch_shc.markdown`) was missing several sections required by the current integration documentation structure: automation examples, data updates, known limitations, troubleshooting, and removal instructions.

This came out of a broader quality-scale gap audit of the `bosch_shc` integration in `home-assistant/core` (see home-assistant/core#177379, #177389, #177390 — async-dependency migration, PARALLEL_UPDATES, and diagnostics.py, all part of the same follow-up series), which flagged these exact doc gaps against the [quality-scale documentation rules](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/).

Content is scoped to what the ha-core integration actually supports today — binary_sensor, cover, sensor, and switch platforms only, no button/select/climate/number entities, no custom services, no options or reconfigure flow — rather than copied wholesale from the more feature-rich HACS custom integration for the same device (which has a much larger platform surface).

`textlint` passes clean on the changed file. (`remark --frail` currently errors on this file with a pre-existing, unrelated config issue — `Cannot serialize items with '1' for options.listItemIndent` — that reproduces identically on the unmodified file before this change, so it isn't something introduced here.)

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#177379, home-assistant/core#177389, home-assistant/core#177390
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
