### PR TITLE
Battery: use binary sensor, style edits

### DIFF
--- a/source/_conditions/battery.is_charging.markdown
+++ b/source/_conditions/battery.is_charging.markdown
@@ -43,10 +43,10 @@ In YAML, **Battery is charging** is referred to as `battery.is_charging`. A basi
 condition: |
   condition: battery.is_charging
   target:
-    entity_id: sensor.phone_battery
+    entity_id: binary_sensor.phone_battery_charging
 {% endexample %}
 
-This passes when `sensor.phone_battery` is charging.
+This passes when `binary_sensor.phone_battery_charging` is charging.
 
 ### Options in YAML
 
@@ -101,7 +101,7 @@ automation: |
   conditions:
     - condition: battery.is_charging
       target:
-        entity_id: sensor.laptop_battery
+        entity_id: binary_sensor.laptop_battery_charging
   actions:
     - action: script.run_nightly_backup
 {% endexample %}

--- a/source/_conditions/battery.is_charging.markdown
+++ b/source/_conditions/battery.is_charging.markdown
@@ -71,7 +71,7 @@ for:
 
 ## Good to know
 
-- The condition works with sensors and devices that report a charging state, such as devices that expose a battery charging attribute.
+- The target must be a binary sensor with the battery charging device class.
 - Devices that are unavailable (`unavailable`) or have an unknown state (`unknown`) are skipped for **Any** and fail for **All**.
 - To check the opposite state, use [Battery is not charging](/conditions/battery.is_not_charging/).
 - To check the battery percentage instead, use [Battery level](/conditions/battery.is_level/).

--- a/source/_conditions/battery.is_level.markdown
+++ b/source/_conditions/battery.is_level.markdown
@@ -152,7 +152,7 @@ behavior:
 
 ## Good to know
 
-- The condition works with sensors that have the battery device class.
+- The target sensor must have the battery device class.
 - Entities that are unavailable (`unavailable`) or have an unknown state (`unknown`) are skipped for **Any** and fail for **All**.
 - Battery level is expressed as a percentage from 0 to 100.
 - This condition checks the entity's current battery reading. To react to changes in the reading, use the [Battery level changed](/triggers/battery.level_changed/) or [Battery level crossed threshold](/triggers/battery.level_crossed/) trigger instead.

--- a/source/_conditions/battery.is_low.markdown
+++ b/source/_conditions/battery.is_low.markdown
@@ -71,8 +71,10 @@ for:
 
 ## Good to know
 
