### PR TITLE
Document ToGrill silence alarm button and timer

### DIFF
--- a/source/_integrations/togrill.markdown
+++ b/source/_integrations/togrill.markdown
@@ -5,12 +5,14 @@ ha_iot_class: Local Push
 ha_config_flow: true
 ha_release: '2025.9'
 ha_category:
+  - Button
   - Event
   - Number
   - Sensor
 ha_domain: togrill
 ha_bluetooth: true
 ha_platforms:
+  - button
   - event
   - number
   - select
@@ -44,6 +46,7 @@ Many ToGrill compatible devices exist from many different vendors. Only a subset
 | Device                           | Model  |
 |----------------------------------|--------|
 | Rubicson - BBQ probe thermometer | Pro-05 |
+| MostEssential - BBQ thermometer  | AT-02  |
 
 ## Events
 
@@ -77,6 +80,7 @@ Many ToGrill compatible devices exist from many different vendors. Only a subset
 **Target temperature**: The target temperature of the given temperature probe. Set value to 0 to disable target alarm.
 **Minimum temperature**: The minimum temperature the grill probe is allowed to reach. Set value to 0 to disable target alarm.
 **Maximum temperature**: The maximum temperature the grill probe is allowed to reach. Set value to 0 to disable target alarm.
+**Timer**: A countdown timer, in minutes, for the given probe. The device sounds an alarm when it reaches zero. Set value to 0 to stop the timer.
 **Alarm interval**: The interval in minutes between successive alarms.
 
 {% tip %}
@@ -84,6 +88,10 @@ Many ToGrill compatible devices exist from many different vendors. Only a subset
 **Target temperature** and the **Minimum temperature** / **Maximum temperature** are exclusive, and will disable the other setting when set on same probe.
 
 {% endtip %}
+
+## Buttons
+
+**Silence alarm**: Acknowledges an active alarm, silencing the device's buzzer for both temperature and timer alarms. The alarm targets themselves are not changed.
 
 ## Removing the integration
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents additions to the **ToGrill** integration:

- A new **Silence alarm** button (adds the `button` platform), which acknowledges and silences an active temperature or timer alarm without changing the alarm targets.
- The per-probe **Timer** number, which was added previously but not yet documented.

Also lists the **MostEssential AT-02** as a tested working device.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#177360
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
