### PR TITLE
Add new sun event triggers offset

### DIFF
--- a/source/_integrations/sun.markdown
+++ b/source/_integrations/sun.markdown
@@ -62,7 +62,7 @@ sun:
 
 Home Assistant provides a set of dedicated sun triggers for sunrise, sunset, dawn, dusk, solar noon, solar midnight, and the sun's elevation. See the [list of triggers](#list-of-triggers) below for the full set.
 
-The classic `sun` trigger described here is still supported and is the one to use when you need a fixed time offset before or after sunrise or sunset.
+The classic `sun` trigger described here is still supported.
 
 The sun's event listener performs the action when the sun rises or sets, with an optional offset.
 

--- a/source/_triggers/sun.dawn.markdown
+++ b/source/_triggers/sun.dawn.markdown
@@ -22,7 +22,10 @@ To use this trigger in an automation:
 3. In the **When** section, select **Add trigger**.
 4. From the search box, search for and select **Dawn**.
 5. Under **Twilight type**, select **Civil**, **Nautical**, or **Astronomical** to choose how dark the start of dawn is.
-6. Select **Save**.
+6. Optionally, set an offset to fire before or after dawn:
+   - Under **Offset**, enter how far from dawn to fire, such as 30 minutes.
+   - Under **Offset type**, select **Before** or **After**.
+7. Select **Save**.
 
 ### Options in the UI
 
@@ -34,6 +37,14 @@ Twilight type:
     - **Civil**: the sun is 6° below the horizon. The brightest twilight, with enough light for most outdoor activities. This is the default.
     - **Nautical**: the sun is 12° below the horizon. The horizon is still faintly visible at sea.
     - **Astronomical**: the sun is 18° below the horizon. The sky is, for most purposes, fully dark.
+Offset:
+  description: The length of time from dawn when the trigger fires, in days, hours, minutes, and seconds. By default there is no offset, so the trigger fires exactly at dawn.
+Offset type:
+  description: |
+    Whether the offset applies before or after dawn:
+
+    - **Before**: fires the offset amount before dawn. This is the default.
+    - **After**: fires the offset amount after dawn.
 {% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}
@@ -54,6 +65,19 @@ trigger: |
     type: astronomical
 {% endexample %}
 
+To fire a fixed amount of time before or after dawn, add the `offset` and `offset_type` options:
+
+{% example %}
+trigger: |
+  trigger: sun.dawn
+  options:
+    offset:
+      minutes: 30
+    offset_type: after
+{% endexample %}
+
+This fires 30 minutes after civil dawn every day.
+
 ### Options in YAML
 
 {% options_yaml %}
@@ -63,6 +87,18 @@ type:
   required: false
   type: string
   default: civil
+offset:
+  description: >
+    The length of time from dawn when the trigger fires. Accepts a time period mapping in `hours`, `minutes`, `seconds`, and `days`. Also accepts a duration string in `HH:MM:SS` format. Combine it with `offset_type` to fire before or after dawn.
+  required: false
+  type: time
+  default: "00:00:00"
+offset_type:
+  description: >
+    Whether the offset applies before or after dawn. Accepts `before` or `after`.
+  required: false
+  type: string
+  default: before
 {% endoptions_yaml %}
 
 ## Good to know

--- a/source/_triggers/sun.dusk.markdown
+++ b/source/_triggers/sun.dusk.markdown
@@ -22,7 +22,10 @@ To use this trigger in an automation:
 3. In the **When** section, select **Add trigger**.
 4. From the search box, search for and select **Dusk**.
 5. Under **Twilight type**, select **Civil**, **Nautical**, or **Astronomical** to choose how dark the end of dusk is.
-6. Select **Save**.
+6. Optionally, set an offset to fire before or after dusk:
+   - Under **Offset**, enter how far from dusk to fire, such as 30 minutes.
+   - Under **Offset type**, select **Before** or **After**.
+7. Select **Save**.
 
 ### Options in the UI
 
@@ -34,6 +37,14 @@ Twilight type:
     - **Civil**: the sun is 6° below the horizon. The brightest twilight, with enough light for most outdoor activities. This is the default.
     - **Nautical**: the sun is 12° below the horizon. The horizon is still faintly visible at sea.
     - **Astronomical**: the sun is 18° below the horizon. The sky is, for most purposes, fully dark.
