### PR TITLE
Skip lock and stale workflows on forks at the job level

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -6,13 +6,13 @@ on:
 
 jobs:
   lock:
+    if: ${{ github.repository_owner == 'home-assistant' }}
     permissions:
       issues: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
-        if: ${{ github.repository_owner == 'home-assistant' }}
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: "30"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   stale:
+    if: ${{ github.repository_owner == 'home-assistant' }}
     permissions:
       actions: write
       issues: write
@@ -13,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
-        if: ${{ github.repository_owner == 'home-assistant' }}
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 60


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The `Lock` and `Stale` workflows both guard against running outside the `home-assistant` organization with `if: ${{ github.repository_owner == 'home-assistant' }}`, but that condition was placed on the action step rather than on the job.

Scheduled workflows do still fire on a fork once Actions is enabled there. With the condition on the step, the job starts on a fork, occupies a runner, and ends up cancelled, which sends a failed workflow run notification to the fork owner.

This moves the condition to the job level in both workflows. On a fork the job is now never created, the run concludes as skipped, and no notification is sent. Behavior inside the `home-assistant` organization is unchanged.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

None of the above apply: this changes repository automation in `.github/workflows`, not documentation content.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

Note for existing forks: GitHub runs the workflow file as it exists on the fork's own default branch, so a fork keeps using the old version until it syncs with `current`. Disabling Actions in the fork stops the notifications immediately.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

---
_Generated by [Claude Code](https://claude.ai/code/session_015jLcLJXh97STLm8MkUmKCA)_