### PR TITLE
Fix flatten example to use the unique filter

### DIFF
--- a/source/_template_functions/flatten.markdown
+++ b/source/_template_functions/flatten.markdown
@@ -99,7 +99,7 @@ Flatten a nested structure and then count the unique values.
 
 {% example %}
 template: |
-  {{ [[1, 2, 3], [2, 3, 4], [4, 5]] | flatten | set | list | count }}
+  {{ [[1, 2, 3], [2, 3, 4], [4, 5]] | flatten | unique | list | count }}
 type: integer
 output: "5"
 {% endexample %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The example under "Flatten and count unique items" on the [`flatten`](https://www.home-assistant.io/template-functions/flatten/) page pipes the list through `set`. `set` is only available as a function, not as a filter, so the example does not render and never produces the documented output of `5`.

This swaps `set` for the `unique` filter, which removes duplicates and is available as a filter. The section title and the documented output stay correct.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #46979

The same pattern appears twice more on the `set` page. Those examples need the function form instead, so I left them out and can follow up in a separate pull request.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
