### PR TITLE
Broadlink: improve finding learned codes

### DIFF
--- a/source/_integrations/broadlink.markdown
+++ b/source/_integrations/broadlink.markdown
@@ -76,7 +76,7 @@ The `climate` entities allow you to monitor and control Broadlink thermostats.
 
 The `infrared` {% term entities %} allow other integrations to transmit IR commands through your Broadlink universal remote. They are created automatically when you configure devices with IR capabilities (`RM mini`, `RM mini 3`, `RM pro`, `RM pro+`, `RM plus`, `RM4 mini`, `RM4 pro`, `RM4C mini`, `RM4C pro`, and `RM4 TV mate`).
 
-The `infrared` entity is complementary to the `remote` entity. Both are created for IR-capable devices. Refer to the [Infrared integration](/integrations/infrared/) integration for more information.
+The `infrared` entity is complementary to the `remote` entity. Both are created for IR-capable devices. Refer to the [Infrared integration](/integrations/infrared/) for more information.
 The existing `remote.learn_command` and `remote.send_command` actions described below are unaffected and remain available for working with learned IR codes.
 
 ## Radio frequency
@@ -207,10 +207,12 @@ The files in the `.storage` folder _should never be edited manually_.
 
 1. Go to {% my supervisor_addon title="**Settings** > **Apps** > **File editor**" addon="core_configurator" %}.
 2. Select **Configuration**.
-3. From ignore patterns, delete **.storage**.
-4. Restart Home Assistant.
-5. Open the File Editor app.
-6. Navigate to `/config/.storage/broadlink_remote_MACADDRESS_codes`, where `MACADDRESS` is your remote's MAC ADDDRESS, for example `112233ab44cd`.
+3. From ignore patterns, remove `.storage`.
+4. Select **Save**.
+5. Restart Home Assistant.
+6. Open the File Editor app.
+7. In the upper-left corner, select **Browse Filesystem**.
+8. Open `.storage/broadlink_remote_MACADDRESS_codes`, where `MACADDRESS` is your remote's MAC ADDRESS, for example `112233ab44cd`.
 
 ### Sending commands
 

--- a/source/_integrations/broadlink.markdown
+++ b/source/_integrations/broadlink.markdown
@@ -76,7 +76,7 @@ The `climate` entities allow you to monitor and control Broadlink thermostats.
 
 The `infrared` {% term entities %} allow other integrations to transmit IR commands through your Broadlink universal remote. They are created automatically when you configure devices with IR capabilities (`RM mini`, `RM mini 3`, `RM pro`, `RM pro+`, `RM plus`, `RM4 mini`, `RM4 pro`, `RM4C mini`, `RM4C pro`, and `RM4 TV mate`).
 
-The `infrared` entity is complementary to the `remote` entity. Both are created for IR-capable devices. Refer to the [Infrared integration](/integrations/infrared/) integration for more information. 
+The `infrared` entity is complementary to the `remote` entity. Both are created for IR-capable devices. Refer to the [Infrared integration](/integrations/infrared/) integration for more information.
 The existing `remote.learn_command` and `remote.send_command` actions described below are unaffected and remain available for working with learned IR codes.
 
 ## Radio frequency
@@ -197,7 +197,20 @@ When the LED blinks for the first time, press the button you want to learn. Then
 
 #### Learned codes storage location
 
-The learned codes are stored in `/config/.storage/` in a JSON file called `broadlink_remote_MACADDRESS_codes`. You can open this file with a text editor and copy the codes to set up [custom IR/RF switches](#setting-up-custom-irrf-switches) or to send them as [base64 codes](#sending-a-base64-code), but beware: the files in the .storage folder _should never be edited manually_.
+The learned codes are stored in `/config/.storage/` in a JSON file called `broadlink_remote_MACADDRESS_codes`. You can open this file with a text editor and copy the codes to set up [custom IR/RF switches](#setting-up-custom-irrf-switches) or to send them as [base64 codes](#sending-a-base64-code).
+
+To view the learned codes using the File Editor {% term app %}:
+
+{% caution %}
+The files in the `.storage` folder _should never be edited manually_.
+{% endcaution %}
+
+1. Go to {% my supervisor_addon title="**Settings** > **Apps** > **File editor**" addon="core_configurator" %}.
+2. Select **Configuration**.
+3. From ignore patterns, delete **.storage**.
+4. Restart Home Assistant.
+5. Open the File Editor app.
+6. Navigate to `/config/.storage/broadlink_remote_MACADDRESS_codes`, where `MACADDRESS` is your remote's MAC ADDDRESS, for example `112233ab44cd`.
 
 ### Sending commands
 
@@ -715,7 +728,7 @@ After a success, do one of the following two options:
     Base64: b'sgAsAREhEBEhESERIREhIRARISIQESERIREgIhAhESERIRAiEBEhESERISEQIhARISERECERIiEQESEhEQABexAhEREhESEQIREhIhARISERESEQIREhIhAhESEQIhAhEREhESEQISIQIRERISEQESERISIQESEhEAABfBAhEREhECIQIREhIhARISERECIQIRIgIhAhESEQIhAiEBEhECIQISIQIhARISEQESIQISIQESEhEQABexAhEREhESEQIhAhIhARISIQESEQIhAhIhAiECERIRAiEBEhESERISEQIhARISERESEQISIQESEiEAABexEhEBEhESERIREhIREQISIQESERIREhIREhECIQIREhEBEhESERISERIRARIiEQESERISERESEhEAAF3AAAAAAAAAAAAAAAAA=='
     ```
 
-2. To learn a button hold RF code, hold the button you wish to learn for 1-2 seconds then immediately press enter.  
+2. To learn a button hold RF code, hold the button you wish to learn for 1-2 seconds then immediately press enter.
     - You will see the same prompts for a short press as shown above. You should see it return a different base64 code.
     - Test the base64 code to ensure it performs the button 'hold' command as expected, rather than the button 'press' command.
     - This might take some trial and error to get the hold timing right before hitting enter to scan for the code.


### PR DESCRIPTION

## Proposed change

Improve https://www.home-assistant.io/integrations/broadlink/#learned-codes-storage-location to explain how to find the `.storage` folder in the file editor.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