+Offset:
+  description: The length of time from dusk when the trigger fires, in days, hours, minutes, and seconds. By default there is no offset, so the trigger fires exactly at dusk.
+Offset type:
+  description: |
+    Whether the offset applies before or after dusk:
+
+    - **Before**: fires the offset amount before dusk. This is the default.
+    - **After**: fires the offset amount after dusk.
 {% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}
@@ -54,6 +65,19 @@ trigger: |
     type: astronomical
 {% endexample %}
 
+To fire a fixed amount of time before or after dusk, add the `offset` and `offset_type` options:
+
+{% example %}
+trigger: |
+  trigger: sun.dusk
+  options:
+    offset:
+      minutes: 30
+    offset_type: before
+{% endexample %}
+
+This fires 30 minutes before civil dusk every day.
+
 ### Options in YAML
 
 {% options_yaml %}
@@ -63,6 +87,18 @@ type:
   required: false
   type: string
   default: civil
+offset:
+  description: >
+    The length of time from dusk when the trigger fires. Accepts a time period mapping in `hours`, `minutes`, `seconds`, and `days`. Also accepts a duration string in `HH:MM:SS` format. Combine it with `offset_type` to fire before or after dusk.
+  required: false
+  type: time
+  default: "00:00:00"
+offset_type:
+  description: >
+    Whether the offset applies before or after dusk. Accepts `before` or `after`.
+  required: false
+  type: string
+  default: before
 {% endoptions_yaml %}
 
 ## Good to know

--- a/source/_triggers/sun.solar_midnight.markdown
+++ b/source/_triggers/sun.solar_midnight.markdown
@@ -21,18 +21,62 @@ To use this trigger in an automation:
 2. Open an existing automation, or select **Create automation** > **Create new automation**.
 3. In the **When** section, select **Add trigger**.
 4. From the search box, search for and select **Solar midnight**.
-5. Select **Save**.
+5. Optionally, set an offset to fire before or after solar midnight:
+   - Under **Offset**, enter how far from solar midnight to fire, such as 30 minutes.
+   - Under **Offset type**, select **Before** or **After**.
+6. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Offset:
+  description: The length of time from solar midnight when the trigger fires, in days, hours, minutes, and seconds. By default there is no offset, so the trigger fires exactly at solar midnight.
+Offset type:
+  description: |
+    Whether the offset applies before or after solar midnight:
+
+    - **Before**: fires the offset amount before solar midnight. This is the default.
+    - **After**: fires the offset amount after solar midnight.
+{% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}
 
-In YAML, refer to this trigger as `sun.solar_midnight`. It has no options:
+In YAML, refer to this trigger as `sun.solar_midnight`. A basic example looks like this:
 
 {% example %}
 trigger: |
   trigger: sun.solar_midnight
 {% endexample %}
 
-This fires every day, the moment the sun reaches its lowest point.
+This fires every day, the moment the sun reaches its lowest point. To fire a fixed amount of time before or after solar midnight, add the `offset` and `offset_type` options:
+
+{% example %}
+trigger: |
+  trigger: sun.solar_midnight
+  options:
+    offset:
+      minutes: 30
+    offset_type: after
+{% endexample %}
+
+This fires 30 minutes after solar midnight every day.
+
+### Options in YAML
+
+{% options_yaml %}
+offset:
+  description: >
+    The length of time from solar midnight when the trigger fires. Accepts a time period mapping in `hours`, `minutes`, `seconds`, and `days`. Also accepts a duration string in `HH:MM:SS` format. Combine it with `offset_type` to fire before or after solar midnight.
+  required: false
+  type: time
+  default: "00:00:00"
+offset_type:
+  description: >
+    Whether the offset applies before or after solar midnight. Accepts `before` or `after`.
+  required: false
+  type: string
+  default: before
+{% endoptions_yaml %}
 
 ## Good to know
 

--- a/source/_triggers/sun.solar_noon.markdown
+++ b/source/_triggers/sun.solar_noon.markdown
@@ -21,18 +21,62 @@ To use this trigger in an automation:
 2. Open an existing automation, or select **Create automation** > **Create new automation**.
 3. In the **When** section, select **Add trigger**.
 4. From the search box, search for and select **Solar noon**.
