### PR TITLE
Revert "Update template light temperature docs to reflect Kelvin values"

### DIFF
--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -1135,7 +1135,7 @@ template:
         set_temperature:
           action: input_number.set_value
           data:
-            value: "{{ color_temp_kelvin }}"
+            value: "{{ color_temp }}"
             entity_id: input_number.temperature_input
         set_hs:
           - action: input_number.set_value
@@ -1192,7 +1192,7 @@ template:
         set_temperature:
           action: input_number.set_value
           data:
-            value: "{{ color_temp_kelvin }}"
+            value: "{{ color_temp }}"
             entity_id: input_number.temperature_input
         set_hs:
           - action: input_number.set_value
@@ -1365,7 +1365,7 @@ light:
       type: template
       default: false
     temperature:
-      description: Defines a template to get the color temperature of the light in Kelvin. The template must return a value between 2000 and 6535.
+      description: Defines a template to get the color temperature of the light. The template must return the color temperature in mireds. If you are using a `color_temp_kelvin` attribute from another source, convert the value to mireds by dividing 1000000 by the `color_temp_kelvin` result.
       required: false
       type: template
       default: optimistic


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
Revert the changes from https://github.com/home-assistant/home-assistant.io/pull/46645 in https://github.com/home-assistant/home-assistant.io/commit/9ac55e5a54de089de7b33df94ca9ef1513b9e4e1

The corresponding code change in https://github.com/home-assistant/core/pull/173531 has not been merged, the docs are now inaccurate.

The PR has some additional discussion, and it's possible that the change will be implemented in a different way (for example, by adding a new parameter rather than making a breaking change to how an existing parameter is used).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

None of the above apply. This PR is intended to adjust missing or incorrect information in the `next` (and `rc`) branches.

The code change has **not** been merged, but the documentation change has made it into the `rc` branch. This means that the documentation will be incorrect for the 2026.8 release unless the documentation change is reverted in the `rc` branch.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/173531
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
