### PR TITLE
Document Subaru binary_sensor platform

### DIFF
--- a/source/_integrations/subaru.markdown
+++ b/source/_integrations/subaru.markdown
@@ -2,6 +2,7 @@
 title: Subaru
 description: Instructions on how to set up your Subaru account with Home Assistant.
 ha_category:
+  - Binary sensor
   - Car
   - Lock
   - Presence detection
@@ -13,6 +14,7 @@ ha_codeowners:
   - '@G-Two'
 ha_domain: subaru
 ha_platforms:
+  - binary_sensor
   - button
   - device_tracker
   - diagnostics
@@ -71,12 +73,54 @@ Available sensors will vary by model, year, and subscription type. The integrati
 
 EV sensors (EV battery level, EV range, EV time to full charge) are only present on PHEV vehicles. The recommended tire pressure sensors are disabled by default and may report `unknown` on older Gen 2 vehicles that do not advertise the underlying tire-pressure recommendation in `vehicle_health`. The vehicle state sensor reports one of `ignition_off`, `ignition_acc` (accessory power), `ignition_on`, or `engine_on_remote_start`; if your vehicle reports a value not in that list, please file a bug and attach the integration's diagnostics download.
 
+## Binary sensors
+
+Binary sensors are added for Gen 2 and newer vehicles. Most are derived from data the vehicle pushes after engine shutdown, so a sensor may show `unknown` until the first push has been received.
+
+### Openings
+
+Each door and window reports open/closed: door front left, door front right, door rear left, door rear right, hood, tailgate, window front left, window front right, window rear left, window rear right, and sunroof.
+
+### Per-door lock status
+
+Read-only lock state for each door (front left/right, rear left/right, tailgate) — independent of the [controllable lock entity](#lock), which reflects the last command sent rather than the vehicle's actual state.
+
+### EV
+
+PHEV vehicles get two additional binary sensors:
+
+- **EV plug**: on when the charging cable is connected.
+- **Charging** *(disabled by default)*: on only while the vehicle is actively drawing charge, distinct from simply being plugged in.
+
+### Vehicle health
+
+The vehicle's warning indicators (Malfunction Indicator Lamps, or MILs) are exposed as diagnostic binary sensors. **Vehicle health** is enabled by default and reflects the overall rollup; the individual indicators below are **disabled by default** — enable the ones you want to track. Only indicators your vehicle actually reports are created.
+
+- Airbag
+- AWD
+- ABS
+- Transmission temperature
+- Blind spot / rear cross traffic
+- Check engine
+- Electronic brakeforce distribution
+- Electric parking brake
+- Engine oil level
+- EyeSight
+- Idle stop & start
+- Oil pressure
+- Electric power steering
+- Reverse automatic braking
+- Steering responsive headlights
+- Telematics
+- Tire pressure
+- Vehicle dynamics control
+- Washer fluid
+
 ## Lock
 
-This integration supports remote locking and unlocking of vehicle doors. If doors are remotely unlocked, they will automatically relock if a door is not opened within a minute. There is no remote notification of this automatic relock.  
-{% note %}
-This integration does not yet support tracking the current lock/unlock state.
-{% endnote %}
+This integration supports remote locking and unlocking of vehicle doors. If doors are remotely unlocked, they will automatically relock if a door is not opened within a minute. There is no remote notification of this automatic relock.
+
+The lock entity's state reflects the last command sent, not necessarily the vehicle's actual state. To see the current lock state of each door, use the [per-door lock status binary sensors](#per-door-lock-status).
 
 ### Unlock specific door
 

--- a/source/_integrations/subaru.markdown
+++ b/source/_integrations/subaru.markdown
@@ -79,7 +79,19 @@ Binary sensors are added for Gen 2 and newer vehicles. Most are derived from dat
 
 ### Openings
 
-Each door and window reports open/closed: door front left, door front right, door rear left, door rear right, hood, tailgate, window front left, window front right, window rear left, window rear right, and sunroof.
+Each door and window reports open or closed:
+
+- Door front left
+- Door front right
+- Door rear left
+- Door rear right
+- Hood
+- Tailgate
+- Window front left
+- Window front right
+- Window rear left
+- Window rear right
+- Sunroof
 
 ### Per-door lock status
 
@@ -89,12 +101,12 @@ Read-only lock state for each door (front left/right, rear left/right, tailgate)
 
 PHEV vehicles get two additional binary sensors:
 
-- **EV plug**: on when the charging cable is connected.
-- **Charging** *(disabled by default)*: on only while the vehicle is actively drawing charge, distinct from simply being plugged in.
+- EV plug: on when the charging cable is connected.
+- Charging (disabled by default): on only while the vehicle is actively drawing charge, distinct from simply being plugged in.
 
 ### Vehicle health
 
-The vehicle's warning indicators (Malfunction Indicator Lamps, or MILs) are exposed as diagnostic binary sensors. **Vehicle health** is enabled by default and reflects the overall rollup; the individual indicators below are **disabled by default** — enable the ones you want to track. Only indicators your vehicle actually reports are created.
+The vehicle's warning indicators (Malfunction Indicator Lamps, or MILs) are exposed as diagnostic binary sensors. Vehicle health is enabled by default and reflects the overall rollup. The individual indicators below are disabled by default; enable the ones you want to track. Only indicators your vehicle actually reports are created.
 
 - Airbag
 - AWD
@@ -102,7 +114,7 @@ The vehicle's warning indicators (Malfunction Indicator Lamps, or MILs) are expo
 - Transmission temperature
 - Blind spot / rear cross traffic
 - Check engine
-- Electronic brakeforce distribution
+- Electronic brake force distribution
 - Electric parking brake
 - Engine oil level
 - EyeSight


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the new `binary_sensor` platform added in home-assistant/core#177907: door/window openings, per-door lock status, EV plug/charging, and vehicle health (overall rollup + per-MIL warning indicators). Also updates the Lock section to point at the new per-door lock sensors instead of the old "doesn't support tracking lock state" note, since that's no longer true.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#177907
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
