### PR TITLE
Document e1000 Tx Unit Hang and network reset after changing the VM network adapter

### DIFF
--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -476,6 +476,17 @@ To create the virtual machine, follow the instructions for the hypervisor you us
 - title: VMware ESXi/vSphere
   content: |
     Use the `E1000` or `E1000E` virtual network adapter. There are confirmed mDNS/Multicast discovery issues when using VMware’s `VMXnet3` virtual network adapter.
+
+    If networking stops working and the virtual machine console repeatedly shows `e1000: Detected Tx Unit Hang`, the emulated `E1000` adapter has stalled. Restart the virtual machine to restore connectivity.
+
+    If you change the network adapter type after installation, reset the network configuration afterwards. The hypervisor assigns the new adapter a different PCI slot, which changes the network interface name inside the virtual machine. The stored network profile no longer matches, and the machine starts up without network access. To reset it, open the virtual machine console, enter `login` at the `ha >` prompt, and run:
+
+    ```bash
+    rm -r /mnt/overlay/etc/NetworkManager/system-connections
+    reboot
+    ```
+
+    Home Assistant OS creates a new default DHCP profile for the new interface during boot. The MAC address stays the same, so an existing DHCP reservation keeps working.
 {% endif %}
 {% if page.installation_type == 'windows' %}
 - title: Hyper-V


### PR DESCRIPTION
## Proposed change

Documents two things that currently trip up Home Assistant OS users on VMware:

1. The `e1000: Detected Tx Unit Hang` failure mode of the emulated E1000 adapter, and that restarting the virtual machine restores connectivity.
2. That changing the virtual network adapter type after installation leaves the machine without network access, and how to recover. The hypervisor assigns the new adapter a different PCI slot, which renames the network interface inside the guest, so the stored NetworkManager profile no longer matches and nothing requests DHCP.

The second point is a recurring source of confusion. In the long-running operating-system issue about this hang (<https://github.com/home-assistant/operating-system/issues/4120>), several users reported that the VM "won't boot" after switching to E1000E or VMXNET3. It does boot — it simply has no network, which is indistinguishable from a boot failure from the outside.

Verified on ESXi 6.7.0 U3 with HAOS 18.2 (kernel 6.18.39-haos): the vmxnet3 driver loads and binds correctly in the guest (`VMXNET3 user: Activate request succeeds`, `gosType=1`), ESXi forces `ethernet0.pciSlotNumber` from 33 to 160 on the device-type change, the interface is renamed `enp2s1` → `ens160`, and the only thing that breaks is the saved connection's path match. Reverting the adapter type restored the original DHCP lease within 20 seconds, confirming it was never a boot problem.

The reset procedure added here is the existing one from the [network documentation](https://developers.home-assistant.io/docs/operating-system/network/); this change just points VMware users to it at the moment they need it.

## Type of change

- [x] Change to an existing page

## Note on the target branch

This targets `current` on purpose: it documents behaviour that exists in shipped versions today, so it is not tied to an upcoming release. The `has-parent` label appears to be a false positive — the linked item above is an **issue**, not a parent PR, and there is no corresponding code change in another repository.
