### PR TITLE
Document SensorPush battery entities

### DIFF
--- a/source/_integrations/sensorpush.markdown
+++ b/source/_integrations/sensorpush.markdown
@@ -36,7 +36,7 @@ The HT.w and HTP.xw also report their battery, as two diagnostic entities: a **B
 Unlike temperature, humidity, and barometric pressure, the battery is not part of the Bluetooth advertisement. Home Assistant has to connect to the sensor to read it, which has two consequences:
 
 - A Bluetooth adapter or [Bluetooth proxy](/integrations/bluetooth/#remote-adapters-bluetooth-proxies) able to make connections must be in range of the sensor. If only a passive proxy can see it, the other entities still work, but no battery entities are created.
-- Each sensor is polled at most once every 24 hours, because connecting to it spends some of the battery being measured.
+- Once a reading has succeeded, each sensor is polled at most once every 24 hours, because connecting to it spends some of the battery being measured. Until then it tries more often, so the entities appear shortly after you add the device rather than the next day.
 
 The HT1 does not expose battery information and does not get these entities.
 

--- a/source/_integrations/sensorpush.markdown
+++ b/source/_integrations/sensorpush.markdown
@@ -29,4 +29,15 @@ Sensor entities (temperature, humidity, barometric pressure) will not be availab
 
 The SensorPush integration will automatically discover devices once the [Bluetooth](/integrations/bluetooth) integration is enabled and functional.
 
+## Battery level
+
+The HT.w and HTP.xw also report their battery, as two diagnostic entities: a **Battery** percentage and a **Voltage** in volts. The percentage is estimated from the voltage, mapping the 2400–3000 mV range SensorPush documents onto 0–100%. A coin cell holds a nearly flat voltage for most of its life and then drops quickly, so expect the percentage to sit near full for a long time and then fall away towards the end.
+
+Unlike temperature, humidity, and barometric pressure, the battery is not part of the Bluetooth advertisement. Home Assistant has to connect to the sensor to read it, which has two consequences:
+
+- A Bluetooth adapter or [Bluetooth proxy](/integrations/bluetooth/#remote-adapters-bluetooth-proxies) able to make connections must be in range of the sensor. If only a passive proxy can see it, the other entities still work, but no battery entities are created.
+- Each sensor is polled at most once every 24 hours, because connecting to it spends some of the battery being measured.
+
+The HT1 does not expose battery information and does not get these entities.
+
 {% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change

Documents the battery percentage and voltage entities added to the SensorPush integration in home-assistant/core#179000.

The part worth spelling out for users is that these entities behave differently from the existing ones. Temperature, humidity, and pressure come from the Bluetooth advertisement, but the battery is only readable over a GATT connection, so it needs a *connectable* adapter or proxy in range, and it is polled only once a day. Users covered by a passive-only proxy will see the other entities but no battery — this explains why rather than leaving it a mystery.

Also notes that the percentage is estimated from voltage and will look flat for most of the cell's life, and that the first generation HT1 does not expose battery at all.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch)
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch)
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch)
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch)
- [ ] Removed stale or deprecated documentation

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#179000
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes home-assistant/core#123134

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting).
- [x] I have verified that the changes are correct and work as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vrLbWPbFFogGyNRmudS2s