-5. Select **Save**.
+5. Optionally, set an offset to fire before or after solar noon:
+   - Under **Offset**, enter how far from solar noon to fire, such as 30 minutes.
+   - Under **Offset type**, select **Before** or **After**.
+6. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Offset:
+  description: The length of time from solar noon when the trigger fires, in days, hours, minutes, and seconds. By default there is no offset, so the trigger fires exactly at solar noon.
+Offset type:
+  description: |
+    Whether the offset applies before or after solar noon:
+
+    - **Before**: fires the offset amount before solar noon. This is the default.
+    - **After**: fires the offset amount after solar noon.
+{% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}
 
-In YAML, refer to this trigger as `sun.solar_noon`. It has no options:
+In YAML, refer to this trigger as `sun.solar_noon`. A basic example looks like this:
 
 {% example %}
 trigger: |
   trigger: sun.solar_noon
 {% endexample %}
 
-This fires every day, the moment the sun reaches its highest point.
+This fires every day, the moment the sun reaches its highest point. To fire a fixed amount of time before or after solar noon, add the `offset` and `offset_type` options:
+
+{% example %}
+trigger: |
+  trigger: sun.solar_noon
+  options:
+    offset:
+      minutes: 30
+    offset_type: after
+{% endexample %}
+
+This fires 30 minutes after solar noon every day.
+
+### Options in YAML
+
+{% options_yaml %}
+offset:
+  description: >
+    The length of time from solar noon when the trigger fires. Accepts a time period mapping in `hours`, `minutes`, `seconds`, and `days`. Also accepts a duration string in `HH:MM:SS` format. Combine it with `offset_type` to fire before or after solar noon.
+  required: false
+  type: time
+  default: "00:00:00"
+offset_type:
+  description: >
+    Whether the offset applies before or after solar noon. Accepts `before` or `after`.
+  required: false
+  type: string
+  default: before
+{% endoptions_yaml %}
 
 ## Good to know
 

--- a/source/_triggers/sun.sunrise.markdown
+++ b/source/_triggers/sun.sunrise.markdown
@@ -21,23 +21,67 @@ To use this trigger in an automation:
 2. Open an existing automation, or select **Create automation** > **Create new automation**.
 3. In the **When** section, select **Add trigger**.
 4. From the search box, search for and select **Sunrise**.
-5. Select **Save**.
+5. Optionally, set an offset to fire before or after sunrise:
+   - Under **Offset**, enter how far from sunrise to fire, such as 30 minutes.
+   - Under **Offset type**, select **Before** or **After**.
+6. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Offset:
+  description: The length of time from sunrise when the trigger fires, in days, hours, minutes, and seconds. By default there is no offset, so the trigger fires exactly at sunrise.
+Offset type:
+  description: |
+    Whether the offset applies before or after sunrise:
+
+    - **Before**: fires the offset amount before sunrise. This is the default.
+    - **After**: fires the offset amount after sunrise.
+{% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}
 
-In YAML, refer to this trigger as `sun.sunrise`. It has no options:
+In YAML, refer to this trigger as `sun.sunrise`. A basic example looks like this:
 
 {% example %}
 trigger: |
   trigger: sun.sunrise
 {% endexample %}
 
-This fires every day, the moment the sun rises above the horizon.
+This fires every day, the moment the sun rises above the horizon. To fire a fixed amount of time before or after sunrise, add the `offset` and `offset_type` options:
+
+{% example %}
+trigger: |
+  trigger: sun.sunrise
+  options:
+    offset:
+      minutes: 30
+    offset_type: after
+{% endexample %}
+
+This fires 30 minutes after sunrise every day.
+
+### Options in YAML
+
+{% options_yaml %}
+offset:
+  description: >
+    The length of time from sunrise when the trigger fires. Accepts a time period mapping in `hours`, `minutes`, `seconds`, and `days`. Also accepts a duration string in `HH:MM:SS` format. Combine it with `offset_type` to fire before or after sunrise.
+  required: false
+  type: time
+  default: "00:00:00"
+offset_type:
+  description: >
+    Whether the offset applies before or after sunrise. Accepts `before` or `after`.
+  required: false
+  type: string
+  default: before
+{% endoptions_yaml %}
 
 ## Good to know
 
 - This trigger does not use a target. It applies to the sun at your configured home location.
