### PR TITLE
Document button event triggers

### DIFF
--- a/source/_integrations/button.markdown
+++ b/source/_integrations/button.markdown
@@ -40,6 +40,14 @@ In addition, the entity can have the following states:
 
 You can use button entities in automations to react when a button is pressed, or to simulate pressing the button from Home Assistant, like pressing a physical button on the device itself.
 
+## Triggers for physical buttons
+
+The button triggers also work with the {% term entity entities %} of the [Event](/integrations/event/) integration that use the **button** device class, such as a wall switch, a remote control button, or a scene controller. This lets you react to a press, a double press, or a hold on real hardware without having to know the event type names your device uses.
+
+The **Button pressed** trigger works with both button entities and these event entities. **Button double pressed**, **Button hold started**, and **Button hold ended** only apply to event entities, because a button entity cannot report those interactions.
+
+Which of these interactions you can use depends on your hardware. A device that only reports single presses does not fire the double press or hold triggers.
+
 {% include integrations/triggers.md %}
 
 {% include integrations/actions.md %}

--- a/source/_integrations/event.markdown
+++ b/source/_integrations/event.markdown
@@ -76,6 +76,17 @@ This video tutorial explains how events work in Home Assistant and how you can s
 
 {% include integrations/triggers.md %}
 
+## Triggers for button events
+
+Event entities that use the **button** device class also work with the triggers of the [Button](/integrations/button/) integration. Use them when you want to react to a press, a double press, or a hold without picking event types yourself:
+
+- [Button pressed](/triggers/button.pressed/)
+- [Button double pressed](/triggers/button.double_pressed/)
+- [Button hold started](/triggers/button.hold_started/)
+- [Button hold ended](/triggers/button.hold_ended/)
+
+Which of these you can use depends on your hardware. A button that only reports single presses does not fire the double press or hold triggers. For anything these triggers do not cover, use the [Event received](/triggers/event.received/) trigger and select the event types your device reports.
+
 ## Event automation examples
 
 ### Automation: send a notification when the doorbell rings

