### PR TITLE
Document P100/P200/P300 support for Lyngdorf integration

### DIFF
--- a/source/_integrations/lyngdorf.markdown
+++ b/source/_integrations/lyngdorf.markdown
@@ -16,14 +16,14 @@ ha_integration_type: device
 ha_quality_scale: silver
 ---
 
-The **Lyngdorf** {% term integration %} allows you to control [Lyngdorf] and [Steinway & Lyngdorf] audio processors and amplifiers from Home Assistant. Lyngdorf Audio is known for their RoomPerfect room correction technology. This integration lets you control power, volume, source selection, sound modes, and audio processing parameters.
+The **Lyngdorf** {% term integration %} allows you to control [Lyngdorf] and [Steinway & Lyngdorf] audio processors and amplifiers from Home Assistant. Lyngdorf Audio is known for its RoomPerfect room correction technology. This integration lets you control power, volume, source selection, sound modes, and audio processing parameters.
 
 [Lyngdorf]: https://lyngdorf.steinwaylyngdorf.com/electronics/
 [Steinway & Lyngdorf]: https://steinwaylyngdorf.com/
 
 ## Supported devices
 
-Lyngdorf:
+### Lyngdorf
 
 - [MP-40](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-mp-40/)
 - MP-50
@@ -32,7 +32,7 @@ Lyngdorf:
 - TDAI-2170
 - [TDAI-3400](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-3400/)
 
-Steinway & Lyngdorf:
+### Steinway & Lyngdorf
 
 - P100
 - P200

--- a/source/_integrations/lyngdorf.markdown
+++ b/source/_integrations/lyngdorf.markdown
@@ -16,11 +16,14 @@ ha_integration_type: device
 ha_quality_scale: silver
 ---
 
-The **Lyngdorf** {% term integration %} allows you to control [Lyngdorf] audio processors and amplifiers from Home Assistant. Lyngdorf Audio is known for their RoomPerfect room correction technology. This integration lets you control power, volume, source selection, sound modes, and audio processing parameters.
+The **Lyngdorf** {% term integration %} allows you to control [Lyngdorf] and [Steinway & Lyngdorf] audio processors and amplifiers from Home Assistant. Lyngdorf Audio is known for their RoomPerfect room correction technology. This integration lets you control power, volume, source selection, sound modes, and audio processing parameters.
 
 [Lyngdorf]: https://lyngdorf.steinwaylyngdorf.com/electronics/
+[Steinway & Lyngdorf]: https://steinwaylyngdorf.com/
 
 ## Supported devices
+
+Lyngdorf:
 
 - [MP-40](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-mp-40/)
 - MP-50
@@ -28,6 +31,12 @@ The **Lyngdorf** {% term integration %} allows you to control [Lyngdorf] audio p
 - [TDAI-1120](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-1120/)
 - TDAI-2170
 - [TDAI-3400](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-3400/)
+
+Steinway & Lyngdorf:
+
+- P100
+- P200
+- P300
 
 {% note %}
 The MP-60 is the only model that has been tested in the wild so far. Other models should work but may not support all features. If you have a different model, please report any issues on [GitHub](https://github.com/home-assistant/core/issues).

--- a/source/_integrations/lyngdorf.markdown
+++ b/source/_integrations/lyngdorf.markdown
@@ -57,10 +57,10 @@ Host:
 
 ### Media players
 
-The integration creates two media player {% term entities %}:
+The integration creates the following media player {% term entities %}:
 
 - **Main zone**: Controls your Lyngdorf device, including power, volume, mute, source selection, and sound mode.
-- **Zone B**: Controls the Zone B output, including power, volume, mute, and source selection.
+- **Zone B**: Controls the Zone B output, including power, volume, mute, and source selection. Only created for models with a Zone B output (the TDAI-series does not have one).
 
 ## Data updates
 


### PR DESCRIPTION
## Proposed change

Documents P100/P200/P300 support, added to the `lyngdorf` library in 1.4.0 (bumped in home-assistant/core#177685). These are Steinway & Lyngdorf-branded multichannel processors, as opposed to the existing MP-/TDAI-series which are Lyngdorf-branded — split the "Supported devices" list by brand accordingly.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#177685
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
