### PR TITLE
Describe the adaptive Tado polling interval

### DIFF
--- a/source/_integrations/tado.markdown
+++ b/source/_integrations/tado.markdown
@@ -84,7 +84,9 @@ Beware that the Tado (v2) API does not provide GPS location of devices, only a b
 
 ## Data updates
 
-The integration normally updates every five minutes. For more detailed steps on how to define a custom polling interval, follow the procedure below.
+How often the integration polls depends on your tado° API budget and on whether anything is currently heating. It polls at most every five minutes while a zone is active, backs off to every 30 minutes when nothing is, and stretches the interval further if the daily call budget is running low. The budget is read from the rate limit headers tado° returns, and resets around midday Central European Time.
+
+For more detailed steps on how to define a custom polling interval, follow the procedure below.
 
 ### Defining a custom polling interval
 


### PR DESCRIPTION
## Proposed change

The page currently says:

> The integration normally updates every five minutes.

That stops being accurate with home-assistant/core#178095. The integration already contains an adaptive interval calculation, but it never actually ran because the value it reads was never stored, so the interval always fell back to the static five minutes. With that fixed, the polling interval becomes:

- at most every five minutes while a zone is actively heating or cooling
- every 30 minutes when nothing is active
- longer than that when the remaining daily API call budget is low

This rewrites the **Data updates** section to describe that, and mentions that the budget comes from the rate limit headers tado° returns and resets around midday CET.

## Type of change

- [x] Update the documentation of an existing integration to match a behaviour change

## Additional information

- Core PR: home-assistant/core#178095
- Background on the tado° API budget: home-assistant/core#162858

## Checklist

- [x] I have read and followed the [documentation standards](https://developers.home-assistant.io/docs/documenting/standards/).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