--- a/source/_triggers/button.double_pressed.markdown
+++ b/source/_triggers/button.double_pressed.markdown
@@ -1,0 +1,115 @@
+---
+title: "Button double pressed"
+trigger: button.double_pressed
+domain: button
+description: "Triggers when one or more buttons are pressed twice in quick succession."
+related_triggers:
+  - button.pressed
+  - button.hold_started
+  - button.hold_ended
+  - event.received
+---
+
+The **Button double pressed** trigger fires when a physical button is pressed twice in quick succession, like double-pressing a button on a wall switch or a remote control. Use it to give one button a second function without adding more hardware, for example a single press for the ceiling light and a double press for the whole room.
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), select the area, floor, device, label, or entity you want to monitor.
+5. From the triggers shown for that target, select **Button double pressed**.
+6. Select **Save**.
+
+### Options in the UI
+
+This trigger has no additional options beyond the target.
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `button.double_pressed`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: button.double_pressed
+  target:
+    entity_id: event.bedside_remote_button
+{% endexample %}
+
+This fires every time `event.bedside_remote_button` reports a double press.
+
+### Options in YAML
+
+This trigger has no additional YAML options beyond the target.
+
+{% include triggers/targets.md domain="event" %}
+
+## Good to know
+
+- This trigger works with event entities that use the **button** device class, such as wall switches, remote controls, and scene controllers. Button entities, like a device's restart or identify button, do not report double presses.
+- The device decides how quickly the two presses must follow each other. Home Assistant fires the trigger once the device reports that the two-press sequence is complete.
+- This trigger fires only for exactly two presses. A sequence of three or more presses does not fire it.
+- Not every button reports double presses. If the trigger never fires, your device may only report single presses. Check the event types the entity supports, and use the [**Event received**](/triggers/event.received/) trigger if you want to react to the exact event types your device reports.
+- Changes to `unavailable` or `unknown` do not count as presses.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn off all the lights with a double press
+
+Use this automation to make a bedside button switch off the lights everywhere, while a single press still controls the bedroom light only. This example targets a label called **All lights** that you create yourself and assign to the light entities you want to include.
+
+- **Trigger**: Button double pressed
+  - **Target**: Bedside remote button (`event.bedside_remote_button`)
+- **Action**: Turn off light
+  - **Target**: All lights (by label)
+
+{% details "YAML example for turning off all the lights with a double press" %}
+
+{% example %}
+automation: |
+  - alias: "Turn off all the lights on a double press"
+    triggers:
+      - trigger: button.double_pressed
+        target:
+          entity_id: event.bedside_remote_button
+    actions:
+      - action: light.turn_off
+        target:
+          label_id: all_lights
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: lock the front door with a double press
+
+Use this automation when you want a deliberate action, like locking a door, to need two presses instead of one.
+
+- **Trigger**: Button double pressed
+  - **Target**: Hallway switch button (`event.hallway_switch_button`)
+- **Action**: Lock lock
+  - **Target**: Front door lock
+
+{% details "YAML example for locking the front door with a double press" %}
+
+{% example %}
+automation: |
+  - alias: "Lock the front door on a double press"
+    triggers:
+      - trigger: button.double_pressed
+        target:
+          entity_id: event.hallway_switch_button
+    actions:
+      - action: lock.lock
+        target:
+          entity_id: lock.front_door
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/button.hold_ended.markdown
+++ b/source/_triggers/button.hold_ended.markdown
@@ -1,0 +1,114 @@
+---
+title: "Button hold ended"
+trigger: button.hold_ended
+domain: button
+description: "Triggers when one or more buttons stop being held."
+related_triggers:
+  - button.hold_started
+  - button.pressed
+  - button.double_pressed
+  - event.received
+---
+
+The **Button hold ended** trigger fires when you release a physical button that you were holding down. Use it to stop something that was started by holding the button, or to run an action only after a deliberate long press. To react at the start of the hold instead, use the [**Button hold started**](/triggers/button.hold_started/) trigger.
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), select the area, floor, device, label, or entity you want to monitor.
+5. From the triggers shown for that target, select **Button hold ended**.
+6. Select **Save**.
+
+### Options in the UI
+
+This trigger has no additional options beyond the target.
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `button.hold_ended`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: button.hold_ended
+  target:
+    entity_id: event.living_room_switch_up_button
+{% endexample %}
+
+This fires every time you stop holding `event.living_room_switch_up_button`.
+
+### Options in YAML
+
+This trigger has no additional YAML options beyond the target.
+
+{% include triggers/targets.md domain="event" %}
+
+## Good to know
+
+- This trigger works with event entities that use the **button** device class, such as wall switches, remote controls, and scene controllers. Button entities, like a device's restart or identify button, do not report holds.
+- This trigger fires only after a hold. Releasing a short press fires the [**Button pressed**](/triggers/button.pressed/) trigger instead, so the two do not overlap.
+- Not every button reports holds. If the trigger never fires, your device may only report single presses. Check the event types the entity supports, and use the [**Event received**](/triggers/event.received/) trigger if you want to react to the exact event types your device reports.
+- Changes to `unavailable` or `unknown` do not count as holds.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: stop the blinds when you release the button
+
+Use this automation together with [**Button hold started**](/triggers/button.hold_started/) so that the blinds move while you hold the button and stop as soon as you let go.
+
+- **Trigger**: Button hold ended
+  - **Target**: Living room switch up button (`event.living_room_switch_up_button`)
+- **Action**: Stop cover
+  - **Target**: Living room blinds
+
+{% details "YAML example for stopping the blinds when a button is released" %}
+
+{% example %}
+automation: |
+  - alias: "Stop the living room blinds when the button is released"
+    triggers:
+      - trigger: button.hold_ended
+        target:
+          entity_id: event.living_room_switch_up_button
+    actions:
+      - action: cover.stop_cover
+        target:
+          entity_id: cover.living_room_blinds
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: lock the front door with a long press
+
+Use this automation when you want locking the door to take a deliberate long press, so it cannot happen by brushing against the switch.
+
+- **Trigger**: Button hold ended
+  - **Target**: Hallway switch button (`event.hallway_switch_button`)
+- **Action**: Lock lock
+  - **Target**: Front door lock
+
+{% details "YAML example for locking the front door with a long press" %}
+
+{% example %}
+automation: |
+  - alias: "Lock the front door on a long press"
+    triggers:
+      - trigger: button.hold_ended
+        target:
+          entity_id: event.hallway_switch_button
+    actions:
+      - action: lock.lock
+        target:
+          entity_id: lock.front_door
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/button.hold_started.markdown
+++ b/source/_triggers/button.hold_started.markdown
@@ -1,0 +1,118 @@
+---
+title: "Button hold started"
+trigger: button.hold_started
+domain: button
+description: "Triggers when one or more buttons start being held."
+related_triggers:
+  - button.hold_ended
+  - button.pressed
+  - button.double_pressed
+  - event.received
+---
+
+The **Button hold started** trigger fires the moment a physical button has been held down long enough to count as a long press, while you are still holding it. Use it to start something that should keep running while you hold the button, such as opening a cover or turning a light to full brightness. To react when you let go instead, use the [**Button hold ended**](/triggers/button.hold_ended/) trigger.
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), select the area, floor, device, label, or entity you want to monitor.
+5. From the triggers shown for that target, select **Button hold started**.
+6. Select **Save**.
+
+### Options in the UI
+
+This trigger has no additional options beyond the target.
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `button.hold_started`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: button.hold_started
+  target:
+    entity_id: event.living_room_switch_up_button
+{% endexample %}
+
+This fires every time you start holding `event.living_room_switch_up_button`.
+
+### Options in YAML
+
+This trigger has no additional YAML options beyond the target.
+
+{% include triggers/targets.md domain="event" %}
+
+## Good to know
+
+- This trigger works with event entities that use the **button** device class, such as wall switches, remote controls, and scene controllers. Button entities, like a device's restart or identify button, do not report holds.
+- The device decides how long a button must be held before it counts as a hold, so the delay before the trigger fires depends on your hardware.
+- This trigger fires once at the start of the hold, not repeatedly while you keep holding.
+- Not every button reports holds. If the trigger never fires, your device may only report single presses. Check the event types the entity supports, and use the [**Event received**](/triggers/event.received/) trigger if you want to react to the exact event types your device reports.
+- Changes to `unavailable` or `unknown` do not count as holds.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: open the blinds while you hold a button
+
+Use this automation together with [**Button hold ended**](/triggers/button.hold_ended/) so that the blinds move while you hold the button and stop when you let go.
+
+- **Trigger**: Button hold started
+  - **Target**: Living room switch up button (`event.living_room_switch_up_button`)
+- **Action**: Open cover
+  - **Target**: Living room blinds
+
+{% details "YAML example for opening the blinds while a button is held" %}
+
+{% example %}
+automation: |
+  - alias: "Open the living room blinds while the button is held"
+    triggers:
+      - trigger: button.hold_started
+        target:
+          entity_id: event.living_room_switch_up_button
+    actions:
+      - action: cover.open_cover
+        target:
+          entity_id: cover.living_room_blinds
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: turn a light to full brightness on a hold
+
+Use this automation when a short press should toggle a light as usual, and holding the same button should take it straight to full brightness.
+
+- **Trigger**: Button hold started
+  - **Target**: Kitchen switch button (`event.kitchen_switch_button`)
+- **Action**: Turn on light
+  - **Target**: Kitchen ceiling light
+  - **Brightness**: 100%
+
+{% details "YAML example for turning a light to full brightness on a hold" %}
+
+{% example %}
+automation: |
+  - alias: "Turn the kitchen light to full brightness on a hold"
+    triggers:
+      - trigger: button.hold_started
+        target:
+          entity_id: event.kitchen_switch_button
+    actions:
+      - action: light.turn_on
+        target:
+          entity_id: light.kitchen_ceiling
+        data:
+          brightness_pct: 100
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/button.pressed.markdown
+++ b/source/_triggers/button.pressed.markdown
@@ -3,9 +3,14 @@ title: "Button pressed"
 trigger: button.pressed
 domain: button
 description: "Triggers when one or more buttons are pressed."
