### PR TITLE
Document BTicino MyHome Server 1 support in the netatmo integration

### DIFF
--- a/source/_integrations/netatmo.markdown
+++ b/source/_integrations/netatmo.markdown
@@ -37,7 +37,7 @@ ha_platforms:
 ha_integration_type: hub
 ---
 
-[Netatmo](https://www.netatmo.com/) is a smart home brand from the Legrand group that makes connected devices for the home, including weather stations, indoor and outdoor cameras, video doorbells, smart thermostats and radiator valves, air quality monitors, and Legrand and BTicino electrical products such as switches, dimmers, and power plugs.
+[Netatmo](https://www.netatmo.com/) is a smart home brand from the Legrand group that makes connected devices for the home, including weather stations, indoor and outdoor cameras, video doorbells, smart thermostats and radiator valves, air quality monitors, and Legrand and BTicino electrical products such as switches, dimmers, power plugs, and shutters, including those connected through a BTicino MyHome Server 1.
 
 The **Netatmo** {% term integration %} connects these devices to Home Assistant, so you can monitor and control your Netatmo products alongside the rest of your smart home. It communicates with Netatmo's cloud service, so an active internet connection and a Netatmo account are required.
 
@@ -94,11 +94,11 @@ The doorbell is currently not supported with the Home Assistant Cloud link mode 
 
 ## Climate
 
-The `netatmo` thermostat platform is consuming the information provided by a [Netatmo Smart Thermostat](https://www.netatmo.com/product/energy/thermostat), [Smart Modulating Thermostat](https://www.netatmo.com/smart-modulating-thermostat) and [Netatmo Smart Radiator Valve](https://www.netatmo.com/additional-smart-radiator-valve). This integration allows you to view the current temperature and control the setpoint.
+The `netatmo` thermostat platform is consuming the information provided by a [Netatmo Smart Thermostat](https://www.netatmo.com/product/energy/thermostat), [Smart Modulating Thermostat](https://www.netatmo.com/smart-modulating-thermostat), [Netatmo Smart Radiator Valve](https://www.netatmo.com/additional-smart-radiator-valve), and BTicino thermostats connected through a MyHome Server 1. This integration allows you to view the current temperature and control the setpoint.
 
 ## Cover
 
-The `netatmo` cover platform provides support for Bubendorff shutters. 
+The `netatmo` cover platform provides support for Bubendorff shutters and BTicino shutters connected through a MyHome Server 1. Support for setting an exact position for a MyHome Server 1 shutter depends on the specific actor: some, such as the F411, only support opening, closing, and stopping, while others support setting an exact position. Home Assistant detects this automatically. For actors without exact position support, the reported state may continue to show opening or closing for a while after the shutter has physically finished moving, until the actor's configured movement duration has elapsed.
 
 ## Fan
 
@@ -107,7 +107,7 @@ The `netatmo` fan plaform provides support for Legrand centralized ventilation c
 ## Light
 
 The `netatmo` light platform is consuming information provided by a [Netatmo Smart Outdoor](https://www.netatmo.com/smart-outdoor-camera) camera and requires an active webhook. This integration allows you to turn on/off the flood lights.
-It further provides support for Legrand/BTicino dimmers.
+It further provides support for Legrand/BTicino dimmers, including those connected through a BTicino MyHome Server 1.
 
 ## Sensor
 
@@ -116,7 +116,7 @@ The `netatmo` sensor platform is consuming the information provided by a [Netatm
 
 ## Switch
 
-The `netatmo` switch platform provides support for Legrand/BTicino switches and power plugs.
+The `netatmo` switch platform provides support for Legrand/BTicino switches and power plugs, including those connected through a BTicino MyHome Server 1.
 
 {% include integrations/actions.md %}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents support for devices connected through a BTicino MyHome Server 1,
added by the netatmo-mhs1-support PR in home-assistant/core (not yet
merged). This isn't limited to shutters - the integration's cloud
account-linking previously excluded the OAuth scope needed to see an MHS1
installation at all, so switches, dimmers and thermostats connected through
one were unreachable too.

Updates the introduction and the Climate, Cover, Light, and Switch sections.
The Cover section also notes that exact-position support for a MyHome
Server 1 shutter depends on the specific actor - some, such as the F411,
only support open/close/stop, while others (for example a calibrated F401)
support setting an exact position - that Home Assistant detects this
automatically, and that for actors without exact position support, the
reported state may continue to show opening/closing for a while after the
shutter has physically finished moving, until the actor's configured
movement duration has elapsed.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/178507
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: none

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards