### PR TITLE
rainbird: Document zone_type configuration option (switch or valve)

### DIFF
--- a/source/_integrations/rainbird.markdown
+++ b/source/_integrations/rainbird.markdown
@@ -7,6 +7,7 @@ ha_category:
   - Irrigation
   - Sensor
   - Switch
+  - Valve
 ha_config_flow: true
 ha_release: 0.61
 ha_iot_class: Local Polling
@@ -20,6 +21,7 @@ ha_platforms:
   - number
   - sensor
   - switch
+  - valve
 ha_integration_type: hub
 ---
 
@@ -31,6 +33,7 @@ There is currently support for the following device types within Home Assistant:
 - [Calendar](#calendar)
 - [Number](#number)
 - [Switch](#switch)
+- [Valve](#valve)
 
 Home Assistant allows you to control the irrigation values, log details about
 the device including optional rain sensor, and allow you to view any upcoming
@@ -59,7 +62,13 @@ The integration provides the following configuration options:
 
 {% configuration_basic %}
 Default irrigation time:
-  description: The number of minutes that the irrigation will run when turning on a zone switch. The default is 6 minutes. This can be overridden with an action (see below).
+  description: The number of minutes that the irrigation will run when turning on a zone switch or opening a zone valve. The default is 6 minutes. This can be overridden with an action (see below).
+Zone entity type:
+  description: >
+    Choose whether irrigation zones are exposed as **Switch** entities or **Valve** entities.
+    The default is **Switch**, which preserves existing behavior.
+    Changing this option and saving will reload the integration, removing the old entities and
+    creating new ones of the selected type.
 {% endconfiguration_basic %}
 
 ## Data updates
@@ -100,7 +109,16 @@ The Rain Bird integration provides the following entities.
 
 - **Irrigation Zone**
   - **Description**: Switches are automatically added for all available zones of
-    configured controllers. Turning on the switch will open the irrigation valve for that zone.
+    configured controllers when the **Zone entity type** configuration option is set to **Switch** (default).
+    Turning on the switch will open the irrigation valve for that zone.
+  - **Available for devices**: All
+
+#### Valve
+
+- **Irrigation Zone**
+  - **Description**: Valve entities are added for all available zones of configured controllers
+    when the **Zone entity type** configuration option is set to **Valve**.
+    Opening the valve will start irrigation for that zone.
   - **Available for devices**: All
 
 {% include integrations/actions.md %}

--- a/source/_integrations/rainbird.markdown
+++ b/source/_integrations/rainbird.markdown
@@ -68,7 +68,9 @@ Zone entity type:
     Choose whether irrigation zones are exposed as **Switch** entities or **Valve** entities.
     The default is **Switch**, which preserves existing behavior.
     Changing this option and saving will reload the integration, removing the old entities and
-    creating new ones of the selected type.
+    creating new ones of the selected type. Because the entity platform changes (for example,
+    from `switch.zone_1` to `valve.zone_1`), any dashboards, automations, or scripts that
+    reference the old entity IDs will need to be updated.
 {% endconfiguration_basic %}
 
 ## Data updates
@@ -108,7 +110,7 @@ The Rain Bird integration provides the following entities.
 #### Switch
 
 - **Irrigation Zone**
-  - **Description**: Switches are automatically added for all available zones of
+  - **Description**: Switch entities are added for all available zones of
     configured controllers when the **Zone entity type** configuration option is set to **Switch** (default).
     Turning on the switch will open the irrigation valve for that zone.
   - **Available for devices**: All


### PR DESCRIPTION
## Proposed change

Documents the new `zone_type` configuration option added in home-assistant/core#177435.

Users can now choose whether Rain Bird sprinkler zones are exposed as **Switch** entities (default, existing behavior) or **Valve** entities via the integration's configuration options.

Changes:
- Added `valve` to `ha_category` and `ha_platforms`
- Added **Valve** to the supported entity list and documented the new entity
- Updated the **Switch** entity description to mention it is the default and linked to `zone_type` option
- Added **Zone entity type** to the Configuration options section with description of the reload behavior
- Updated the default irrigation time description to mention both switches and valves

## Example

## Checklist

- [x] The documentation follows the [home-assistant.io standards](https://developers.home-assistant.io/docs/documenting/standards)
- [x] The documentation has been tested. 

## Additional information

Related core PR: home-assistant/core#177435