### PR TITLE
Document GeoSphere Austria advance warnings and get_warnings action

### DIFF
--- a/source/_actions/geosphere_austria_warnings.get_warnings.markdown
+++ b/source/_actions/geosphere_austria_warnings.get_warnings.markdown
@@ -1,0 +1,105 @@
+---
+title: "Get warnings"
+action: geosphere_austria_warnings.get_warnings
+domain: geosphere_austria_warnings
+description: "Retrieves all active and advance weather warnings for a GeoSphere Austria location."
+---
+
+Use this action to retrieve the full details of every weather warning GeoSphere Austria currently publishes for one of your locations, including the warning text, the expected impacts, and the recommended actions.
+
+The **Warning level** and **Advance warning level** sensors only describe the single most severe warning. Use this action when you want all of them, for example to list every warning in a notification or on a dashboard.
+
+This action returns its result in a response variable, which you can use in later steps of the same automation or script.
+
+{% include actions/ui_header.md %}
+
+To get warnings from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **GeoSphere Austria Warnings: Get warnings**.
+6. Select the **Location** to get the warnings for.
+7. In the **Response variable** field, enter a name to store the data in, such as `warnings`.
+8. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Location:
+  description: The monitored municipality to get the warnings for.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `geosphere_austria_warnings.get_warnings`. Store the result in a response variable so you can use it in later steps:
+
+{% example %}
+action: |
+  action: geosphere_austria_warnings.get_warnings
+  data:
+    config_entry: 1b4ba1c4d8f5e3a29c6e7d2f0a3b8c91
+  response_variable: warnings
+{% endexample %}
+
+This stores the warnings for the selected municipality in `warnings`.
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry:
+  description: >
+    The monitored municipality to get the warnings for.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Response data
+
+The response contains two lists:
+
+- `active_warnings`: Warnings that have already started and have not ended yet.
+- `advance_warnings`: Warnings that GeoSphere Austria has issued but that start later.
+
+A list with no warnings is empty. Both lists are sorted by severity, with the most severe warning first. Warnings of equal severity are sorted by start time, earliest first.
+
+Each warning contains the following fields:
+
+- `warning_id`, `change_id`, `course_id`: The identifiers GeoSphere Austria assigns to the warning.
+- `type`: The kind of weather event. One of `storm`, `rain`, `snow`, `black_ice`, `thunderstorm`, `heat`, or `cold`.
+- `level`: The severity. One of `yellow`, `orange`, or `red`.
+- `start` and `end`: When the warning starts and ends, in ISO 8601 format.
+- `text`: A summary of the warning.
+- `impacts`: The effects to expect.
+- `recommendations`: What GeoSphere Austria advises you to do.
+- `meteo_text`: Additional meteorological detail.
+- `update_reason`: Why the warning was last updated. Empty when it has not been updated.
+
+```yaml
+active_warnings:
+  - warning_id: 4149
+    change_id: 6
+    course_id: 12
+    type: storm
+    level: orange
+    start: "2023-03-27T08:00:00+00:00"
+    end: "2023-03-27T18:00:00+00:00"
+    text: Orange storm warning from Mon, 27.03.2023 08:00 until Mon, 27.03.2023 18:00
+    impacts: "* Branches may fall and objects may be thrown around."
+    recommendations: "* Be careful in forests, parks and avenues!"
+    meteo_text: Strong northwest winds with gusts between 60 and 80 km/h.
+    update_reason: ""
+advance_warnings: []
+```
+
+The values are read from the data the integration already holds, so calling this action does not contact GeoSphere Austria.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/geosphere_austria_warnings.get_warnings.markdown
+++ b/source/_actions/geosphere_austria_warnings.get_warnings.markdown
@@ -42,7 +42,7 @@ In YAML, refer to this action as `geosphere_austria_warnings.get_warnings`. Stor
 action: |
   action: geosphere_austria_warnings.get_warnings
   data:
-    config_entry: 1b4ba1c4d8f5e3a29c6e7d2f0a3b8c91
+    config_entry: YOUR_CONFIG_ENTRY_ID
   response_variable: warnings
 {% endexample %}
 

--- a/source/_integrations/geosphere_austria_warnings.markdown
+++ b/source/_integrations/geosphere_austria_warnings.markdown
@@ -47,12 +47,37 @@ Each entry adds one service {% term device %} named after the monitored municipa
 
 ### Sensors
 
+GeoSphere Austria publishes each warning with a start and an end time. A warning that has already started counts as *active*. A warning that GeoSphere Austria has issued but that starts later counts as an *advance* warning, so you can prepare before it takes effect.
+
 - **Warning level**
   - **Description**: The highest severity level of all currently active warnings.
   - **Possible states**: No warning, Yellow, Orange, Red.
 - **Active warnings**
   - **Description**: The number of currently active warnings.
   - **Unit**: warnings
+- **Advance warning level**
+  - **Description**: The highest severity level of all warnings that start later.
+  - **Possible states**: No warning, Yellow, Orange, Red.
+- **Advance warnings**
+  - **Description**: The number of warnings that start later.
+  - **Unit**: warnings
+
+#### Warning details
+
+**Warning level** and **Advance warning level** describe the single most severe warning behind their state. If several warnings share the highest severity, the one that starts first is used.
+
+Both sensors provide the following attributes:
+
+- `type`: The kind of weather event. One of `storm`, `rain`, `snow`, `black_ice`, `thunderstorm`, `heat`, or `cold`.
+- `start`: When the warning starts, in ISO 8601 format.
+- `end`: When the warning ends, in ISO 8601 format.
+- `warning_id`: The identifier GeoSphere Austria assigns to the warning.
+
+When there is no warning, the sensor state is **No warning** and these attributes are not set.
+
+To read every warning instead of only the most severe one, use the [Get warnings](/actions/geosphere_austria_warnings.get_warnings/) action.
+
+{% include integrations/actions.md %}
 
 ## Automation examples
 
@@ -98,6 +123,45 @@ automation: |
           Warning level {{ states('sensor.innsbruck_warning_level') }}
           with {{ states('sensor.innsbruck_active_warnings') }}
           active warning(s) for Innsbruck.
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: preparing before a severe warning starts
+
+Get a notification when GeoSphere Austria issues an orange or red warning that starts later, together with the type of weather event and when it begins.
+
+- **Trigger**: State
+  - **Entity**: Innsbruck advance warning level (`sensor.innsbruck_advance_warning_level`)
+  - **To**: Orange
+  - **To**: Red
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+  - **Message**: `{{ state_attr('sensor.innsbruck_advance_warning_level', 'type') }} warning for Innsbruck starts at {{ state_attr('sensor.innsbruck_advance_warning_level', 'start') | as_datetime | as_local }}.`
+  - **Title**: `Weather warning ahead`
+
+{% details "YAML example for notifying before a warning starts" %}
+
+{% example %}
+automation: |
+  alias: "Notify before a severe warning starts"
+  triggers:
+    - trigger: state
+      entity_id: sensor.innsbruck_advance_warning_level
+      to:
+        - orange
+        - red
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        title: "Weather warning ahead"
+        message: >-
+          {{ state_attr('sensor.innsbruck_advance_warning_level', 'type') }}
+          warning for Innsbruck starts at
+          {{ state_attr('sensor.innsbruck_advance_warning_level', 'start')
+             | as_datetime | as_local }}.
 {% endexample %}
 
 {% enddetails %}


### PR DESCRIPTION
Adds the Advance warning level and Advance warnings sensors, the warning detail attributes on both level sensors, and a dedicated action page for geosphere_austria_warnings.get_warnings.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/178358
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
