### PR TITLE
Document Shelly device replacement

### DIFF
--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -519,6 +519,27 @@ Please check from the device Web UI that the configured server is reachable.
 - For battery-powered devices, the `update` platform entities only inform about the availability of firmware updates but are not able to trigger the update process.
 - Using the `homeassistant.update_entity` action for an entity belonging to a battery-powered device is not possible because most of the time these devices are sleeping (are offline).
 
+## Replacing a device
+
+If a Shelly device fails, you can move its configuration to the replacement unit instead of setting the new device up from scratch. The entities, entity IDs, history, and automations of the old device are kept.
+
+To be offered the migration, all of the following must be true:
+
+- The replacement must report the **same device name** as the old device, and that name must be set **before the device is added** to Home Assistant. Set it in the Shelly app or in the device web interface. A device with no name reports its host name, which contains its own MAC address, so two unnamed devices never match each other.
+- Both devices must be the same model and the same [generation](#shelly-device-generations).
+- The existing configuration entry must not be working. As long as the old device still answers, Home Assistant assumes both devices are in use and sets the new one up separately.
+
+When you add the replacement, Home Assistant offers two options:
+
+- **Add as a new device**: sets the device up as an additional device and leaves the existing configuration untouched. Two Shelly devices are allowed to share a name.
+- **Migrate configuration to the new device**: moves the configuration of the old device over to the new one, including its sub-devices.
+
+The host, port, and credentials of the migrated configuration are taken from the new device. If the old device used a password and the new one does not, the stored credentials are dropped.
+
+{% note %}
+If another device in Home Assistant is already registered for the MAC address of the replacement, the migration is refused and nothing is changed. Add the Shelly as a new device instead.
+{% endnote %}
+
 ## Removing the integration
 
 This integration follows standard integration removal, no extra steps are required.

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -537,7 +537,7 @@ When you add the replacement, Home Assistant offers two options:
 The host, port, and credentials of the migrated configuration are taken from the new device. If the old device used a password and the new one does not, the stored credentials are dropped.
 
 {% note %}
-If another device in Home Assistant is already registered for the MAC address of the replacement, the migration is refused and nothing is changed. Add the Shelly as a new device instead.
+If the Shelly integration already has a device registered for the MAC address of the replacement, the migration is refused and nothing is changed. Add the Shelly as a new device instead.
 {% endnote %}
 
 ## Removing the integration


### PR DESCRIPTION
## Proposed change

Documents the device replacement flow added to the Shelly integration in home-assistant/core#174581.

When a Shelly is replaced, the configuration of the old unit can be migrated onto the new one instead of setting it up from scratch, which keeps entities, entity IDs, history and automations. The new section describes the conditions that have to be met, the two options the flow offers, and what happens to host, port and credentials.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch)
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch)
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch)
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch)
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #
- Link to parent pull request in the codebase: home-assistant/core#174581
- Link to parent pull request in the Brands repository:

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] All text is written in US English.
- [x] I've checked the PR preview and everything looks good.