+related_triggers:
+  - button.double_pressed
+  - button.hold_started
+  - button.hold_ended
+  - event.received
 ---
 
-Use this trigger when you want an automation to run every time a button entity is pressed. This is useful when a button starts a task on a device and you also want Home Assistant to take a follow-up action.
+Use this trigger when you want an automation to run every time a button is pressed. It works with button entities, such as a reset or maintenance button that a device exposes, and with the event entities that represent physical buttons, like a wall switch or a remote control button.
 
 {% include triggers/ui_header.md %}
 
@@ -41,9 +46,12 @@ This trigger has no additional YAML options beyond the target.
 
 {% include triggers/targets.md %}
 
+Besides button entities, this trigger also watches event entities that use the **button** device class. If a target contains both kinds, Home Assistant watches all of them.
+
 ## Good to know
 
-- This trigger fires when Home Assistant detects a button press from the button entity.
+- This trigger fires when Home Assistant detects a button press from the entity.
+- For event entities, it fires on a completed short press. Holds and double presses are reported as separate event types, so use [**Button hold started**](/triggers/button.hold_started/), [**Button hold ended**](/triggers/button.hold_ended/), or [**Button double pressed**](/triggers/button.double_pressed/) for those.
 - Changes to `unavailable` or `unknown` do not count as button presses.
 - If you only need to press a button from an automation, use the related [**Press button**](/actions/button.press/) action instead.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This adds docs for the pressed, double_pressed, hold_started, hold_ended, button triggers for event entities with the button device class.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/177683
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
