### PR TITLE
Correct availability remark for the LG webOS TV screen switch

### DIFF
--- a/source/_integrations/webostv.markdown
+++ b/source/_integrations/webostv.markdown
@@ -65,7 +65,7 @@ The **LG webOS TV** integration provides the following entities.
 
 - **Screen**
   - **Description**: Turns off the TV screen while the TV keeps running, so you can keep listening to the sound. Turn the switch back on to show the picture again.
-  - **Remarks**: You can only switch the screen while the TV is on. If you try to switch it while the TV is off, Home Assistant shows an error message.
+  - **Remarks**: This entity is unavailable while the TV is off, even if you use a [Device is requested to turn on](/triggers/webostv.turn_on/) automation to keep the media player available.
 
 {% include integrations/triggers.md %}
 

--- a/source/_integrations/webostv.markdown
+++ b/source/_integrations/webostv.markdown
@@ -65,7 +65,7 @@ The **LG webOS TV** integration provides the following entities.
 
 - **Screen**
   - **Description**: Turns off the TV screen while the TV keeps running, so you can keep listening to the sound. Turn the switch back on to show the picture again.
-  - **Remarks**: This entity is unavailable while the TV is off, even if you use a [Device is requested to turn on](/triggers/webostv.turn_on/) automation to keep the media player available.
+  - **Remarks**: This entity is unavailable when the TV is off, even if the TV media player remains available (for example, because you use the [**Device is requested to turn on**](/triggers/webostv.turn_on/) trigger).
 
 {% include integrations/triggers.md %}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Corrects the availability remark for the Screen switch documented in [#47193](https://github.com/darkrain-nl/home-assistant.io/issues/47193).

While that PR was open, the parent core PR [home-assistant/core#177938](https://github.com/home-assistant/core/pull/177938) changed during review and reinstated the available override on the screen switch entity:

@property
@override
def available(self) -> bool:
    """Return true if the entity is available."""
    return super().available and self._client.tv_state.is_on
The merged text says you get an error message if you try to switch the screen while the TV is off, but the entity is unavailable in that state, so there is nothing to select. The remark now describes what actually happens, including the case where a turn-on automation keeps the media player available while the screen switch still goes unavailable.

This targets next because the screen switch entity has not been released yet.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/177938
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
