### PR TITLE
Mention Tesla Wall Connector split-phase option

### DIFF
--- a/source/_posts/2026-08-05-release-20268.markdown
+++ b/source/_posts/2026-08-05-release-20268.markdown
@@ -284,7 +284,7 @@ It is not just new {% term integrations %} that have been added; existing ones k
 - **[WiiM]** added multi-room grouping and metadata synchronization. Thanks, [@Linkplay2020]!
 - **[SMLIGHT]** added Bluetooth proxy support and an infrared receiver for SMLIGHT Ultima devices. Thanks, [@tl-sl]!
 - **[Vizio]** added command aliases for its remote. Thanks, [@raman325]!
-- **[Tesla Wall Connector]** added vehicle current and Wi-Fi signal sensors. Thanks, [@sarabveer]!
+- **[Tesla Wall Connector]** now has an option to switch the Total power sensor calculation between single-phase / split-phase service and three-phase service. It also added vehicle current and Wi-Fi signal sensors. Thanks, [@sarabveer]!
 - **[Teslemetry]** added control for seat coolers. Thanks, [@Bre77]!
 - **[Tessie]** added a navigation-destination text entity. Thanks, [@Mattheinrichs]!
 - **[Gardena Bluetooth]** added tank pressure and water temperature sensors. Thanks, [@icereed]!


### PR DESCRIPTION
## Proposed change

Updates the 2026.8 release notes to mention the new Tesla Wall Connector option that switches the Total power sensor calculation between single-phase or split-phase service and three-phase service.

This pull request intentionally targets the rc branch because it updates the existing 2026.8 release post published on rc.home-assistant.io.

## Type of change

- [x] Adjusted missing information in the 2026.8 release notes.

## Additional information

- Related Core implementation: https://github.com/home-assistant/core/pull/175883
- Core commit: https://github.com/home-assistant/core/commit/0b83bb23350d5d740fb9eae520a70bef657009d3

## Checklist

- [x] This pull request targets the rc branch for the 2026.8 release notes.
- [x] The documentation follows the Home Assistant documentation standards.