### PR TITLE
Correct the button label in the third-party app repository steps

### DIFF
--- a/source/_includes/common-tasks/third-party-addons.md
+++ b/source/_includes/common-tasks/third-party-addons.md
@@ -16,7 +16,7 @@ To add an app repository, follow these steps:
         ```text
         https://github.com/home-assistant/hassio-addons-example
         ```
-2. Go to {% my supervisor title="**Settings** > **Apps**" %} and select **App store**.
+2. Go to {% my supervisor title="**Settings** > **Apps**" %} and select **Install app**.
    ![Screenshot of the Home Assistant app store](/images/getting-started/app-store.png)
 3. In the top-right corner, select the three dots {% icon "mdi:dots-vertical" %} menu, and select **Repositories**.
 4. Add the URL of the repository and select **Add**.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Step 2 of "Installing a third-party app repository" tells you to go to **Settings** > **Apps** and select **App store**, but there is no button with that label on that page. The button is labeled **Install app**.

In the frontend, `src/panels/config/apps/ha-config-apps-installed.ts` (the **Settings** > **Apps** page) renders the button as `ui.panel.config.apps.installed.add_app` with `href="/config/apps/available"`, and `src/translations/en.json` translates that key to "Install app". "App store" is a different key, `ui.panel.config.apps.store.title`, which is the header of the page the button opens (`src/panels/config/apps/ha-config-apps-available.ts`).

This updates the step to name the button the reader actually sees. The screenshot and its alt text stay valid, because they show the App store page that opens after selecting **Install app**. It also brings the step in line with the [Apps page](https://www.home-assistant.io/apps/), which already tells readers to go to **Settings** > **Apps** and select **Install app**.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #47055

The text lives in `source/_includes/common-tasks/third-party-addons.md`, which is included by [Common tasks: Operating System](https://www.home-assistant.io/common-tasks/os/#installing-a-third-party-app-repository). That is the only page that includes it, and the wrong wording appears only once in the repository.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
