### PR TITLE
Add Roborock dock controls for V1 vacuums

### DIFF
--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -179,9 +179,6 @@ The vacuum entity holds the ability to control most things the vacuum can do, su
 - **Mop attached**
   - **Description**: States if the mop is currently attached.
 
-- **Mop drying status**
-  - **Description**: Only available on docks with drying capabilites - States if the mop is currently being driven.
-
 - **Water box attached**
   - **Description**: States if the water box is currently attached.
 
@@ -197,6 +194,8 @@ The vacuum entity holds the ability to control most things the vacuum can do, su
 - **Dirty water box**
   - **Description**: Only available on docks with dirty water tanks built-in. States if the dirty water tank is full, or if the dirty water box is not installed.
 
+- **Emptying dust bin**
+  - **Description**: Only available on docks that support automatic dust collection. States if the dock is currently emptying the vacuum's dust bin.
 
 #### Sensor
 
@@ -270,6 +269,12 @@ The vacuum entity holds the ability to control most things the vacuum can do, su
 - **Do not disturb**
   - **Description**: This enables _Do not disturb_ during the time frame you have set in the app or on the time entity. When _Do not disturb_ is enabled, the vacuum does not run or speak.
 
+- **Mop wash**
+  - **Description**: Only available on docks with mop washing capabilities. States if the mop is currently being washed, and lets you start or stop washing.
+
+- **Mop drying**
+  - **Description**: Only available on docks with mop drying capabilities. States if the mop is currently being dried, and lets you start or stop drying.
+
 #### Number
 
 - **Volume**
@@ -290,6 +295,11 @@ There are currently four buttons that allow you to reset the various maintenance
 
 - **Reset air filter**
   - **Description**: The air filter is expected to be replaced every 150 hours.
+
+Some docks also expose an action button:
+
+- **Empty dust bin**
+  - **Description**: Only available on docks that support automatic dust collection. Empties the vacuum's dust bin into the dock.
 
 In addition, some vacuums allow routines to be set up in the app. For each of those routines, a button entity will be created, allowing you to trigger it.
 

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -197,8 +197,6 @@ The vacuum entity holds the ability to control most things the vacuum can do, su
 - **Dirty water box**
   - **Description**: Only available on docks with dirty water tanks built-in. States if the dirty water tank is full, or if the dirty water box is not installed.
 
-- **Emptying dust bin**
-  - **Description**: Only available on docks that support automatic dust collection. States if the dock is currently emptying the vacuum's dust bin.
 
 #### Sensor
 
@@ -272,7 +270,10 @@ The vacuum entity holds the ability to control most things the vacuum can do, su
 - **Do not disturb**
   - **Description**: This enables _Do not disturb_ during the time frame you have set in the app or on the time entity. When _Do not disturb_ is enabled, the vacuum does not run or speak.
 
-- **Mop wash**
+- **Dust emptying**
+  - **Description**: Only available on docks that support automatic dust collection. States if the dock is currently emptying the vacuum's dust bin, and lets you start or stop emptying.
+
+- **Mop washing**
   - **Description**: Only available on docks with mop washing capabilities. States if the mop is currently being washed, and lets you start or stop washing.
 
 - **Mop drying**
@@ -298,11 +299,6 @@ There are currently four buttons that allow you to reset the various maintenance
 
 - **Reset air filter**
   - **Description**: The air filter is expected to be replaced every 150 hours.
-
-Some docks also expose an additional button entity:
-
-- **Empty dust bin**
-  - **Description**: Only available on docks that support automatic dust collection. Empties the vacuum's dust bin into the dock.
 
 In addition, some vacuums allow routines to be set up in the app. For each of those routines, a button entity will be created, allowing you to trigger it.
 

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -296,7 +296,7 @@ There are currently four buttons that allow you to reset the various maintenance
 - **Reset air filter**
   - **Description**: The air filter is expected to be replaced every 150 hours.
 
-Some docks also expose an action button:
+Some docks also expose an additional button entity:
 
 - **Empty dust bin**
   - **Description**: Only available on docks that support automatic dust collection. Empties the vacuum's dust bin into the dock.

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -179,6 +179,9 @@ The vacuum entity holds the ability to control most things the vacuum can do, su
 - **Mop attached**
   - **Description**: States if the mop is currently attached.
 
+- **Mop drying status**
+  - **Description**: Only available on docks with drying capabilites - States if the mop is currently being driven.
+
 - **Water box attached**
   - **Description**: States if the water box is currently attached.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the three new Roborock dock switches: **Dust emptying**, **Mop washing**, and **Mop drying**. Each one reports whether the dock action is running and lets you start or stop it, and is only created when the dock supports it.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/177404
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


