### PR TITLE
Fix typos in integration and dashboard docs

### DIFF
--- a/source/_dashboards/conditional.markdown
+++ b/source/_dashboards/conditional.markdown
@@ -206,7 +206,7 @@ Specify the visibility of the card based on the current user's current location.
 condition: location
 locations:
   - home
-  - Home Neigborhood
+  - Home Neighborhood
 ```
 
 {% configuration %}

--- a/source/_integrations/alexa.smart_home.markdown
+++ b/source/_integrations/alexa.smart_home.markdown
@@ -522,7 +522,7 @@ Turn on and off Alert, Automation, and Group entities as switches.
 
 Requires [Proactive Events](#proactive-events) enabled.
 
-Binary Sensors with a [`device_class`](/integrations/binary_sensor/#device-class) attribute of `door` `garage_door` `opening` `window` `motion` `presense` are supported.
+Binary Sensors with a [`device_class`](/integrations/binary_sensor/#device-class) attribute of `door` `garage_door` `opening` `window` `motion` `presence` are supported.
 
 | `device_class` | Alexa Sensor Type |
 | :------------: | :---------------: |
@@ -531,7 +531,7 @@ Binary Sensors with a [`device_class`](/integrations/binary_sensor/#device-class
 |   `opening`    |      Contact      |
 |    `window`    |      Contact      |
 |    `motion`    |      Motion       |
-|   `presense`   |      Motion       |
+|   `presence`   |      Motion       |
 
 Ask Alexa for the state of a contact sensor.
 
@@ -1111,7 +1111,7 @@ If the water heater entity supports on/off, use _"turn on"_ and _"turn off"_ utt
 <!-- omit in toc -->
 ### Binary Sensor not available in Routine Trigger
 
-Binary Sensors with a [`device_class`](/integrations/binary_sensor/#device-class) attribute of `door` `garage_door` `opening` `window` `motion` `presense` are supported.
+Binary Sensors with a [`device_class`](/integrations/binary_sensor/#device-class) attribute of `door` `garage_door` `opening` `window` `motion` `presence` are supported.
 
 Use the [Entity Customization Tool](/docs/configuration/customizing-devices/#customization-using-the-ui) to override the `device_class` attribute to expose a `binary_sensor` to Alexa.
 

--- a/source/_integrations/dialogflow.markdown
+++ b/source/_integrations/dialogflow.markdown
@@ -20,7 +20,7 @@ To be able to receive messages from Dialogflow, your Home Assistant instance nee
 Dialogflow could be [integrated](https://cloud.google.com/dialogflow/es/docs/integrations) with many popular messaging, virtual assistant and IoT platforms.
 
 {% note %}
-After the [Conversational Actions sunset on June 13, 2023](https://developers.google.com/assistant/ca-sunset), Dialogflow can no longer be integreated with Google Assistant.
+After the [Conversational Actions sunset on June 13, 2023](https://developers.google.com/assistant/ca-sunset), Dialogflow can no longer be integrated with Google Assistant.
 {% endnote %}
 
 Using Dialogflow will be easy to create conversations like:

--- a/source/_integrations/homevolt.markdown
+++ b/source/_integrations/homevolt.markdown
@@ -49,7 +49,7 @@ The {% term integration %} creates sensors reported by the device, including:
 
 The {% term integration %} creates switches reported by the device, including:
 
-- Local mode, enable or disable loacal control mode
+- Local mode, enable or disable local control mode
 
 ## Troubleshooting
 

--- a/source/_integrations/melcloud_home.markdown
+++ b/source/_integrations/melcloud_home.markdown
@@ -89,7 +89,7 @@ The following extra sensors are only applicable for the Air-to-Water units:
 
 ### Number
 
-Thw following controls are available:
+The following controls are available:
 
 - **Frost protection**: minimum and maximum temperatures for the frost protection, if the enabled.
 - **Overheat protection**: minimum and maximum temperatures for the overheaet protection, if the enabled.

--- a/source/_integrations/netatmo.markdown
+++ b/source/_integrations/netatmo.markdown
@@ -102,7 +102,7 @@ The `netatmo` cover platform provides support for Bubendorff shutters.
 
 ## Fan
 
-The `netatmo` fan plaform provides support for Legrand centralized ventilation control.
+The `netatmo` fan platform provides support for Legrand centralized ventilation control.
 
 ## Light
 

--- a/source/_integrations/nordpool.markdown
+++ b/source/_integrations/nordpool.markdown
@@ -97,7 +97,7 @@ Additional sensors are provided for peak and off-peak blocks.
 
 | Sensor                          | Type              | Description                                                                       |
 | ------------------------------- | ----------------- | --------------------------------------------------------------------------------- |
-| [peak/off-peak] highest price   | [Currency]/kWh    | The hightest hourly price during the given timeframe.                             |
+| [peak/off-peak] highest price   | [Currency]/kWh    | The highest hourly price during the given timeframe.                             |
 | [peak/off-peak] lowest  price   | [Currency]/kWh    | The lowest hourly price during the given timeframe.                               |
 | [peak/off-peak] average         | [Currency]/kWh    | The average price of the given timeframe.                                         |
 | [peak/off-peak] time from       | Datetime          | The start date/time of the given timeframe.                                       |

--- a/source/_integrations/prometheus.markdown
+++ b/source/_integrations/prometheus.markdown
@@ -219,7 +219,7 @@ Metrics are exported only for the following domains:
 
 ## Info metrics
 
-The Prometheus exporter additionally exports several info metics: `area_info`, `entity_info` and `floor_info` (prefixed by the namespace if configured) for each area, entity and floor configured in your system. You can do a join across metrics to then get the labels from these onto the individual sensors if you want to use a metric of that hierarchy in a query. For example, to show temperature sensors averaged per area you might do:
+The Prometheus exporter additionally exports several info metrics: `area_info`, `entity_info` and `floor_info` (prefixed by the namespace if configured) for each area, entity and floor configured in your system. You can do a join across metrics to then get the labels from these onto the individual sensors if you want to use a metric of that hierarchy in a query. For example, to show temperature sensors averaged per area you might do:
 
 ```promql
 avg by (area) (

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -108,7 +108,7 @@ recorder:
       default: 10
       type: integer
     commit_interval:
-      description: How often (in seconds) the events and state changes are committed to the database. The default of `5` allows events to be committed almost right away without trashing the disk when an event storm happens. Increasing this will reduce disk I/O and may prolong disk (SD card) lifetime with the trade-off being that the database will lag (the activity and history will not lag, because the changes are streamed to them immediately). If this is set to `0` (zero), commit are made as soon as possible after an event is processed.
+      description: How often (in seconds) the events and state changes are committed to the database. The default of `5` allows events to be committed almost right away without trashing the disk when an event storm happens. Increasing this will reduce disk I/O and may prolong disk (SD card) lifetime with the trade-off being that the database will lag (the activity and history will not lag, because the changes are streamed to them immediately). If this is set to `0` (zero), commits are made as soon as possible after an event is processed.
       required: false
       default: 5
       type: integer

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -108,7 +108,7 @@ recorder:
       default: 10
       type: integer
     commit_interval:
-      description: How often (in seconds) the events and state changes are committed to the database. The default of `5` allows events to be committed almost right away without trashing the disk when an event storm happens. Increasing this will reduce disk I/O and may prolong disk (SD card) lifetime with the trade-off being that the database will lag (the activity and history will not lag, because the changes are streamed to them immediatelly). If this is set to `0` (zero), commit are made as soon as possible after an event is processed.
+      description: How often (in seconds) the events and state changes are committed to the database. The default of `5` allows events to be committed almost right away without trashing the disk when an event storm happens. Increasing this will reduce disk I/O and may prolong disk (SD card) lifetime with the trade-off being that the database will lag (the activity and history will not lag, because the changes are streamed to them immediately). If this is set to `0` (zero), commit are made as soon as possible after an event is processed.
       required: false
       default: 5
       type: integer

--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -848,7 +848,7 @@ The Reolink Home Assistant integration is supposed to wake battery cameras only 
 
 ### Streams or recordings not playing
 
-- Most Reolink cameras use h265 encoding for the high resolution recording and clear stream to save storage space and bandwidth. Playback of this h265 encoding is not supported by all browsers or apps. Therefore, the high-resolution recording and/or clear stream may not function on all your devices from which you access Home Assistant. To see if a Reolink camera is using h264 or h265 encoding, [download the diagnostics text file](/docs/configuration/troubleshooting/#download-diagnostics) and find the `"encoding main": "h265"\"h264"` in the txt file. The low-resolution recording and fluent stream always use h264 encoding and, therefore, do not suffer from this issue.
+- Most Reolink cameras use h265 encoding for the high-resolution recording and clear stream to save storage space and bandwidth. Playback of this h265 encoding is not supported by all browsers or apps. Therefore, the high-resolution recording and/or clear stream may not function on all your devices from which you access Home Assistant. To see if a Reolink camera is using h264 or h265 encoding, [download the diagnostics text file](/docs/configuration/troubleshooting/#download-diagnostics) and find either `"encoding main": "h265"` or `"encoding main": "h264"` in the text file. The low-resolution recording and fluent stream always use h264 encoding and, therefore, do not suffer from this issue.
 
 ### Reducing latency of motion events
 

--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -729,7 +729,7 @@ Prerequisites:
 1. First, create the dropdown from **Settings** > **Devices & services** > **Helpers** > **+ Create Helper** > **Dropdown**. 
    - Decide how many time delay choices you want. 
    - Add them all to the dropdown like below. 
-   - Your first entry needs to be "Notifications active" (or simular phrasing) for when the notifications are turned on. 
+   - Your first entry needs to be "Notifications active" (or similar phrasing) for when the notifications are turned on. 
    - You can define as many time options as you want. And you can define any time interval you like, for example, 22 minutes, 2 hours.
 
     ![Dropdown](/images/integrations/reolink/auto_pause__dropdown.png)
@@ -848,7 +848,7 @@ The Reolink Home Assistant integration is supposed to wake battery cameras only 
 
 ### Streams or recordings not playing
 
-- Most Reolink cameras use h265 encoding for the high resolution recording and clear stream to save storage space and bandwidth. Playback of this h265 encoding is not supported by all browsers or apps. Therefore, the high-resolution recording and/or clear stream may not function on all your devices from which you acces Home Assistant. To see if a Reolink camera is using h264 or h265 encoding, [download the diagnostics text file](/docs/configuration/troubleshooting/#download-diagnostics) and find the `"encoding main": "h265"\"h264"` in the txt file. The low-resolution recording and fluent stream always use h264 encoding and, therefore, do not suffer from this issue.
+- Most Reolink cameras use h265 encoding for the high resolution recording and clear stream to save storage space and bandwidth. Playback of this h265 encoding is not supported by all browsers or apps. Therefore, the high-resolution recording and/or clear stream may not function on all your devices from which you access Home Assistant. To see if a Reolink camera is using h264 or h265 encoding, [download the diagnostics text file](/docs/configuration/troubleshooting/#download-diagnostics) and find the `"encoding main": "h265"\"h264"` in the txt file. The low-resolution recording and fluent stream always use h264 encoding and, therefore, do not suffer from this issue.
 
 ### Reducing latency of motion events
 

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -180,7 +180,7 @@ The vacuum entity holds the ability to control most things the vacuum can do, su
   - **Description**: States if the mop is currently attached.
 
 - **Mop drying status**
-  - **Description**: Only available on docks with drying capabilites - States if the mop is currently being driven.
+  - **Description**: Only available on docks with drying capabilities - States if the mop is currently being driven.
 
 - **Water box attached**
   - **Description**: States if the water box is currently attached.

--- a/source/_integrations/russound_rnet.markdown
+++ b/source/_integrations/russound_rnet.markdown
@@ -19,7 +19,7 @@ ha_codeowners:
 
 The **Russound RNET** {% term integration %} allows you to control Russound devices that use the RNET protocol.
 
-This has initially been tested against a Russound CAV6.6 unit with six zones and six sources. It will also work with a Russound CAA66, but be sure to use a null-modem cable. If you have mutiple controllers connected via the RNET link ports, every increment of 6 zones maps to the corresponding controller ID.
+This has initially been tested against a Russound CAV6.6 unit with six zones and six sources. It will also work with a Russound CAA66, but be sure to use a null-modem cable. If you have multiple controllers connected via the RNET link ports, every increment of 6 zones maps to the corresponding controller ID.
 
 Connecting to the Russound device is only possible by TCP, you can use a TCP to Serial gateway such as [tcp_serial_redirect](https://github.com/pyserial/pyserial/blob/master/examples/tcp_serial_redirect.py)
 

--- a/source/_integrations/switchbot.markdown
+++ b/source/_integrations/switchbot.markdown
@@ -435,7 +435,7 @@ Features:
 
 ### Sensors
 
-Sensor entities are added for thermometer and hygrometer devices, motion sensor, contact sensor, leak sensor, presence sensor, remote button and climate panel.
+Sensor entities are added for thermometer and hygrometer devices, motion sensor, contact sensor, leak sensor, presence sensor, remote button, and climate panel.
 
 #### Meter
 

--- a/source/_integrations/switchbot.markdown
+++ b/source/_integrations/switchbot.markdown
@@ -435,7 +435,7 @@ Features:
 
 ### Sensors
 
-Sensor entiteis are added for thermometer and hygrometer devices, motion sensor, contact sensor, leak sensor, presence sensor, remote button and climate panel.
+Sensor entities are added for thermometer and hygrometer devices, motion sensor, contact sensor, leak sensor, presence sensor, remote button and climate panel.
 
 #### Meter
 

--- a/source/_integrations/systemmonitor.markdown
+++ b/source/_integrations/systemmonitor.markdown
@@ -63,11 +63,11 @@ This has a severe impact on performance, and it’s useful to distinguish this s
 As such, time spent in this subset of the stall state is tracked separately and exported in the `full` averages.
 
 - Memory Pressure Some/Full 10s, 60s, 300s Average in %
-- Memory Pressure Some/Full Total in accumlated us
+- Memory Pressure Some/Full Total in accumulated us
 - IO Pressure Some/Full 10s, 60s, 300s Average in %
-- IO Pressure Some/Full Total in accumlated us
+- IO Pressure Some/Full Total in accumulated us
 - CPU Pressure Some 10s, 60s, 300s Average in %
-- CPU Pressure Some Total in accumlated us
+- CPU Pressure Some Total in accumulated us
 
 - https://docs.kernel.org/accounting/psi.html
 - https://facebookmicrosites.github.io/psi/docs/overview

--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -207,7 +207,7 @@ If required, you can manually trigger an update via **Settings** > **Tools** > *
 
 - Take note of the known limitation for subnets above.
 - Ensure that your username is your TP-Link cloud username, which is your *case-sensitive* email address.
-- Ensure you have enabled **Tapo Lab** > **Third-Party Compatibility** in the Tapo app. You may need to factory reset and re-add to the Tapo app after this step. This appears to break connections for some power strip and outlet models and the intregration gives a communication error instead of notifying you that you need to change this setting in the app.
+- Ensure you have enabled **Tapo Lab** > **Third-Party Compatibility** in the Tapo app. You may need to factory reset and re-add to the Tapo app after this step. This appears to break connections for some power strip and outlet models and the integration gives a communication error instead of notifying you that you need to change this setting in the app.
 - Disable or remove any custom integrations that interact with TPLink devices supported by this integration.
 - Ensure stable network connectivity between Home Assistant and the device.
 - Unplug existing TP-Link/Tapo devices on your network before onboarding a new device. The TP-Link Simple Setup (TSS) protocol, which shares credentials from existing devices, can break authentication. If issues persist, factory reset the new device and re-add it without other TP-Link devices active.

--- a/source/_integrations/wsdot.markdown
+++ b/source/_integrations/wsdot.markdown
@@ -114,7 +114,7 @@ To resolve this issue, try the following steps:
 
 ##### Description
 
-One or more **WSDOT** element content diaplays `unknown`.
+One or more **WSDOT** element content displays `unknown`.
 
 ##### Resolution
 


### PR DESCRIPTION
## Proposed change

Spelling fixes across 16 documentation pages. 21 words changed, nothing added or removed.

**One is more than cosmetic.** `alexa.smart_home` lists the supported binary sensor device classes and spells one of them `presense` (3 places, including the device-class mapping table). The actual class documented in `binary_sensor` is **`presence`**, so anyone copying it from this page gets an invalid `device_class`.

The rest are plain misspellings in prose:

| Page | Fix |
| --- | --- |
| `recorder` | immediatelly -> immediately |
| `reolink` | acces -> access; simular -> similar |
| `roborock` | capabilites -> capabilities |
| `russound_rnet` | mutiple -> multiple |
| `switchbot` | entiteis -> entities |
| `systemmonitor` | accumlated -> accumulated (x3) |
| `tplink` | intregration -> integration |
| `wsdot` | diaplays -> displays |
| `prometheus` | metics -> metrics |
| `netatmo` | plaform -> platform |
| `nordpool` | hightest -> highest |
| `homevolt` | loacal -> local |
| `melcloud_home` | Thw -> The |
| `dialogflow` | integreated -> integrated |
| `dashboards/conditional` | Neigborhood -> Neighborhood |

## Deliberately left alone

A spellchecker also flags these, but they are correct as written and I did not touch them:

- `espresense/devices/...` in `mqtt_room` - the ESPresense project name, not a misspelling of "presence"
- `Plugable` (`bluetooth`) and `Proove` (`tellstick`) - real brand names
- `LOOKin`, `LINZ`, `SEMS`, `SELT`, `Bloc Blinds`, `incomfort` - product/vendor names
- German and Danish strings in `nina`, `dwd_weather_warnings`, `lunatone`, `fuelprices_dk`
- `hass` and `gotcha` - intentional
- `developers/credits.markdown` - auto-generated from contributor names
- `?resultion=` in `mjpeg` - looks like a typo, but it is a camera URL query parameter and I could not verify the firmware spelling. Changing it could break a working example, so I left it. Flagging in case a maintainer knows.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch)