### PR TITLE
Add button platform to NeoPool docs

### DIFF
--- a/source/_integrations/neopool.markdown
+++ b/source/_integrations/neopool.markdown
@@ -8,6 +8,7 @@ ha_codeowners:
   - "@svasek"
 ha_domain: neopool
 ha_platforms:
+  - button
   - light
   - sensor
   - switch
@@ -100,11 +101,17 @@ Enable cover sensor:
 
 ## Supported functionality
 
-The integration exposes the controller's runtime state as sensor entities, plus an optional light entity for the pool light relay and switch entities for filtration, backwash, the auxiliary relays, and the controller's configuration flags.
+The integration exposes the controller's runtime state as sensor entities, plus an optional light entity for the pool light relay, switch entities for filtration, backwash, the auxiliary relays, and the controller's configuration flags, and button entities for device maintenance actions.
 
 {% note %}
 Only entities backed by a detected hardware module or an enabled controller option are registered. The rest stay hidden until the module or option becomes available. Each bullet below lists the specific requirement for that entity.
 {% endnote %}
+
+### Buttons
+
+- **Synchronize device time**: Writes the current Home Assistant time to the controller's clock.
+- **Clear error messages**: Clears the controller's active error and alarm messages.
+- **Reset cell runtime counter**: Resets the partial cell-runtime counter used to track electrolytic cell wear. Added when the hydrolysis module is present. Diagnostic and disabled by default, because it clears a wear counter you may want to keep.
 
 ### Light
 

--- a/source/_integrations/neopool.markdown
+++ b/source/_integrations/neopool.markdown
@@ -109,9 +109,9 @@ Only entities backed by a detected hardware module or an enabled controller opti
 
 ### Buttons
 
-- **Synchronize device time**: Writes the current Home Assistant time to the controller's clock.
+- **Synchronize device time**: Writes Home Assistant's current time to the controller's clock.
 - **Clear error messages**: Clears the controller's active error and alarm messages.
-- **Reset cell runtime counter**: Resets the partial cell-runtime counter used to track electrolytic cell wear. Added when the hydrolysis module is present. Diagnostic and disabled by default, because it clears a wear counter you may want to keep.
+- **Reset cell runtime counter**: Resets the partial cell-runtime counter used to track electrolytic cell wear. Added when the hydrolysis module is present. This button is a configuration entity and is disabled by default, because it clears a wear counter you may want to keep.
 
 ### Light
 


### PR DESCRIPTION
## Proposed change

Documents the `button` platform for the NeoPool integration, added in home-assistant/core#178693. Adds `button` to `ha_platforms` and a new "Buttons" section under "Supported functionality" describing the three action buttons: synchronize device time, clear error messages, and reset cell runtime counter.

## Type of change

- [ ] Spelling, grammar or other readability improvements ([`current`][docs-current] branch).
- [ ] Adjusted content to improve clarity.
- [ ] Added documentation for a new integration I'm adding to Home Assistant.
- [x] Added documentation for a new feature I'm adding to an existing integration ([`next`][docs-next] branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#178693
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - [Documentation for existing features][docs-current] should use the `current` branch.
  - [Documentation for new or changing features][docs-next] should use the `next` branch.
- [x] The documentation follows the Home Assistant documentation standards.

[docs-current]: https://github.com/home-assistant/home-assistant.io/tree/current
[docs-next]: https://github.com/home-assistant/home-assistant.io/tree/next
