### PR TITLE
Add confirmation options to toggle card feature

### DIFF
--- a/source/dashboards/features.markdown
+++ b/source/dashboards/features.markdown
@@ -1044,6 +1044,16 @@ type:
   required: true
   description: "`toggle`"
   type: string
+confirm_turn_on:
+  required: false
+  description: Show a confirmation dialog before turning on the entity.
+  type: boolean
+  default: false
+confirm_turn_off:
+  required: false
+  description: Show a confirmation dialog before turning off the entity.
+  type: boolean
+  default: false
 {% endconfiguration %}
 
 ## Trend graph

--- a/source/dashboards/features.markdown
+++ b/source/dashboards/features.markdown
@@ -1037,6 +1037,8 @@ Widget that displays a button to toggle a [switch](/integrations/switch) or [inp
 ```yaml
 features:
   - type: "toggle"
+    confirm_turn_on: true
+    confirm_turn_off: true
 ```
 
 {% configuration features %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the new `confirm_turn_on` and `confirm_turn_off` options of the toggle card feature. When enabled, a confirmation dialog is shown before the entity is turned on or off, preventing accidental toggles.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/53436
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
