### PR TITLE
Document new teslemetry entities: tonneau cover, regen/FSD sensors, rear defroster

### DIFF
--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -132,6 +132,7 @@ Entities in the device tracker platform specifically require the `Vehicle locati
 |Cover|Charge port door|Yes|
 |Cover|Frunk|Yes|
 |Cover|Sunroof|No|
+|Cover|Tonneau|Yes|
 |Cover|Trunk|Yes|
 |Cover|Vent windows|Yes|
 |Device tracker|Location|Yes|
@@ -344,6 +345,7 @@ The integration is designed to not wake the vehicle to poll for data. Updates fo
 -   **Vehicle Sleep:** The integration will not actively wake a vehicle to fetch data. However, sending commands (such as locking, unlocking, or climate control) will wake the vehicle.
 -   **Rate Limits:** While Teslemetry handles upstream rate limiting with Tesla, excessive polling or command usage from aggressive automations may encounter temporary API limits.
 -   **Virtual Key:** Modern vehicles require a [virtual key](https://teslemetry.com/docs/topics/virtualkey) to operate. Please follow the instructions on the [Teslemetry Console](https://teslemetry.com/console) to set this up.
+-   **Tonneau cover:** The tonneau cover entity is only created for Cybertruck vehicles. Opening, closing, and stopping the cover requires the vehicle command scope; without it, the entity only reports the current position.
 
 ## Troubleshooting
 

--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -100,6 +100,7 @@ Entities in the device tracker platform specifically require the `Vehicle locati
 |Binary sensor|Pin to drive enabled|No|
 |Binary sensor|Preconditioning enabled|No|
 |Binary sensor|Preconditioning|No|
+|Binary sensor|Rear defroster|No|
 |Binary sensor|Rear display HVAC|No|
 |Binary sensor|Rear driver door|Yes|
 |Binary sensor|Rear driver window|Yes|
@@ -190,6 +191,8 @@ Entities in the device tracker platform specifically require the `Vehicle locati
 |Sensor|Ideal battery range|No|
 |Sensor|Inside temperature|Yes|
 |Sensor|Left temperature request|No|
+|Sensor|Lifetime energy gained regen|No|
+|Sensor|Miles since reset|No|
 |Sensor|Odometer|No|
 |Sensor|Outside temperature|Yes|
 |Sensor|Passenger temperature setting|No|
@@ -224,6 +227,7 @@ Entities in the device tracker platform specifically require the `Vehicle locati
 |Sensor|Scheduled charging start time|No|
 |Sensor|Scheduled departure time|No|
 |Sensor|Secondary drive unit torque command|No|
+|Sensor|Self-driving miles since reset|No|
 |Sensor|Sentry mode|Yes|
 |Sensor|Shift state|No|
 |Sensor|Speed|No|


### PR DESCRIPTION
## Proposed change

Companion documentation for three new Teslemetry entities backed by streaming fields introduced in vehicle firmware 2025.44, split across three independent parent PRs that all touch the same `teslemetry.markdown` page:

- Cybertruck tonneau cover (controllable open/close/stop, Cybertruck-only)
- Two diagnostic sensors: lifetime regenerative energy and FSD/self-driving miles since reset
- Rear defroster binary sensor

## Type of change

- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/177610, https://github.com/home-assistant/core/pull/177608, https://github.com/home-assistant/core/pull/177609

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
