### PR TITLE
Fix code owner check in the task creation restriction

### DIFF
--- a/.github/workflows/restrict-task-creation.yml
+++ b/.github/workflows/restrict-task-creation.yml
@@ -55,8 +55,6 @@ jobs:
                 }
               }
 
-              // Compare complete handles, so a username that is only a prefix of an
-              // owner does not pass. GitHub usernames are case-insensitive.
               if (owners.has(issueAuthor.toLowerCase())) {
                 console.log(`✅ ${issueAuthor} is an integration code owner`);
                 return; // Authorized

--- a/.github/workflows/restrict-task-creation.yml
+++ b/.github/workflows/restrict-task-creation.yml
@@ -31,20 +31,33 @@ jobs:
 
             // If not an org member, check if they're a codeowner
             try {
-              // Fetch CODEOWNERS file from the repository
+              // Fetch CODEOWNERS file from the next branch, so that code owners of
+              // integrations that are not released yet are recognized as well
               const { data: codeownersFile } = await github.rest.repos.getContent({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 path: 'CODEOWNERS',
-                ref: 'dev'
+                ref: 'next'
               });
 
               // Decode the content (it's base64 encoded)
               const codeownersContent = Buffer.from(codeownersFile.content, 'base64').toString('utf-8');
 
-              // Check if the issue author is mentioned in CODEOWNERS
-              // GitHub usernames in CODEOWNERS are prefixed with @
-              if (codeownersContent.includes(`@${issueAuthor}`)) {
+              // Collect the owner handles, skipping comments. An entry is either a
+              // user (@username) or a team (@org/team-name). Teams are ignored here,
+              // because their members are already covered by the check above.
+              const owners = new Set();
+              for (const line of codeownersContent.split('\n')) {
+                for (const entry of line.split('#')[0].split(/\s+/)) {
+                  if (entry.startsWith('@') && !entry.includes('/')) {
+                    owners.add(entry.slice(1).toLowerCase());
+                  }
+                }
+              }
+
+              // Compare complete handles, so a username that is only a prefix of an
+              // owner does not pass. GitHub usernames are case-insensitive.
+              if (owners.has(issueAuthor.toLowerCase())) {
                 console.log(`✅ ${issueAuthor} is an integration code owner`);
                 return; // Authorized
               }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The `Restrict task creation` workflow authorizes the author of a new **Task** issue in two steps: organization membership first, and integration code ownership as a fallback. The second step has two problems.

**The CODEOWNERS file was fetched from a branch that does not exist.** The lookup used `ref: 'dev'`, but this repository has `current` and `next`. Every request returned a 404, which the surrounding `catch` swallowed into a `console.error`, so the code owner path never authorized anyone and organization membership was effectively the only way to pass. A code owner opening a Task issue had it closed automatically, with nothing but a log line to explain why.

This now reads from `next` rather than `dev`. Reading from `next` also covers code owners of integrations that have not been released yet, since their documentation lands there first.

**The author was matched with a substring search.** The check was `codeownersContent.includes('@' + issueAuthor)`, which passes for any username that happens to be a prefix of a listed code owner. For example, a `@shred` account would match the code owner entry `@shred86`. The handles are now parsed out of the file and compared in full, case-insensitively, since GitHub usernames are not case-sensitive. Team entries such as `@home-assistant/core` are skipped, because their members already pass the organization check above.

Verified the parser against the current CODEOWNERS file: it extracts 716 user handles, matches every real code owner including on differing case, and rejects prefixes, team names, and unknown users.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

None of the above apply: this changes repository automation in `.github/workflows`, not documentation content.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

One behavior is left unchanged and may be worth a follow-up: a failure to fetch CODEOWNERS is still caught and falls through to closing the issue, so a temporary API problem closes a legitimate contributor's Task issue with only a log line as a record. Fixing the branch reference makes that far less likely, but the silent fail-closed path is still there.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

---
_Generated by [Claude Code](https://claude.ai/code/session_015jLcLJXh97STLm8MkUmKCA)_