### PR TITLE
Expand KNX entry in 2026.8 release notes

### DIFF
--- a/source/_posts/2026-08-05-release-20268.markdown
+++ b/source/_posts/2026-08-05-release-20268.markdown
@@ -327,7 +327,7 @@ It is not just new {% term integrations %} that have been added; existing ones k
 - **[Roborock]** got plenty of love for the Q10, with a do-not-disturb switch, switch entities, a map image, and a volume control. Thanks, [@lboue] and [@tubededentifrice]!
 - **[Whirlpool]** added an oven light, an oven cook-mode select, and an oven target-temperature number. Thanks, [@matthewdias] and [@bdlcalvin]!
 - **[MQTT]** gained an infrared platform, so you can send infrared commands over MQTT. Thanks, [@jbouwh]!
-- **[KNX]** got a whole set of improvements: **button** and **notify** entities can now be configured from the interface, the KNX panel gained a **Send telegram** dialog (shortcut <kbd>s</kbd>) to quickly send a telegram, a datapoint type reference to look up the supported DPTs, and a device view for your project data. On top of that, all KNX entities now restore their state after a reload or restart. Thanks, [@farmio]!
+- **[KNX]** got a whole set of improvements. Button and notify entities can now be configured from the interface, the KNX panel gained a **Send telegram** dialog (keyboard shortcut <kbd>s</kbd>), plus a datapoint type (DPT) reference and a device view for your project data. On top of that, all KNX entities now restore their state after a reload or restart. Thanks, [@farmio]!
 - **[Enphase Envoy]** added ACB battery sensors, along with sleep and wake controls. Thanks, [@genestealer]!
 - **[MELCloud]** gained on/off control, an operation-mode select, and a flow-temperature number for air-to-water heat pump zones. Thanks, [@imilchev]!
 - **[MELCloud Home]** added energy-consumption reporting and a number platform. Thanks, [@erwindouna]!

--- a/source/_posts/2026-08-05-release-20268.markdown
+++ b/source/_posts/2026-08-05-release-20268.markdown
@@ -327,7 +327,7 @@ It is not just new {% term integrations %} that have been added; existing ones k
 - **[Roborock]** got plenty of love for the Q10, with a do-not-disturb switch, switch entities, a map image, and a volume control. Thanks, [@lboue] and [@tubededentifrice]!
 - **[Whirlpool]** added an oven light, an oven cook-mode select, and an oven target-temperature number. Thanks, [@matthewdias] and [@bdlcalvin]!
 - **[MQTT]** gained an infrared platform, so you can send infrared commands over MQTT. Thanks, [@jbouwh]!
-- **[KNX]** button entities can now be configured from the interface. Thanks, [@farmio]!
+- **[KNX]** got a whole set of improvements: **button** and **notify** entities can now be configured from the interface, the KNX panel gained a **Send telegram** dialog (shortcut <kbd>s</kbd>) to quickly send a telegram, a datapoint type reference to look up the supported DPTs, and a device view for your project data. On top of that, all KNX entities now restore their state after a reload or restart. Thanks, [@farmio]!
 - **[Enphase Envoy]** added ACB battery sensors, along with sleep and wake controls. Thanks, [@genestealer]!
 - **[MELCloud]** gained on/off control, an operation-mode select, and a flow-temperature number for air-to-water heat pump zones. Thanks, [@imilchev]!
 - **[MELCloud Home]** added energy-consumption reporting and a number platform. Thanks, [@erwindouna]!


### PR DESCRIPTION
## Proposed change

Expands the KNX line in the "Noteworthy improvements to existing integrations" section of the 2026.8 release notes. Besides button entities, this release also brings notify entity configuration from the UI, a **Send telegram** dialog in the KNX panel, a datapoint type reference, a device view for project data, and state restoring for all KNX entities.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch)
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch)
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch)
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch)
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR fixes or closes issue: fixes #
- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:

🤖 Generated with [Claude Code](https://claude.com/claude-code)