### PR TITLE
Add Persang Infrared integration documentation

### DIFF
--- a/source/_integrations/persang_infrared.markdown
+++ b/source/_integrations/persang_infrared.markdown
@@ -1,0 +1,75 @@
+---
+title: Persang Infrared
+description: Integration to control Persang speakers using an infrared transmitter.
+ha_category:
+  - Button
+  - Infrared
+  - Media player
+ha_release: 2026.9
+ha_iot_class: Assumed State
+ha_codeowners:
+  - '@Dr-Blank'
+ha_domain: persang_infrared
+ha_config_flow: true
+ha_platforms:
+  - button
+  - media_player
+ha_integration_type: device
+ha_quality_scale: bronze
+---
+
+The **Persang Infrared** {% term integration %} lets you control a Persang Bluetooth speaker using any infrared transmitter previously configured in Home Assistant.
+
+Because the integration communicates over infrared, it operates in a one-way, fire-and-forget fashion: commands are sent to the speaker but there is no feedback channel to confirm the current state. The integration therefore uses assumed states, and restores the last state it sent after a restart.
+
+## Prerequisites
+
+Before setting up the Persang Infrared integration, you need a working infrared transmitter set up in Home Assistant that exposes an [Infrared](/integrations/infrared/) entity. For example, you can use an ESPHome device with an IR LED pointed at your speaker.
+
+{% include integrations/config_flow.md %}
+
+{% configuration_basic %}
+Infrared transmitter:
+  description: The infrared transmitter entity to use for sending commands. This must be an entity provided by a hardware integration (such as ESPHome) that has already been set up with an IR transmitter.
+{% endconfiguration_basic %}
+
+## Supported devices
+
+The IR commands were captured from the remote shipped with a Persang Octane 9 speaker. Persang sells the same remote as a spare part for several of its speakers, so other Persang models are likely to respond to the same commands, but only the Octane 9 has been verified.
+
+If your speaker does not respond, or if you want another Persang remote supported, please [open an issue on the infrared-protocols repository](https://github.com/home-assistant-libs/infrared-protocols/issues) with captured IR signals from your remote.
+
+## Supported functionality
+
+The **Persang Infrared** integration provides the following entities.
+
+### Media player
+
+- **Persang speaker**
+  - **Description**: Represents the speaker and allows you to control it over IR.
+  - **Supported features**: Turn on, turn off, volume up, volume down, mute, play, pause, next track, and previous track.
+
+### Buttons
+
+The remaining remote buttons, which the media player entity has no place for, are provided as buttons:
+
+- **Mode**: Cycles through the speaker's playback modes.
+- **Equalizer**: Cycles through the speaker's equalizer presets.
+- **Scan**: Starts scanning the current source.
+- **Repeat**: Cycles through the repeat modes.
+- **0** to **9**: Send the corresponding numeric key, which the speaker uses to select a track.
+
+## Known limitations
+
+- The integration uses assumed state, meaning Home Assistant cannot read the actual state of the speaker (for example, whether it is on or off, or what the current volume is).
+- Presses on the physical remote are not tracked. The integration only sends commands through an infrared transmitter, so using the remote directly leaves the entities showing whatever state Home Assistant last set.
+- Turning on and turning off the speaker both send the same IR power toggle command, as is standard with infrared remotes. The same applies to play and pause, and to muting and unmuting.
+- Volume control is step-based only; there is no way to set an absolute volume level.
+- The mode, equalizer, and repeat buttons cycle through the available settings, so Home Assistant cannot select a specific one or tell which one is active.
+- Source selection is not exposed, because the remote has no dedicated source buttons.
+
+## Removing the integration
+
+This integration follows standard integration removal.
+
+{% include integrations/remove_device_service.md %}


### PR DESCRIPTION
## Proposed change

Documentation for the new `persang_infrared` integration, which controls Persang Bluetooth speakers through an infrared transmitter already set up in Home Assistant.

Covers the prerequisites, the config flow, which devices are known to work (the command set was captured from a Persang Octane 9 remote, and Persang sells the same handset as a spare for its other speakers), every entity the integration creates, and the limitations that come with an emitter-only, assumed-state IR device.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/178107
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/10912
- This PR fixes or closes issue: fixes #
