### PR TITLE
Add prerequisites and removal instructions for Insteon

### DIFF
--- a/source/_integrations/insteon.markdown
+++ b/source/_integrations/insteon.markdown
@@ -41,7 +41,7 @@ _If you have factory reset your device, please see the instructions [Recovering 
 
 ## Prerequisites
 
-- **PLM (2413U, 2412U, or serial 2413S/2412S)**: the modem must be plugged into the Home Assistant host. Note the serial port path (for example `/dev/ttyUSB0` on Linux; check **Settings** > **System** > **Hardware** > **All hardware**).
+- **PLM (2413U, 2412U, or serial 2413S/2412S)**: the modem must be plugged into the Home Assistant host. Note the serial port path (for example `/dev/ttyUSB0` on Linux; check {% my hardware title="Settings > System > Hardware" %} > **dot menu** > **All Hardware**).
 - **Hub version 1 (2242, pre-2014) or Hub version 2 (2245)**: the Hub must be reachable on your network. Reserve a fixed IP address for it on your router. Hub version 1 uses port 9761; Hub version 2 uses port 25105.
 - **Hub version 2 credentials**: the username and password are printed on the label on the bottom of the Hub.
 - Insteon devices must be linked to the modem before they show up in Home Assistant, either from a previous controller setup or by linking them after setup with the **Add device** function in the Insteon panel.
@@ -177,7 +177,7 @@ automation:
     conditions:
       - condition: state
         entity_id: light.some_light
-        state: "off"
+        state: "on"
     actions:
       - action: light.turn_off
         target:

--- a/source/_integrations/insteon.markdown
+++ b/source/_integrations/insteon.markdown
@@ -3,10 +3,12 @@ title: Insteon
 description: Instructions on how to set up an Insteon Modem (PLM or Hub) locally within Home Assistant.
 ha_category:
   - Binary sensor
+  - Climate
   - Cover
   - Fan
   - Hub
   - Light
+  - Lock
   - Sensor
   - Switch
 ha_iot_class: Local Push
@@ -15,6 +17,7 @@ ha_domain: insteon
 ha_codeowners:
   - '@teharris1'
   - '@ssyrell'
+  - '@connorgallopo'
 ha_config_flow: true
 ha_platforms:
   - binary_sensor
@@ -35,6 +38,13 @@ The Insteon apps (Director or Insteon for Hub) are a paid service using the Inst
 This {% term integration %} adds support for integrating your Insteon network with Home Assistant. It has been tested with all USB and serial PowerLinc Modems (PLM) including [2413U], [2448A7], [2413S] and [2412S] models. It has also been tested to work with the [2242] and [2245] Hubs.
 
 _If you have factory reset your device, please see the instructions [Recovering After Factory Resetting The Hub](#recovering-after-factory-resetting-the-hub) for how to proceed._
+
+## Prerequisites
+
+- **PLM (2413U, 2412U, or serial 2413S/2412S)**: the modem must be plugged into the Home Assistant host. Note the serial port path (for example `/dev/ttyUSB0` on Linux; check **Settings** > **System** > **Hardware** > **All hardware**).
+- **Hub version 1 (2242, pre-2014) or Hub version 2 (2245)**: the Hub must be reachable on your network. Reserve a fixed IP address for it on your router. Hub version 1 uses port 9761; Hub version 2 uses port 25105.
+- **Hub version 2 credentials**: the username and password are printed on the label on the bottom of the Hub.
+- Insteon devices must be linked to the modem before they show up in Home Assistant, either from a previous controller setup or by linking them after setup with the **Add device** function of the Insteon panel.
 
 {% include integrations/config_flow.md %}
 
@@ -145,9 +155,9 @@ automation:
     triggers:
       - trigger: event
         event_type: insteon.button_on
-    event_data:
-      address: 1a2b3c
-      button: c
+        event_data:
+          address: 1a2b3c
+          button: c
     conditions:
       - condition: state
         entity_id: light.some_light
@@ -161,15 +171,15 @@ automation:
   - alias: "Turn a light off"
     triggers:
       - trigger: event
-        event_type: insteon.button_on
-    event_data:
-      address: 1a2b3c
+        event_type: insteon.button_off
+        event_data:
+          address: 1a2b3c
     conditions:
       - condition: state
         entity_id: light.some_light
         state: "off"
     actions:
-      - action: light.turn_on
+      - action: light.turn_off
         target:
           entity_id: light.some_light
 ```
@@ -204,3 +214,11 @@ Many users tried to factory reset their Insteon Hub when the Insteon app stopped
 3. Add devices to the Hub using the instructions for adding devices to the Insteon integration using the [Insteon configuration panel](#insteon-configuration-panel)
 
 Once your devices are linked to the Hub again they will appear in Home Assistant automatically.
+
+## Removing the integration
+
+This integration follows standard integration removal.
+
+{% include integrations/remove_device_service.md %}
+
+Removing the integration does not change the Insteon network itself. Devices stay linked to the modem and keep working with their existing links. If you are retiring the modem, use the **Delete device** function in the Insteon panel for each device first. This removes the links to the modem stored in each device and needs the modem still connected. Factory resetting the modem is not enough: it only clears the modem's own link database, and the records stored in your devices keep pointing at it.

--- a/source/_integrations/insteon.markdown
+++ b/source/_integrations/insteon.markdown
@@ -41,7 +41,7 @@ _If you have factory reset your device, please see the instructions [Recovering 
 
 ## Prerequisites
 
-- **PLM (2413U, 2412U, or serial 2413S/2412S)**: the modem must be plugged into the Home Assistant host. Note the serial port path (for example `/dev/ttyUSB0` on Linux; check {% my hardware title="Settings > System > Hardware" %} > **dot menu** > **All Hardware**).
+- **PLM (2413U, 2412U, or serial 2413S/2412S)**: the modem must be plugged into the Home Assistant host. Note the serial port path (for example `/dev/ttyUSB0` on Linux; check {% my hardware title="Settings > System > Hardware" %} > **System hardware**).
 - **Hub version 1 (2242, pre-2014) or Hub version 2 (2245)**: the Hub must be reachable on your network. Reserve a fixed IP address for it on your router. Hub version 1 uses port 9761; Hub version 2 uses port 25105.
 - **Hub version 2 credentials**: the username and password are printed on the label on the bottom of the Hub.
 - Insteon devices must be linked to the modem before they show up in Home Assistant, either from a previous controller setup or by linking them after setup with the **Add device** function in the Insteon panel.

--- a/source/_integrations/insteon.markdown
+++ b/source/_integrations/insteon.markdown
@@ -44,7 +44,7 @@ _If you have factory reset your device, please see the instructions [Recovering 
 - **PLM (2413U, 2412U, or serial 2413S/2412S)**: the modem must be plugged into the Home Assistant host. Note the serial port path (for example `/dev/ttyUSB0` on Linux; check **Settings** > **System** > **Hardware** > **All hardware**).
 - **Hub version 1 (2242, pre-2014) or Hub version 2 (2245)**: the Hub must be reachable on your network. Reserve a fixed IP address for it on your router. Hub version 1 uses port 9761; Hub version 2 uses port 25105.
 - **Hub version 2 credentials**: the username and password are printed on the label on the bottom of the Hub.
-- Insteon devices must be linked to the modem before they show up in Home Assistant, either from a previous controller setup or by linking them after setup with the **Add device** function of the Insteon panel.
+- Insteon devices must be linked to the modem before they show up in Home Assistant, either from a previous controller setup or by linking them after setup with the **Add device** function in the Insteon panel.
 
 {% include integrations/config_flow.md %}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add the missing Prerequisites and Removing the integration sections to the Insteon page, and fix a few things that were wrong or stale.

Prerequisites covers what each modem type needs before setup: the serial port path for a PLM, a reserved IP address and the right port for each Hub generation, the Hub v2 credentials from the label on the unit, and the fact that devices show up only after they are linked to the modem. The removal section documents the standard flow plus what actually happens on the Insteon side when a modem is retired: links stored in the devices survive a modem factory reset, so the correct order is deleting devices through the Insteon panel while the modem is still connected. That guidance was checked against the Insteon developer documentation.

Also in this change: Climate and Lock join `ha_category` (both platforms have shipped for years), I am added to `ha_codeowners` to match the integration manifest, and the two mini-remote automation examples are fixed. Their `event_data` blocks were dedented to the top level where they did nothing, and the "Turn a light off" example triggered on `insteon.button_on` and called `light.turn_on`.

[Link to CORE codeowner PR (MERGED)](https://github.com/home-assistant/core/pull/177253)

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
