### PR TITLE
Reapply "Update template light temperature docs to reflect Kelvin values" (#47240)

### DIFF
--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -1135,7 +1135,7 @@ template:
         set_temperature:
           action: input_number.set_value
           data:
-            value: "{{ color_temp }}"
+            value: "{{ color_temp_kelvin }}"
             entity_id: input_number.temperature_input
         set_hs:
           - action: input_number.set_value
@@ -1192,7 +1192,7 @@ template:
         set_temperature:
           action: input_number.set_value
           data:
-            value: "{{ color_temp }}"
+            value: "{{ color_temp_kelvin }}"
             entity_id: input_number.temperature_input
         set_hs:
           - action: input_number.set_value
@@ -1365,7 +1365,7 @@ light:
       type: template
       default: false
     temperature:
-      description: Defines a template to get the color temperature of the light. The template must return the color temperature in mireds. If you are using a `color_temp_kelvin` attribute from another source, convert the value to mireds by dividing 1000000 by the `color_temp_kelvin` result.
+      description: Defines a template to get the color temperature of the light in Kelvin. The template must return a value between 2000 and 6535.
       required: false
       type: template
       default: optimistic


### PR DESCRIPTION
Reapplies documentation added in https://github.com/home-assistant/home-assistant.io/pull/46645 and reverted in https://github.com/home-assistant/home-assistant.io/pull/47240.

## Proposed change

The template light's `temperature` config option now expects Kelvin values (2000 to 6535) instead of mired values. This updates the documentation to reflect that change.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/173531
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
