### PR TITLE
Add Tado heating circuit select

### DIFF
--- a/source/_integrations/tado.markdown
+++ b/source/_integrations/tado.markdown
@@ -6,6 +6,7 @@ ha_category:
   - Climate
   - Hub
   - Presence detection
+  - Select
   - Sensor
   - Switch
   - Water heater
@@ -21,6 +22,7 @@ ha_platforms:
   - binary_sensor
   - climate
   - diagnostics
+  - select
   - sensor
   - switch
   - water_heater
@@ -39,6 +41,7 @@ There is currently support for the following device types within Home Assistant:
 - Sensor - for some additional information of the zones.
 - Weather - for information about the current weather at the location of your Tado home.
 - Switch - for controlling child lock on supported devices.
+- Select - for choosing which heating circuit serves a zone.
 
 The Tado thermostats are internet connected thermostats. There exists an unofficial API at [my.tado.com](https://my.tado.com/), which is used by their website and now by this component.
 


### PR DESCRIPTION
## Proposed change

Documents the per-zone heating circuit select added in home-assistant/core#178096.

Homes with more than one heating circuit — for example a boiler plus underfloor heating on separate receivers — can now see and change which circuit serves each heating zone. This adds the `Select` category and the `select` platform to the integration page, and lists the entity with the other supported device types.

## Type of change

- [x] Add a new integration platform (`select`) to an existing integration page

## Additional information

- Core PR: home-assistant/core#178096 (merged)

## Checklist

- [x] I have read and followed the [documentation standards](https://developers.home-assistant.io/docs/documenting/standards/).
