### PR TITLE
Document HTTP default port

### DIFF
--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -33,7 +33,7 @@ Server port:
   description: |
     The port Home Assistant listens on. Starting with Home Assistant 2026.8, the default is `80` on Home Assistant Operating System. For Home Assistant Container, the default remains `8123`.
 
-    If the `SETUP_PORT` environment variable is set, Home Assistant uses that port instead of the installation default.
+    If `SETUP_PORT` is set, it overrides these defaults for all installation types.
 
     _Caution_: If you use the
     [Home Assistant Companion app](https://companion.home-assistant.io/), update the Home Assistant URL

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -31,7 +31,7 @@ To change how Home Assistant serves its web interface, go to {% my network title
 {% options_ui %}
 Server port:
   description: |
-    The port Home Assistant listens on. Starting with Home Assistant 2026.8, the default is `80` for installations managed by Supervisor, including Home Assistant Operating System and Home Assistant Supervised. For Home Assistant Core and Home Assistant Container, the default remains `8123`. Examples on this page use `8123`; replace it with your configured server port if your installation uses a different port.
+    The port Home Assistant listens on. Starting with Home Assistant 2026.8, the default is `80` for Home Assistant Operating System. For Home Assistant Container, the default remains `8123`. Examples on this page use `8123`; replace it with your configured server port if your installation uses a different port.
 
     If your installation method lets you set environment variables for Home Assistant, `SETUP_PORT` overrides these defaults at startup.
 

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -33,7 +33,7 @@ Server port:
   description: |
     The port Home Assistant listens on. Starting with Home Assistant 2026.8, the default is `80` on Home Assistant Operating System. For Home Assistant Container, the default remains `8123`.
 
-    If `SETUP_PORT` is set, it overrides these defaults for all installation types.
+    If your installation method lets you set environment variables for Home Assistant, `SETUP_PORT` overrides these defaults at startup.
 
     _Caution_: If you use the
     [Home Assistant Companion app](https://companion.home-assistant.io/), update the Home Assistant URL

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -31,7 +31,7 @@ To change how Home Assistant serves its web interface, go to {% my network title
 {% options_ui %}
 Server port:
   description: |
-    The port Home Assistant listens on. Starting with Home Assistant 2026.8, the default is `80` on Home Assistant Operating System. For Home Assistant Container, the default remains `8123`.
+    The port Home Assistant listens on. Starting with Home Assistant 2026.8, the default is `80` for installations managed by Supervisor, including Home Assistant Operating System and Home Assistant Supervised. For Home Assistant Core and Home Assistant Container, the default remains `8123`.
 
     If your installation method lets you set environment variables for Home Assistant, `SETUP_PORT` overrides these defaults at startup.
 

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -31,7 +31,7 @@ To change how Home Assistant serves its web interface, go to {% my network title
 {% options_ui %}
 Server port:
   description: |
-    The port Home Assistant listens on. Starting with Home Assistant 2026.8, the default is `80` for installations managed by Supervisor, including Home Assistant Operating System and Home Assistant Supervised. For Home Assistant Core and Home Assistant Container, the default remains `8123`.
+    The port Home Assistant listens on. Starting with Home Assistant 2026.8, the default is `80` for installations managed by Supervisor, including Home Assistant Operating System and Home Assistant Supervised. For Home Assistant Core and Home Assistant Container, the default remains `8123`. Examples on this page use `8123`; replace it with your configured server port if your installation uses a different port.
 
     If your installation method lets you set environment variables for Home Assistant, `SETUP_PORT` overrides these defaults at startup.
 
@@ -295,7 +295,7 @@ For more examples please visit the [HTTP binary sensor](#examples) page.
 
 ### The HTTP server fails to start
 
-If a saved setting prevents the HTTP server from starting, for example if an SSL certificate file is missing or the configured port is already in use, Home Assistant falls back to the last known-good configuration so you can regain access. If no working configuration is available, Home Assistant starts with the default HTTP settings (port `8123`, without SSL).
+If a saved setting prevents the HTTP server from starting, for example if an SSL certificate file is missing or the configured port is already in use, Home Assistant falls back to the last known-good configuration so you can regain access. If no working configuration is available, Home Assistant starts with the default HTTP settings for your installation method, without SSL.
 
 To fix this, check the logs for the underlying error. Then, open the **HTTP server** section under {% my network title="**Settings** > **System** > **Network**" %}, correct the values, and save.
 

--- a/source/_integrations/http.markdown
+++ b/source/_integrations/http.markdown
@@ -31,7 +31,9 @@ To change how Home Assistant serves its web interface, go to {% my network title
 {% options_ui %}
 Server port:
   description: |
-    The port Home Assistant listens on. The default is `8123`.
+    The port Home Assistant listens on. Starting with Home Assistant 2026.8, the default is `80` on Home Assistant Operating System. For Home Assistant Container, the default remains `8123`.
+
+    If the `SETUP_PORT` environment variable is set, Home Assistant uses that port instead of the installation default.
 
     _Caution_: If you use the
     [Home Assistant Companion app](https://companion.home-assistant.io/), update the Home Assistant URL


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
Document the HTTP server default port change for Home Assistant 2026.8. Home Assistant Operating System now uses port `80` by default. Home Assistant Container continues to use port `8123` by default.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#174278, home-assistant/core#176976
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: Part of home-assistant/home-assistant.io#46763

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
