### PR TITLE
Update Schlage for the bronze quality scale

### DIFF
--- a/source/_integrations/schlage.markdown
+++ b/source/_integrations/schlage.markdown
@@ -2,7 +2,9 @@
 title: Schlage
 description: Instructions on how to integrate Schlage WiFi smart locks into Home Assistant.
 ha_category:
+  - Binary sensor
   - Lock
+  - Select
   - Sensor
   - Switch
 ha_release: 2023.9
@@ -19,9 +21,14 @@ ha_platforms:
   - switch
 ha_integration_type: hub
 ha_domain: schlage
+ha_quality_scale: bronze
 ---
 
-The **Schlage** {% term integration %} provides connectivity with Schlage WiFi smart locks through Schlage's cloud API.
+[Schlage] is a lock manufacturer whose Encode range of smart deadbolts and levers connects directly to your WiFi network, without needing a separate hub or bridge.
+
+The **Schlage** {% term integration %} controls those locks through Schlage's cloud API. It reports lock state, battery level, and keypad status, and exposes the lock's settings so they can be changed from Home Assistant.
+
+[Schlage]: https://www.schlage.com/
 
 ## Known working devices
 

--- a/source/_integrations/schlage.markdown
+++ b/source/_integrations/schlage.markdown
@@ -73,8 +73,8 @@ Once you have enabled the Schlage integration, you should see the following sens
 
 Once you have enabled the Schlage integration, you should see the following switches:
 
-- **1-Touch Locking** - When enabled, locks the lock with a press of the Schlage button.
-- **Keypress Beep** - Controls whether the lock will emit beeping tones on use.
+- **1-touch locking** - When enabled, locks the lock with a press of the Schlage button.
+- **Keypress beep** - Controls whether the lock will emit beeping tones on use.
 
 {% include integrations/actions.md %}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documentation half of the Schlage bronze quality scale work.

- Explain what Schlage is and link to the manufacturer. The page previously opened straight into what the integration connects to, without saying what the devices are. This was raised in the review of https://github.com/home-assistant/core/pull/131735 and is what the `docs-high-level-description` rule asks for.
- Add the `Binary sensor` and `Select` categories. Both platforms already ship, but the page never listed them.
- Record `ha_quality_scale: bronze`.

The remaining gold documentation rules for this integration — use cases, examples, known limitations, supported devices, supported functions and troubleshooting — are a larger restructure and are not part of this PR.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/178337
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