-- The condition works with binary sensors that have the `battery` device class. These are typically separate entities from the battery percentage sensor and only report `on` (low) or `off` (normal).
-- Not every battery-powered device exposes a low-battery indicator. If yours doesn't, use [Battery level](/conditions/battery.is_level/) with a percentage threshold instead.
+- The target must be a binary sensor with the battery device class.
+- The device must expose a low-battery indicator.
+- Low-battery binary sensors are typically separate entities from the battery percentage sensor and only report `on` (low) or `off` (normal).
+- If your device reports only a battery percentage, use [Battery level](/conditions/battery.is_level/) with a percentage threshold instead.
 - Devices that are unavailable (`unavailable`) or have an unknown state (`unknown`) are skipped for **Any** and fail for **All**.
 - To check the opposite state, use [Battery is not low](/conditions/battery.is_not_low/).
 - For an overview of the status of your battery {% term entities %}, open the [**Maintenance** dashboard](/dashboards/dashboards/#dashboards-only-shown-in-the-dashboard-list-by-default). This dashboard allows you to quickly see which batteries need replacing.

--- a/source/_conditions/battery.is_not_charging.markdown
+++ b/source/_conditions/battery.is_not_charging.markdown
@@ -41,10 +41,10 @@ In YAML, **Battery is not charging** is referred to as `battery.is_not_charging`
 condition: |
   condition: battery.is_not_charging
   target:
-    entity_id: sensor.phone_battery
+    entity_id: binary_sensor.phone_battery_charging
 {% endexample %}
 
-This passes when `sensor.phone_battery` is not charging.
+This passes when `binary_sensor.phone_battery_charging` is not charging.
 
 ### Options in YAML
 
@@ -69,7 +69,7 @@ for:
 
 ## Good to know
 
-- The condition works with sensors and devices that report a charging state, such as devices that expose a battery charging attribute.
+- The target must be a binary sensor with the battery charging device class.
 - Devices that are unavailable (`unavailable`) or have an unknown state (`unknown`) are skipped for **Any** and fail for **All**.
 - A fully charged device with the charger still connected may report as not charging, because the charger has stopped drawing power. If you want to be sure the device is unplugged, combine this condition with [Battery level](/conditions/battery.is_level/).
 - To check the opposite state, use [Battery is charging](/conditions/battery.is_charging/).
@@ -100,7 +100,7 @@ automation: |
   conditions:
     - condition: battery.is_not_charging
       target:
-        entity_id: sensor.phone_battery
+        entity_id: binary_sensor.phone_battery_charging
   actions:
     - action: notify.send_message
       target:

--- a/source/_conditions/battery.is_not_low.markdown
+++ b/source/_conditions/battery.is_not_low.markdown
@@ -71,8 +71,10 @@ for:
 
 ## Good to know
 
-- The condition works with binary sensors that have the `battery` device class. These are typically separate entities from the battery percentage sensor and only report `on` (low) or `off` (normal).
-- Not every battery-powered device exposes a low-battery indicator. If yours doesn't, use [Battery level](/conditions/battery.is_level/) with a percentage threshold instead.
+- The target must be a binary sensor with the `battery` device class.
+- The device must expose a low-battery indicator.
+- Low-battery binary sensors are typically separate entities from the battery percentage sensor and only report `on` (low) or `off` (normal).
+- If your device reports only a battery percentage, use [Battery level](/conditions/battery.is_level/) with a percentage threshold instead.
 - Devices that are unavailable (`unavailable`) or have an unknown state (`unknown`) are skipped for **Any** and fail for **All**.
 - To check the opposite state, use [Battery is low](/conditions/battery.is_low/).
 - For an overview of the status of your battery {% term entities %}, open the [**Maintenance** dashboard](/dashboards/dashboards/#dashboards-only-shown-in-the-dashboard-list-by-default). This dashboard allows you to quickly see which batteries need replacing.

--- a/source/_triggers/battery.became_low.markdown
+++ b/source/_triggers/battery.became_low.markdown
@@ -93,8 +93,9 @@ for:
 
 ## Good to know
 
-- This trigger works with `binary_sensor` entities that have the `battery` device class. These are separate from battery percentage sensors (`sensor` entities with the `battery` device class). If your device only exposes a percentage sensor, use [Battery level crossed threshold](/triggers/battery.level_crossed/) instead.
+- Use a binary sensor entity with the battery device class.
 - Use a label to group battery-powered devices across different areas, and target that label to monitor them all from a single automation.
+- For battery percentage sensors, use [Battery level crossed threshold](/triggers/battery.level_crossed/) instead.
 - Combine this trigger with a notification action to get a push notification on your phone the moment any sensor runs low.
 
 {% include triggers/try_it.md %}

--- a/source/_triggers/battery.level_changed.markdown
+++ b/source/_triggers/battery.level_changed.markdown
@@ -121,11 +121,11 @@ threshold:
 
 ## Good to know
 
+- Use a sensor with the battery device class.
 - The threshold type controls both the direction and the landing zone of the change. Use **Above** or **Below** to filter by direction, **In range** to fire only when the new value is inside a range, and **Outside range** to fire only when it escapes a range.
 - Use **Any change** to fire on every reading update regardless of direction or where the new value lands.
 - To react only when a battery level first crosses a specific value, use [Battery level crossed threshold](/triggers/battery.level_crossed/) instead.
 - Pair this trigger with the Battery level condition to verify the reading meets a threshold before continuing the automation.
-- The trigger works with sensors that have the battery device class.
 
 {% include triggers/try_it.md %}
 
@@ -164,5 +164,4 @@ automation: |
 {% endexample %}
 
 {% enddetails %}
-
 

--- a/source/_triggers/battery.level_crossed.markdown
+++ b/source/_triggers/battery.level_crossed.markdown
@@ -158,11 +158,11 @@ for:
 
 ## Good to know
 
+- Use a sensor with the battery device class.
 - **Above** and **Below** fire on the crossing moment only. Once the reading is above the threshold, the trigger does not fire again until the reading dips back below it and then crosses above again.
 - **In range** (`between`) fires when the reading moves from outside the bounds into the bounds. **Outside range** (`outside`) fires when the reading moves from inside the bounds past either bound.
 - Pair this trigger with the [Battery level changed](/triggers/battery.level_changed/) trigger if you also want to react to smaller fluctuations between crossings.
 - Pair this trigger with the Battery level condition to double-check the final state.
-- The trigger works with sensors that have the battery device class.
 
 {% include triggers/try_it.md %}
 

--- a/source/_triggers/battery.no_longer_low.markdown
+++ b/source/_triggers/battery.no_longer_low.markdown
@@ -91,8 +91,9 @@ for:
 
 ## Good to know
 
-- This trigger works with `binary_sensor` entities that have the `battery` device class. These are separate from battery percentage sensors (`sensor` entities with the `battery` device class). If your device only exposes a percentage sensor, use [Battery level crossed threshold](/triggers/battery.level_crossed/) instead.
+- Use a binary sensor entity with the battery device class.
 - What counts as "low" depends on the device and its integration. The battery binary sensor is controlled by the device or its integration, not by Home Assistant.
+- For battery percentage sensors, use [Battery level crossed threshold](/triggers/battery.level_crossed/) instead.
 - Use this trigger together with [Battery low](/triggers/battery.became_low/) to build a complete low-battery workflow: alert when a device goes low, and confirm or log when it is healthy again.
 
 {% include triggers/try_it.md %}

--- a/source/_triggers/battery.started_charging.markdown
+++ b/source/_triggers/battery.started_charging.markdown
@@ -84,7 +84,6 @@ for:
 - **Battery started charging** fires only when a device transitions from not charging to actively charging. If a device is already charging when Home Assistant starts, the trigger does not fire.
 - To react when a device stops charging, use [Battery stopped charging](/triggers/battery.stopped_charging/).
 - To fire when the battery level crosses a specific percentage, use [Battery level crossed threshold](/triggers/battery.level_crossed/) instead.
-- The trigger works with sensors that report a charging state, such as devices that expose a battery charging attribute.
 
 {% include triggers/try_it.md %}
 

--- a/source/_triggers/battery.started_charging.markdown
+++ b/source/_triggers/battery.started_charging.markdown
@@ -46,10 +46,10 @@ In YAML, **Battery started charging** is referred to as `battery.started_chargin
 trigger: |
   trigger: battery.started_charging
   target:
-    entity_id: sensor.phone_battery
+    entity_id: binary_sensor.phone_battery_charging
 {% endexample %}
 
-This fires every time `sensor.phone_battery` starts charging.
+This fires every time `binary_sensor.phone_battery_charging` starts charging.
 
 ### Options in YAML
 
@@ -80,6 +80,7 @@ for:
 
 ## Good to know
 
+- Use a binary sensor with the battery charging device class.
 - **Battery started charging** fires only when a device transitions from not charging to actively charging. If a device is already charging when Home Assistant starts, the trigger does not fire.
 - To react when a device stops charging, use [Battery stopped charging](/triggers/battery.stopped_charging/).
 - To fire when the battery level crosses a specific percentage, use [Battery level crossed threshold](/triggers/battery.level_crossed/) instead.
@@ -107,7 +108,7 @@ automation: |
   triggers:
     - trigger: battery.started_charging
       target:
-        entity_id: sensor.phone_battery
+        entity_id: binary_sensor.phone_battery_charging
   actions:
     - action: notify.send_message
       target:

--- a/source/_triggers/battery.stopped_charging.markdown
+++ b/source/_triggers/battery.stopped_charging.markdown
@@ -46,10 +46,10 @@ In YAML, **Battery stopped charging** is referred to as `battery.stopped_chargin
 trigger: |
   trigger: battery.stopped_charging
   target:
-    entity_id: sensor.phone_battery
+    entity_id: binary_sensor.phone_battery_charging
 {% endexample %}
 
-This fires every time `sensor.phone_battery` stops charging.
+This fires every time `binary_sensor.phone_battery_charging` stops charging.
 
 ### Options in YAML
 
@@ -80,6 +80,7 @@ for:
 
 ## Good to know
 
+- Use a binary sensor with the battery charging device class.
 - **Battery stopped charging** fires both when a device is unplugged and when it finishes charging naturally. If you only want to react when the battery is full, combine this trigger with a condition that checks the battery level.
 - To react when a device starts charging, use [Battery started charging](/triggers/battery.started_charging/).
 - To fire when the battery level crosses a specific percentage, use [Battery level crossed threshold](/triggers/battery.level_crossed/) instead.
@@ -107,7 +108,7 @@ automation: |
   triggers:
     - trigger: battery.stopped_charging
       target:
-        entity_id: sensor.tablet_battery
+        entity_id: binary_sensor.tablet_battery_charging
   conditions:
     - condition: numeric_state
       entity_id: sensor.tablet_battery

--- a/source/_triggers/battery.stopped_charging.markdown
+++ b/source/_triggers/battery.stopped_charging.markdown
@@ -84,7 +84,6 @@ for:
 - **Battery stopped charging** fires both when a device is unplugged and when it finishes charging naturally. If you only want to react when the battery is full, combine this trigger with a condition that checks the battery level.
 - To react when a device starts charging, use [Battery started charging](/triggers/battery.started_charging/).
 - To fire when the battery level crosses a specific percentage, use [Battery level crossed threshold](/triggers/battery.level_crossed/) instead.
-- The trigger works with sensors that report a charging state, such as devices that expose a battery charging attribute.
 
 {% include triggers/try_it.md %}
 


### PR DESCRIPTION
## Proposed change

- Use binary sensor for battery examples.

<details><summary>Evidence in core</summary>
<p>

- `homeassistant/components/battery/condition.py`
  - Lines 17-24: `BATTERY_LOW_DOMAIN_SPECS` and `BATTERY_CHARGING_DOMAIN_SPECS` both use `BINARY_SENSOR_DOMAIN`.
  - Lines 31-51: `is_low`, `is_not_low`, `is_charging`, and `is_not_charging` all use those binary sensor specs.
  - Lines 27-29 and 52-56: `only is_level` uses `SENSOR_DOMAIN` with `SensorDeviceClass.BATTERY`.
- `homeassistant/components/battery/trigger.py`
  - Lines 18-25: low and charging specs both use `BINARY_SENSOR_DOMAIN`.
  - Lines 32-44: `became_low`, `no_longer_low`, `started_charging`, and `stopped_charging` all use those binary sensor specs.
  - Lines 28-30 and 45-54: only `level_changed` and `level_crossed_threshold` use battery percentage sensor entities.
- `homeassistant/components/binary_sensor/__init__.py`
  - Lines 34-38: `BATTERY = "battery"` means on = low, off = normal; `BATTERY_CHARGING = "battery_charging"` means on = charging, off = not charging.
- `homeassistant/components/sensor/const.py`
  - Lines 173-177: `SensorDeviceClass.BATTERY` is percentage battery left, unit `%`.
- `homeassistant/helpers/automation.py`
  - Lines 40-57: target entities are filtered by domain and device class, so a `sensor.*` will not match a spec that requires `binary_sensor`.

Core tests also confirm this:

- `tests/components/battery/test_condition.py`
  - Lines 78-109: low and charging conditions are tested against `binary_sensor` targets with required device classes `battery` or `battery_charging`.
  - Lines 190-257: `battery.is_level` is tested separately against sensor targets.
- `tests/components/battery/test_trigger.py`
  - Lines 79-114, 139-174, and 199-234: low and charging triggers are tested against `binary_sensor` targets with required device classes `battery` or `battery_charging`.
  - Lines 259-276: level triggers are tested separately against sensor targets.


</p>
</details> 

- Tidy up related "Good to know" sections.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- Related issue: https://github.com/home-assistant/home-assistant.io/issues/46957

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
