### PR TITLE
Flume: use reported battery and bridge status from the device

### DIFF
--- a/source/_integrations/flume.markdown
+++ b/source/_integrations/flume.markdown
@@ -39,9 +39,9 @@ Flume notifications are fetched every 5 minutes and are available via the `flume
 - High flow
 - Leak detected
 
-To clear the notifications, you will need to use your Flume app or go to: [https://portal.flumewater.com/notifications](https://portal.flumewater.com/notifications) and clear the notification in question.
+To clear these notifications, you will need to use your Flume app or go to: [https://portal.flumewater.com/notifications](https://portal.flumewater.com/notifications) and clear the notification in question. The **High flow** and **Leak detected** sensors stay on until you do.
 
-The **Battery** and **Connectivity** sensors do not use notifications. They report what your Flume device reports directly and are checked once an hour, so after you replace the batteries, the battery status updates on its own.
+The **Battery** and **Connectivity** sensors do not use notifications. They report what your Flume device reports directly and are checked once an hour. After you replace the batteries, the battery status updates on its own, and there is no notification to clear.
 
 Example of an automation that sends a Home Assistant notification of the most recent usage alert:
 

--- a/source/_integrations/flume.markdown
+++ b/source/_integrations/flume.markdown
@@ -39,9 +39,9 @@ Flume notifications are fetched every 5 minutes and are available via the `flume
 - High flow
 - Leak detected
 
-To clear these notifications, you will need to use your Flume app or go to: [https://portal.flumewater.com/notifications](https://portal.flumewater.com/notifications) and clear the notification in question. The **High flow** and **Leak detected** sensors stay on until you do.
+To clear these notifications, use your Flume app or the [Flume notifications portal](https://portal.flumewater.com/notifications). The **High flow** and **Leak detected** sensors stay on until you do.
 
-The **Battery** and **Connectivity** sensors do not use notifications. They report what your Flume device reports directly and are checked once an hour. After you replace the batteries, the battery status updates on its own, without you clearing anything. The low battery notification itself stays in your Flume app, and in the `flume.list_notifications` response, until you clear it.
+The **Battery** and **Connectivity** sensors do not use notifications. They report what your Flume device reports directly and are checked every hour. After you replace the batteries, the battery status updates on its own, with nothing for you to clear. The **Low battery** notification stays in your Flume app, and in the `flume.list_notifications` response, until you clear it.
 
 Example of an automation that sends a Home Assistant notification of the most recent usage alert:
 

--- a/source/_integrations/flume.markdown
+++ b/source/_integrations/flume.markdown
@@ -36,12 +36,12 @@ To add `Flume` to your installation, go to {% my integrations title="**Settings*
 
 Flume notifications are fetched every 5 minutes and are available via the `flume.list_notifications` action. Some notifications are available via the following binary sensors:
 
-- Bridge disconnected
 - High flow
 - Leak detected
-- Low battery
 
 To clear the notifications, you will need to use your Flume app or go to: [https://portal.flumewater.com/notifications](https://portal.flumewater.com/notifications) and clear the notification in question.
+
+The **Battery** and **Connectivity** sensors do not use notifications. They report what your Flume device reports directly and are checked once an hour, so after you replace the batteries, the battery status updates on its own.
 
 Example of an automation that sends a Home Assistant notification of the most recent usage alert:
 

--- a/source/_integrations/flume.markdown
+++ b/source/_integrations/flume.markdown
@@ -41,7 +41,7 @@ Flume notifications are fetched every 5 minutes and are available via the `flume
 
 To clear these notifications, you will need to use your Flume app or go to: [https://portal.flumewater.com/notifications](https://portal.flumewater.com/notifications) and clear the notification in question. The **High flow** and **Leak detected** sensors stay on until you do.
 
-The **Battery** and **Connectivity** sensors do not use notifications. They report what your Flume device reports directly and are checked once an hour. After you replace the batteries, the battery status updates on its own, and there is no notification to clear.
+The **Battery** and **Connectivity** sensors do not use notifications. They report what your Flume device reports directly and are checked once an hour. After you replace the batteries, the battery status updates on its own, without you clearing anything. The low battery notification itself stays in your Flume app, and in the `flume.list_notifications` response, until you clear it.
 
 Example of an automation that sends a Home Assistant notification of the most recent usage alert:
 


### PR DESCRIPTION
## Proposed change

Follows the linked core PR, which changes where the Flume battery binary sensor gets its data.

The battery sensor used to be derived from the Flume notification list. Those notifications stay active until they are deleted in the Flume app, so the sensor stayed on indefinitely after the batteries were replaced — the docs told people to go clear the notification as the remedy. It now reads the battery level reported by the Flume devices endpoint, so it recovers on its own and that instruction no longer applies.

Changes to the **Notifications** section:

- Removed **Low battery** from the list of notification-derived binary sensors.
- Removed **Bridge disconnected** from that same list. This one is a pre-existing inaccuracy unrelated to the core change: that sensor has always read the `connected` field from the devices endpoint rather than a notification. Happy to split it out if you would rather keep this PR to the battery change alone.
- Added a sentence explaining that the **Battery** and **Connectivity** sensors report what the device reports directly, are checked hourly, and do not need a notification cleared.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#178471
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #162174

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
