### PR TITLE
Clarify ViCare "Invalid redirection URI" is often a reused app Client ID

### DIFF
--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -142,6 +142,8 @@ When adding or re-authenticating the integration, you get this error in the brow
 
 Set the **Redirect URIs** on your API client in the [Viessmann developer portal](https://app.developer.viessmann-climatesolutions.com) to exactly `https://my.home-assistant.io/redirect/oauth`, save (it may take up to an hour to become active), and try again.
 
+This error also appears if you reuse someone else's Client ID, such as the ViCare app's from older guides. That client only accepts `vicare://oauth-callback/everest`, which Home Assistant cannot use. The fix is not to change the redirect, but to create your own API client (see [prerequisites](#prerequisites)) and use its Client ID.
+
 ### Client not registered
 
 When adding the integration, you get this error in the browser:

--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -142,7 +142,7 @@ When adding or re-authenticating the integration, you get this error in the brow
 
 Set the **Redirect URIs** on your API client in the [Viessmann developer portal](https://app.developer.viessmann-climatesolutions.com) to exactly `https://my.home-assistant.io/redirect/oauth`, save (it may take up to an hour to become active), and try again.
 
-This error also appears if you reuse someone else's Client ID, such as the ViCare app's from older guides. That client only accepts `vicare://oauth-callback/everest`, which Home Assistant cannot use. The fix is not to change the redirect, but to create your own API client (see [prerequisites](#prerequisites)) and use its Client ID.
+This error can also happen if you use a **Client ID** from older guides, like the one used by the ViCare app. That client only allows the redirect URI `vicare://oauth-callback/everest`, which Home Assistant cannot use. Instead of trying to change the redirect URI, create your own API client (see [prerequisites](#prerequisites)) and use its **Client ID**.
 
 ### Client not registered
 


### PR DESCRIPTION
## Proposed change

Adds a note to the ViCare **Invalid redirection URI** troubleshooting section: the error is often caused by reusing the ViCare app's Client ID from older guides, whose only valid redirect (`vicare://oauth-callback/everest`) the Home Assistant OAuth flow cannot use. Points users to creating their own client instead. Prompted by #46951.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
