### PR TITLE
Insteon: document Monitor Mode requirement for USB PowerLinc Modems

### DIFF
--- a/source/_integrations/insteon.markdown
+++ b/source/_integrations/insteon.markdown
@@ -121,9 +121,9 @@ Editing a device's All-Link Database can cause the device to become unresponsive
 - **Configure device overrides**: Add or remove device overrides. See [Device overrides](#device-overrides) below.
 - **Delete device**: Delete an Insteon device from the network using the device's Insteon address.
 
-## Monitor Mode (USB PowerLinc Modems)
+## Monitor Mode (PowerLinc Modems)
 
-If you use a serial **USB PowerLinc Modem (PLM)**—such as the 2413U or 2413S—rather than an Insteon Hub, Home Assistant may not update a device's state or fire the `insteon.button_on` and `insteon.button_off` [events](#events-and-mini-remotes) when the device is operated **at the wall** or by an **RF** control such as a remote, motion, leak, or open/close sensor. Controlling the device *from* Home Assistant still works, and this can happen even when the device is correctly linked to the modem.
+If you use a **PowerLinc Modem (PLM)**—such as the USB 2413U or the serial (RS-232) 2413S—rather than an Insteon Hub, Home Assistant may not update a device's state or fire the `insteon.button_on` and `insteon.button_off` [events](#events-and-mini-remotes) when the device is operated **at the wall** or by an **RF** control such as a remote, motion, leak, or open/close sensor. Controlling the device *from* Home Assistant still works, and this can happen even when the device is correctly linked to the modem.
 
 This is caused by the modem's **Monitor Mode** being disabled. With Monitor Mode off, a PLM only reports messages addressed directly to it, so it does not forward the all-link broadcast and cleanup messages that devices send when they are operated locally. Enabling Monitor Mode allows the modem to report this traffic, and Home Assistant then updates state and fires events as expected.
 
@@ -133,7 +133,7 @@ To enable Monitor Mode:
 2. Select the **Properties** tab. If `monitor_mode` is not listed, enable **Advanced Mode** in your Home Assistant user profile and reopen the panel.
 3. Set `monitor_mode` to on and use **Write to device** to save it to the modem. See [Device properties](#device-properties) for details on changing and writing properties.
 
-The setting is stored in the modem's own memory and persists across restarts and Home Assistant upgrades. It applies only to serial PLMs; the Insteon **Hub** does not use this setting.
+The setting is stored in the modem's own memory and persists across restarts and Home Assistant upgrades. It applies only to PLMs; the Insteon **Hub** does not use this setting.
 
 {% note %}
 With Monitor Mode enabled, the modem reports **all** Insteon traffic it overhears, not just traffic for your linked devices. On very large or busy networks, this slightly increases processing load. This is expected and is required for physical and RF events to reach Home Assistant.

--- a/source/_integrations/insteon.markdown
+++ b/source/_integrations/insteon.markdown
@@ -121,6 +121,24 @@ Editing a device's All-Link Database can cause the device to become unresponsive
 - **Configure device overrides**: Add or remove device overrides. See [Device overrides](#device-overrides) below.
 - **Delete device**: Delete an Insteon device from the network using the device's Insteon address.
 
+## Monitor Mode (USB PowerLinc Modems)
+
+If you use a serial **USB PowerLinc Modem (PLM)**—such as the 2413U or 2413S—rather than an Insteon Hub, Home Assistant may not update a device's state or fire the `insteon.button_on` and `insteon.button_off` [events](#events-and-mini-remotes) when the device is operated **at the wall** or by an **RF** control such as a remote, motion, leak, or open/close sensor. Controlling the device *from* Home Assistant still works, and this can happen even when the device is correctly linked to the modem.
+
+This is caused by the modem's **Monitor Mode** being disabled. With Monitor Mode off, a PLM only reports messages addressed directly to it, so it does not forward the all-link broadcast and cleanup messages that devices send when they are operated locally. Enabling Monitor Mode allows the modem to report this traffic, and Home Assistant then updates state and fires events as expected.
+
+To enable Monitor Mode:
+
+1. Open the [Insteon configuration panel](#insteon-configuration-panel) and select the modem (PLM) from the list of devices.
+2. Select the **Properties** tab. If `monitor_mode` is not listed, enable **Advanced Mode** in your Home Assistant user profile and reopen the panel.
+3. Set `monitor_mode` to on and use **Write to device** to save it to the modem. See [Device properties](#device-properties) for details on changing and writing properties.
+
+The setting is stored in the modem's own memory and persists across restarts and Home Assistant upgrades. It applies only to serial PLMs; the Insteon **Hub** does not use this setting.
+
+{% note %}
+With Monitor Mode enabled, the modem reports **all** Insteon traffic it overhears, not just traffic for your linked devices. On very large or busy networks, this slightly increases processing load. This is expected and is required for physical and RF events to reach Home Assistant.
+{% endnote %}
+
 ## Controlling Insteon scenes
 
 Insteon scenes are controlled through automations and scripts. Use the [Scene on](/actions/insteon.scene_on/) action to turn a scene on and the [Scene off](/actions/insteon.scene_off/) action to turn it off. Both take the Insteon group or scene number.


### PR DESCRIPTION
## Proposed change

Documents **Monitor Mode**, which PowerLinc Modems (PLM) — the USB 2413U or serial 2413S — require in order to report physically- or RF-triggered device events to Home Assistant. Without it, a correctly-linked PLM updates state only for commands issued *by* Home Assistant and silently ignores wall presses, RF remotes, and battery (motion/leak/open-close) sensors.

This is a hard-to-diagnose source of "physical button presses do nothing in Home Assistant" reports (for example home-assistant/core#99705, where the same PLM works under other Insteon software but is silent in HA). The setting already exists as an advanced device property (`monitor_mode`) but is undocumented. This PR adds a "Monitor Mode (PowerLinc Modems)" section explaining the behavior and how to enable the setting from the Insteon configuration panel.

Related core issue proposing that the Insteon integration enable Monitor Mode automatically for PLMs (default-on, opt-out, Hub excluded): home-assistant/core#177618

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration/feature (`next` branch).

## Additional information

- This documents already-released behavior, so it targets the `current` branch.
- Related issue: home-assistant/core#177618

## Checklist

- [x] This PR targets the correct branch (`current` for existing behavior).
- [x] The documentation follows the [documentation standards](https://developers.home-assistant.io/docs/documenting/standards/).
