### PR TITLE
Update Tomorrow.io documentation for location subentries

### DIFF
--- a/source/_integrations/tomorrowio.markdown
+++ b/source/_integrations/tomorrowio.markdown
@@ -38,3 +38,29 @@ When using a free account, the information provided by Tomorrow.io is limited to
 | `daily`       | Daily  forecasts for the next 14 days                                                                            |
 
 {% include integrations/config_flow.md %}
+
+{% configuration_basic %}
+API key:
+  description: "Your Tomorrow.io API key."
+{% endconfiguration_basic %}
+
+The integration creates one entry per API key. The places you want weather and air quality data for are added to that entry as locations.
+
+{% note %}
+If you set up Tomorrow.io before this version, your existing entries are migrated automatically: locations sharing an API key are collected under a single entry, and their entities, devices, and history are preserved.
+{% endnote %}
+
+## Adding a location
+
+1. Go to {% my integrations title="**Settings** > **Devices & services**" %} and select the **Tomorrow.io** integration.
+2. Select **Add location**.
+3. Enter a name and pick the location on the map.
+4. Optionally adjust **Minutes between NowCast forecasts** (1, 5, 15, 30, or 60), which controls the granularity of the `nowcast` forecast.
+
+### Changing a location
+
+To change a location's name, coordinates, or NowCast timestep, select the three-dot menu next to the location and select **Reconfigure location**.
+
+## Data updates
+
+All of an API key's locations are {% term polling polled %} together in one cycle. The polling interval is calculated from your account's daily request limit and the number of configured locations, keeping usage at about 90% of the available daily requests.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documentation for the Tomorrow.io restructure to one config entry per API key with location subentries (home-assistant/core#177911): API-key-only setup, adding and reconfiguring locations (including the NowCast timestep, which replaces the old options flow), an automatic-migration note for existing users, and a data-updates section explaining the shared polling cycle.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/177911
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EJdgr9Lb3JETRD4XPkXL2
