### PR TITLE
Document the sensors provided by the Meater integration

### DIFF
--- a/source/_integrations/meater.markdown
+++ b/source/_integrations/meater.markdown
@@ -22,7 +22,41 @@ The **Meater** {% term integration %} allows for communicating with the [Meater 
 
 Once configuration is complete, probes will be added as soon as they're seen by Home Assistant. They will be marked unavailable when the probes are disconnected from Meater Cloud.
 
-Currently, both the internal and external temperature of each probe will be displayed.
+## Supported functionality
+
+The **Meater** integration provides the following entities for each probe.
+
+### Sensors
+
+- **Ambient temperature**
+  - **Description**: Ambient temperature reported by the probe.
+
+- **Internal temperature**
+  - **Description**: Temperature measured at the probe tip.
+
+- **Cooking**
+  - **Description**: Name of the selected meat, or the custom name set in the Meater app.
+  - **Remarks**: Unavailable while no cook is in progress.
+
+- **Cook state**
+  - **Description**: State of the current cook, such as **Not started**, **Started**, **Resting**, or **Finished**.
+  - **Remarks**: Unavailable while no cook is in progress.
+
+- **Target temperature**
+  - **Description**: Target temperature of the current cook.
+  - **Remarks**: Unavailable while no cook is in progress.
+
+- **Peak temperature**
+  - **Description**: Peak temperature of the current cook.
+  - **Remarks**: Unavailable while no cook is in progress.
+
+- **Time remaining**
+  - **Description**: Timestamp at which the current cook is expected to finish.
+  - **Remarks**: Unavailable while no cook is in progress.
+
+- **Time elapsed**
+  - **Description**: Timestamp at which the current cook started.
+  - **Remarks**: Unavailable while no cook is in progress.
 
 ## Troubleshooting
 

--- a/source/_integrations/meater.markdown
+++ b/source/_integrations/meater.markdown
@@ -30,9 +30,11 @@ The **Meater** integration provides the following entities for each probe.
 
 - **Ambient temperature**
   - **Description**: Ambient temperature reported by the probe.
+  - **Device class**: `temperature`
 
 - **Internal temperature**
   - **Description**: Temperature measured at the probe tip.
+  - **Device class**: `temperature`
 
 - **Cooking**
   - **Description**: Name of the selected meat, or the custom name set in the Meater app.
@@ -40,22 +42,27 @@ The **Meater** integration provides the following entities for each probe.
 
 - **Cook state**
   - **Description**: State of the current cook, such as **Not started**, **Started**, **Resting**, or **Finished**.
+  - **Device class**: `enum`
   - **Remarks**: Unavailable while no cook is in progress.
 
 - **Target temperature**
   - **Description**: Target temperature of the current cook.
+  - **Device class**: `temperature`
   - **Remarks**: Unavailable while no cook is in progress.
 
 - **Peak temperature**
   - **Description**: Peak temperature of the current cook.
+  - **Device class**: `temperature`
   - **Remarks**: Unavailable while no cook is in progress.
 
 - **Time remaining**
-  - **Description**: Timestamp at which the current cook is expected to finish.
+  - **Description**: Timestamp at which the current cook is expected to finish, not the remaining duration.
+  - **Device class**: `timestamp`
   - **Remarks**: Unavailable while no cook is in progress.
 
 - **Time elapsed**
-  - **Description**: Timestamp at which the current cook started.
+  - **Description**: Timestamp at which the current cook started, not the elapsed duration.
+  - **Device class**: `timestamp`
   - **Remarks**: Unavailable while no cook is in progress.
 
 ## Troubleshooting

--- a/source/_integrations/meater.markdown
+++ b/source/_integrations/meater.markdown
@@ -30,11 +30,11 @@ The **Meater** integration provides the following entities for each probe.
 
 - **Ambient temperature**
   - **Description**: Ambient temperature reported by the probe.
-  - **Device class**: `temperature`
+  - **Device class**: temperature
 
 - **Internal temperature**
   - **Description**: Temperature measured at the probe tip.
-  - **Device class**: `temperature`
+  - **Device class**: temperature
 
 - **Cooking**
   - **Description**: Name of the selected meat, or the custom name set in the Meater app.
@@ -42,27 +42,27 @@ The **Meater** integration provides the following entities for each probe.
 
 - **Cook state**
   - **Description**: State of the current cook, such as **Not started**, **Started**, **Resting**, or **Finished**.
-  - **Device class**: `enum`
+  - **Device class**: enum
   - **Remarks**: Unavailable while no cook is in progress.
 
 - **Target temperature**
   - **Description**: Target temperature of the current cook.
-  - **Device class**: `temperature`
+  - **Device class**: temperature
   - **Remarks**: Unavailable while no cook is in progress.
 
 - **Peak temperature**
   - **Description**: Peak temperature of the current cook.
-  - **Device class**: `temperature`
+  - **Device class**: temperature
   - **Remarks**: Unavailable while no cook is in progress.
 
 - **Time remaining**
   - **Description**: Timestamp at which the current cook is expected to finish, not the remaining duration.
-  - **Device class**: `timestamp`
+  - **Device class**: timestamp
   - **Remarks**: Unavailable while no cook is in progress.
 
 - **Time elapsed**
   - **Description**: Timestamp at which the current cook started, not the elapsed duration.
-  - **Device class**: `timestamp`
+  - **Device class**: timestamp
   - **Remarks**: Unavailable while no cook is in progress.
 
 ## Troubleshooting


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The page said that only the internal and external temperature of each probe are displayed. The integration creates eight sensors per probe, and there is no external temperature sensor: the second temperature is **Ambient temperature**. This documents all eight sensors and notes which ones are only available during a cook.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
