### PR TITLE
Document Speedtest.net server option and removal steps

### DIFF
--- a/source/_integrations/speedtestdotnet.markdown
+++ b/source/_integrations/speedtestdotnet.markdown
@@ -26,6 +26,15 @@ By default, a speed test will be run every hour. You can disable polling using s
 
 {% include common-tasks/define_custom_polling.md %}
 
+## Configuration options
+
+After setup, you can choose which server the speed test runs against. Go to {% my integrations title="**Settings** > **Devices & services**" %}, select the **Speedtest.net** integration, and then select the cogwheel {% icon "mdi:cog-outline" %} (**Configure**).
+
+{% configuration_basic %}
+Select test server:
+  description: "The Speedtest.net server to use for tests. Select auto detect to automatically choose a server. Defaults to `*Auto Detect`."
+{% endconfiguration_basic %}
+
 ## Integration sensors
 
 The following sensors are added by the integration:
@@ -86,3 +95,9 @@ automation:
 - Running this integration can have negative effects on the system's performance as it requires a fair amount of memory.
 - If run frequently, this integration can use a considerable amount of data. Frequent updates should be avoided on bandwidth-capped connections.
 - While the speedtest is running your network capacity is fully utilized. This may have a negative effect on other devices using the network such as gaming consoles or streaming boxes.
+
+## Removing the integration
+
+This integration follows standard integration removal. No extra steps are required.
+
+{% include integrations/remove_device_service.md %}

--- a/source/_integrations/speedtestdotnet.markdown
+++ b/source/_integrations/speedtestdotnet.markdown
@@ -32,7 +32,7 @@ After setup, you can choose which server the speed test runs against. Go to {% m
 
 {% configuration_basic %}
 Select test server:
-  description: "The Speedtest.net server to use for tests. Select auto detect to automatically choose a server. Defaults to `*Auto Detect`."
+  description: "The Speedtest.net server to use for tests. Select `*Auto Detect` to automatically choose a server. Defaults to `*Auto Detect`."
 {% endconfiguration_basic %}
 
 ## Integration sensors


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The Speedtest.net page is missing two things the integration's own `quality_scale.yaml` still lists as `todo`: `docs-configuration-parameters` and `docs-removal-instructions`.

This adds a `## Configuration options` section for the test server option. The label and description are taken from the integration's `strings.json`, and the documented default `*Auto Detect` from `DEFAULT_SERVER` in `const.py`. It also adds the standard `## Removing the integration` section; the integration defines no `async_remove_entry` and no `async_remove_config_entry_device`, so removal is the plain config entry flow.

No existing text is changed.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

Both sections describe behavior that already ships, so there is no code change to link. Flipping the two quality scale rules to `done` belongs in a separate core pull request.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