-- The trigger fires exactly at sunrise. To fire a fixed amount of time before or after sunrise, use the classic [sun trigger](/integrations/sun/#automation-trigger), which accepts an offset. For light-based timing that adapts to the seasons, use [Sun elevation crossed threshold](/triggers/sun.elevation_crossed_threshold/) instead.
+- To fire a fixed amount of time before or after sunrise, set the **Offset** and **Offset type** options. For light-based timing that adapts to the seasons, use [Sun elevation crossed threshold](/triggers/sun.elevation_crossed_threshold/) instead.
 - To react to the first light before sunrise, use [Dawn](/triggers/sun.dawn/). To react when the sun goes down, use [Sunset](/triggers/sun.sunset/).
 
 {% include triggers/try_it.md %}

--- a/source/_triggers/sun.sunset.markdown
+++ b/source/_triggers/sun.sunset.markdown
@@ -21,23 +21,67 @@ To use this trigger in an automation:
 2. Open an existing automation, or select **Create automation** > **Create new automation**.
 3. In the **When** section, select **Add trigger**.
 4. From the search box, search for and select **Sunset**.
-5. Select **Save**.
+5. Optionally, set an offset to fire before or after sunset:
+   - Under **Offset**, enter how far from sunset to fire, such as 30 minutes.
+   - Under **Offset type**, select **Before** or **After**.
+6. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Offset:
+  description: The length of time from sunset when the trigger fires, in days, hours, minutes, and seconds. By default there is no offset, so the trigger fires exactly at sunset.
+Offset type:
+  description: |
+    Whether the offset applies before or after sunset:
+
+    - **Before**: fires the offset amount before sunset. This is the default.
+    - **After**: fires the offset amount after sunset.
+{% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}
 
-In YAML, refer to this trigger as `sun.sunset`. It has no options:
+In YAML, refer to this trigger as `sun.sunset`. A basic example looks like this:
 
 {% example %}
 trigger: |
   trigger: sun.sunset
 {% endexample %}
 
-This fires every day, the moment the sun sets below the horizon.
+This fires every day, the moment the sun sets below the horizon. To fire a fixed amount of time before or after sunset, add the `offset` and `offset_type` options:
+
+{% example %}
+trigger: |
+  trigger: sun.sunset
+  options:
+    offset:
+      minutes: 30
+    offset_type: before
+{% endexample %}
+
+This fires 30 minutes before sunset every day.
+
+### Options in YAML
+
+{% options_yaml %}
+offset:
+  description: >
+    The length of time from sunset when the trigger fires. Accepts a time period mapping in `hours`, `minutes`, `seconds`, and `days`. Also accepts a duration string in `HH:MM:SS` format. Combine it with `offset_type` to fire before or after sunset.
+  required: false
+  type: time
+  default: "00:00:00"
+offset_type:
+  description: >
+    Whether the offset applies before or after sunset. Accepts `before` or `after`.
+  required: false
+  type: string
+  default: before
+{% endoptions_yaml %}
 
 ## Good to know
 
 - This trigger does not use a target. It applies to the sun at your configured home location.
-- The trigger fires exactly at sunset. To fire a fixed amount of time before or after sunset, use the classic [sun trigger](/integrations/sun/#automation-trigger), which accepts an offset. For light-based timing that adapts to the seasons, use [Sun elevation crossed threshold](/triggers/sun.elevation_crossed_threshold/) instead.
+- To fire a fixed amount of time before or after sunset, set the **Offset** and **Offset type** options. For light-based timing that adapts to the seasons, use [Sun elevation crossed threshold](/triggers/sun.elevation_crossed_threshold/) instead.
 - To react to the last light after sunset, use [Dusk](/triggers/sun.dusk/). To react when the sun comes up, use [Sunrise](/triggers/sun.sunrise/).
 
 {% include triggers/try_it.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
- Document the added offset option for the new sun event triggers.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/176967/
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
