### PR TITLE
Document Subaru integration removal steps

### DIFF
--- a/source/_integrations/subaru.markdown
+++ b/source/_integrations/subaru.markdown
@@ -140,3 +140,11 @@ Vehicle polling draws power from the 12V battery. Long term use without driving 
 **Q:** Should I enable the vehicle polling option?
 
 **A:** Probably not. One use case is if you have a PHEV and want to monitor your charging progress. Otherwise, the data isn't going to change much after you've shutdown your vehicle (tire pressures are only updated when the vehicle is in motion). A future revision will expose vehicle polling as an action to enable incorporation into automations.
+
+## Removing the integration
+
+This integration follows standard integration removal. No extra steps are required.
+
+{% include integrations/remove_device_service.md %}
+
+If you also want to revoke Home Assistant's access to your MySubaru account, log in to [MySubaru](https://www.mysubaru.com) and remove the Home Assistant device under **Settings** > **Devices**.


### PR DESCRIPTION
## Proposed change

Adds the missing "Removing the integration" section to the Subaru docs — standard removal, plus a note on revoking MySubaru account access. Closes the `docs-removal-instructions` gap for an upcoming Bronze quality-scale declaration (no accompanying code PR yet).

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
