### PR TITLE
Document area-based target filtering for HomeKit Bridge

### DIFF
--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -144,6 +144,48 @@ homekit:
           description: Entities to be excluded.
           required: false
           type: list
+        include_targets:
+          description: Areas, devices, floors, or labels whose entities are included. ([Filter by area, device, floor, or label](#filter-by-area-device-floor-or-label))
+          required: false
+          type: map
+          keys:
+            area_id:
+              description: Areas to be included. Matches the entities assigned to the area, as well as the entities of the devices in that area.
+              required: false
+              type: list
+            device_id:
+              description: Devices to be included. Matches the entities of those devices.
+              required: false
+              type: list
+            floor_id:
+              description: Floors to be included. Matches the entities in every area on that floor.
+              required: false
+              type: list
+            label_id:
+              description: Labels to be included. Matches the entities with that label, as well as the entities of the devices and areas with that label.
+              required: false
+              type: list
+        exclude_targets:
+          description: Areas, devices, floors, or labels whose entities are excluded. Accepts the same keys as `include_targets`. ([Filter by area, device, floor, or label](#filter-by-area-device-floor-or-label))
+          required: false
+          type: map
+          keys:
+            area_id:
+              description: Areas to be excluded.
+              required: false
+              type: list
+            device_id:
+              description: Devices to be excluded.
+              required: false
+              type: list
+            floor_id:
+              description: Floors to be excluded.
+              required: false
+              type: list
+            label_id:
+              description: Labels to be excluded.
+              required: false
+              type: list
     entity_config:
       description: Configuration for specific entities. All subordinate keys are the corresponding entity ids of the domains, e.g., `alarm_control_panel.alarm`.
       required: false
@@ -421,6 +463,45 @@ homekit:
 {% include common-tasks/filters.md %}
 
 Hidden entities and categorized entities (config, diagnostic, and system entities) are not included unless they are explicitly matched by `include_entity_globs` or `include_entities` or selected in the UI in include mode.
+
+### Filter by area, device, floor, or label
+
+Instead of listing entities one by one, you can filter by where an entity is or by how it is labeled.
+
+To filter by area in the UI:
+
+1. Go to {% my integrations title="**Settings** > **Devices & services**" %} and select **Configure** on the bridge you want to change.
+2. On the **Select the entities to be included** or **Select the entities to be excluded** step, use **Included areas** or **Excluded areas** to select the areas you want.
+3. Complete the options flow.
+
+In YAML, use the `include_targets` and `exclude_targets` keys. Both accept `area_id`, `device_id`, `floor_id`, and `label_id`, each holding a list of IDs. Since the options flow currently offers area pickers only, use YAML if you want to filter by device, floor, or label.
+
+```yaml
+# Example filter to include the living room lights, except labeled entities
+homekit:
+  - filter:
+      include_domains:
+        - light
+      include_targets:
+        area_id:
+          - living_room
+      exclude_targets:
+        label_id:
+          - hidden_from_homekit
+```
+
+Targets are applied on top of the rules above:
+
+- Entities and entity globs that you list explicitly are absolute. They are included or excluded regardless of the targets you use.
+- `exclude_targets` subtracts. Any remaining entity that matches an excluded target is not exposed to HomeKit.
+- `include_targets` narrows the include. When you combine included domains with included targets, only the entities that match both are exposed to HomeKit. In the example above, this is the lights in the living room, not every light in your home.
+- `include_targets` on its own acts as the include list. If you do not include any domains, every entity that matches an included target is exposed to HomeKit.
+- Excluded domains stay excluded, even if an entity matches an included target.
+- A filter without targets behaves exactly as before, so your existing configuration keeps working unchanged.
+
+Targets never match hidden entities, categorized entities, or disabled entities. To expose one of those, list it in `include_entities`.
+
+Target membership is dynamic. If you move an entity to another area, or add or remove a label, the bridge reloads a moment later so that it reflects the change.
 
 ## Docker Network Isolation
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -477,7 +477,7 @@ To filter by area in the UI:
 In YAML, use the `include_targets` and `exclude_targets` keys. Both accept `area_id`, `device_id`, `floor_id`, and `label_id`, each holding a list of IDs. Since the options flow currently offers area pickers only, use YAML if you want to filter by device, floor, or label.
 
 ```yaml
-# Example filter to include the living room lights, except labeled entities
+# Example filter to include the living room lights, except the ones labeled hidden_from_homekit
 homekit:
   - filter:
       include_domains:
@@ -499,7 +499,7 @@ Targets are applied on top of the rules above:
 - Excluded domains stay excluded, even if an entity matches an included target.
 - A filter without targets behaves exactly as before, so your existing configuration keeps working unchanged.
 
-Targets never match hidden entities, categorized entities, or disabled entities. To expose one of those, list it in `include_entities`.
+Targets never match hidden entities, categorized entities, or disabled entities. To expose a hidden or categorized entity, match it with `include_entities` or `include_entity_globs`. Disabled entities have no state, so they cannot be exposed to HomeKit at all.
 
 Target membership is dynamic. If you move an entity to another area, or add or remove a label, the bridge reloads a moment later so that it reflects the change.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the area-based target filtering added to the HomeKit Bridge filter in home-assistant/core#177773.

The `filter` configuration block gains the two new keys, and a new **Filter by area, device, floor, or label** section under **Configure Filter** covers:

- The **Included areas** and **Excluded areas** pickers in the include and exclude steps of the options flow.
- The `include_targets` and `exclude_targets` YAML keys, with `area_id`, `device_id`, `floor_id`, and `label_id`.
- How targets combine with the existing domain, entity, and glob filters: explicit entities and globs stay absolute, exclude targets subtract, include targets narrow the include (a selected domain intersects with a selected area rather than being replaced by it), include targets on their own act as the include list, and excluded domains stay excluded.
- That configurations without targets are unaffected.
- That targets never match hidden, categorized, or disabled entities, which still need an explicit `include_entities` listing.
- That target membership is dynamic, so the bridge reloads when an entity is moved to another area or is labeled or unlabeled.

The options flow in the core PR exposes areas only, while the YAML schema accepts all four target types. The docs therefore document all four keys and state that the pickers currently cover areas only, so no working configuration is left undocumented.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/177773
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
