### PR TITLE
Fix UniFi Access blueprint triggers to ignore unavailable/unknown states

### DIFF
--- a/source/blueprints/integrations/unifi_access_door_access_notification.yaml
+++ b/source/blueprints/integrations/unifi_access_door_access_notification.yaml
@@ -7,7 +7,7 @@ blueprint:
   domain: automation
   author: RaHehl
   homeassistant:
-    min_version: 2026.4.0
+    min_version: 2026.7.0
 
   input:
     access_entity:
@@ -44,14 +44,12 @@ blueprint:
         action:
 
 triggers:
-  - trigger: state
-    entity_id: !input access_entity
-
-conditions:
-  - condition: state
-    entity_id: !input access_entity
-    attribute: event_type
-    state: !input event_type
+  - trigger: event.received
+    target:
+      entity_id: !input access_entity
+    options:
+      event_type:
+        - !input event_type
 
 actions: !input actions
 

--- a/source/blueprints/integrations/unifi_access_doorbell_notification.yaml
+++ b/source/blueprints/integrations/unifi_access_doorbell_notification.yaml
@@ -6,7 +6,7 @@ blueprint:
   domain: automation
   author: RaHehl
   homeassistant:
-    min_version: 2026.4.0
+    min_version: 2026.7.0
 
   input:
     doorbell_entity:
@@ -30,8 +30,12 @@ blueprint:
         action:
 
 triggers:
-  - trigger: state
-    entity_id: !input doorbell_entity
+  - trigger: event.received
+    target:
+      entity_id: !input doorbell_entity
+    options:
+      event_type:
+        - ring
 
 actions: !input actions
 


### PR DESCRIPTION
## Summary
- Both UniFi Access blueprints (`unifi_access_doorbell_notification.yaml` and `unifi_access_door_access_notification.yaml`) used a generic `state` trigger on the event entity, which fires on *any* state change — including transitions to/from `unavailable`/`unknown` (e.g. on a Home Assistant restart or a WebSocket reconnect to the UniFi Access controller).
- The doorbell blueprint had no condition to filter these out, so it could send a false "someone's at the door" notification without an actual ring event.
- Switched both to the `event.received` trigger, which only fires for the specified event type(s) and ignores `unavailable`/`unknown` transitions. This also let us drop the extra `condition: state` block from the door access blueprint, since event type filtering now happens at the trigger.
- Bumped `min_version` from `2026.4.0` to `2026.7.0`, since purpose-specific triggers like `event.received` graduated from Labs to the default automation editor in the 2026.7 release.

## Test plan
- [ ] Validated blueprint YAML syntax
- [ ] Imported both blueprints into a test Home Assistant instance with UniFi Access and confirmed the doorbell/access triggers fire only on real events, not on restarts/reconnects