### PR TITLE
Precompute the domain index for action, trigger, and condition pages

### DIFF
--- a/plugins/domain_index.rb
+++ b/plugins/domain_index.rb
@@ -42,9 +42,14 @@ module Jekyll
       KINDS.each do |collection_name, kind|
         domain_data = site.data["#{kind}_domains"]
         domain_data = [] unless domain_data.is_a?(Array)
-        data_by_key = domain_data
-                      .select { |entry| entry.is_a?(Hash) && entry['key'] }
-                      .to_h { |entry| [entry['key'], entry] }
+        # Keep the first entry per key, matching how the previous Liquid
+        # lookup (`| where: 'key', ... | first`) resolved duplicates.
+        data_by_key = {}
+        domain_data.each do |entry|
+          next unless entry.is_a?(Hash) && entry['key']
+
+          data_by_key[entry['key']] ||= entry
+        end
 
         lookup = {}
         site.collections[collection_name]&.docs&.each do |doc|

--- a/plugins/domain_index.rb
+++ b/plugins/domain_index.rb
@@ -1,0 +1,69 @@
+# Precompute the per-domain label/icon index used by the action, trigger,
+# and condition pages and sidebars.
+#
+# Without this, every action/trigger/condition page resolved each domain
+# label with `site.integrations | where: 'ha_domain', domain | first`,
+# a linear scan over 1500+ integration documents. Repeated for every
+# domain in the sidebar of every page, that scan dominated the build time.
+#
+# For each collection this generator exposes:
+#
+#   site.data['<kind>_domain_index']   ordered array of entries, sorted by
+#                                      domain key, for building the full
+#                                      domain list in sidebars and indexes
+#   site.data['<kind>_domain_lookup']  the same entries keyed by domain,
+#                                      for single-domain lookups
+#
+# Each entry carries 'key', 'label', 'icon', and 'description'. Values come
+# from the optional site.data['<kind>_domains'] data file when present, and
+# fall back to the integration title and a generic puzzle icon otherwise.
+module Jekyll
+  class DomainIndexGenerator < Generator
+    safe true
+    priority :low
+
+    KINDS = {
+      'actions' => 'action',
+      'triggers' => 'trigger',
+      'conditions' => 'condition'
+    }.freeze
+
+    DEFAULT_ICON = 'mdi:puzzle-outline'.freeze
+
+    def generate(site)
+      integration_titles = {}
+      site.collections['integrations']&.docs&.each do |doc|
+        domain = doc.data['ha_domain']
+        next unless domain
+
+        integration_titles[domain] ||= doc.data['title'] || domain
+      end
+
+      KINDS.each do |collection_name, kind|
+        domain_data = site.data["#{kind}_domains"]
+        domain_data = [] unless domain_data.is_a?(Array)
+        data_by_key = domain_data
+                      .select { |entry| entry.is_a?(Hash) && entry['key'] }
+                      .to_h { |entry| [entry['key'], entry] }
+
+        lookup = {}
+        site.collections[collection_name]&.docs&.each do |doc|
+          domain = doc.data['domain']
+          next unless domain
+          next if lookup.key?(domain)
+
+          entry = data_by_key[domain] || {}
+          lookup[domain] = {
+            'key' => domain,
+            'label' => entry['label'] || integration_titles[domain] || domain,
+            'icon' => entry['icon'] || DEFAULT_ICON,
+            'description' => entry['description']
+          }
+        end
+
+        site.data["#{kind}_domain_index"] = lookup.values.sort_by { |entry| entry['key'] }
+        site.data["#{kind}_domain_lookup"] = lookup
+      end
+    end
+  end
+end

--- a/source/_includes/asides/action_integrations.html
+++ b/source/_includes/asides/action_integrations.html
@@ -1,20 +1,10 @@
-{%- assign domains = site.actions | map: 'domain' | uniq | sort -%}
 <section class="aside-module grid__item one-whole lap-one-half">
   <div class='section'>
     <h2 class="h1 title epsilon">{% icon "mdi:puzzle-outline" %} Integrations</h2>
     <ul class='divided'>
-      {%- for domain_key in domains -%}
-        {%- assign domain_data = site.data.action_domains | where: 'key', domain_key | first -%}
-        {%- if domain_data -%}
-          {%- assign domain_label = domain_data.label -%}
-          {%- assign domain_icon = domain_data.icon -%}
-        {%- else -%}
-          {%- assign integration = site.integrations | where: 'ha_domain', domain_key | first -%}
-          {%- assign domain_label = integration.title | default: domain_key -%}
-          {%- assign domain_icon = 'mdi:puzzle-outline' -%}
-        {%- endif -%}
-        <li{% if domain_key == page.domain %} class="active"{% endif %}>
-          <a href='/actions/#{{ domain_key }}'><iconify-icon inline icon='{{ domain_icon }}'></iconify-icon> {{ domain_label }}</a>
+      {%- for entry in site.data.action_domain_index -%}
+        <li{% if entry.key == page.domain %} class="active"{% endif %}>
+          <a href='/actions/#{{ entry.key }}'><iconify-icon inline icon='{{ entry.icon }}'></iconify-icon> {{ entry.label }}</a>
         </li>
       {%- endfor -%}
     </ul>

--- a/source/_includes/asides/action_meta.html
+++ b/source/_includes/asides/action_meta.html
@@ -1,10 +1,5 @@
-{%- assign domain_data = site.data.action_domains | where: 'key', page.domain | first -%}
-{%- if domain_data -%}
-  {%- assign domain_label = domain_data.label -%}
-{%- else -%}
-  {%- assign integration = site.integrations | where: 'ha_domain', page.domain | first -%}
-  {%- assign domain_label = integration.title | default: page.domain -%}
-{%- endif -%}
+{%- assign domain_entry = site.data.action_domain_lookup[page.domain] -%}
+{%- assign domain_label = domain_entry.label | default: page.domain -%}
 
 <section class="aside-module grid__item one-whole lap-one-half">
   <div class='section'>

--- a/source/_includes/asides/condition_integrations.html
+++ b/source/_includes/asides/condition_integrations.html
@@ -1,20 +1,10 @@
-{%- assign domains = site.conditions | map: 'domain' | uniq | sort -%}
 <section class="aside-module grid__item one-whole lap-one-half">
   <div class='section'>
     <h2 class="h1 title epsilon">{% icon "mdi:puzzle-outline" %} Integrations</h2>
     <ul class='divided'>
-      {%- for domain_key in domains -%}
-        {%- assign domain_data = site.data.condition_domains | where: 'key', domain_key | first -%}
-        {%- if domain_data -%}
-          {%- assign domain_label = domain_data.label -%}
-          {%- assign domain_icon = domain_data.icon -%}
-        {%- else -%}
-          {%- assign integration = site.integrations | where: 'ha_domain', domain_key | first -%}
-          {%- assign domain_label = integration.title | default: domain_key -%}
-          {%- assign domain_icon = 'mdi:puzzle-outline' -%}
-        {%- endif -%}
-        <li{% if domain_key == page.domain %} class="active"{% endif %}>
-          <a href='/conditions/#{{ domain_key }}'><iconify-icon inline icon='{{ domain_icon }}'></iconify-icon> {{ domain_label }}</a>
+      {%- for entry in site.data.condition_domain_index -%}
+        <li{% if entry.key == page.domain %} class="active"{% endif %}>
+          <a href='/conditions/#{{ entry.key }}'><iconify-icon inline icon='{{ entry.icon }}'></iconify-icon> {{ entry.label }}</a>
         </li>
       {%- endfor -%}
     </ul>

--- a/source/_includes/asides/condition_meta.html
+++ b/source/_includes/asides/condition_meta.html
@@ -1,10 +1,5 @@
-{%- assign domain_data = site.data.condition_domains | where: 'key', page.domain | first -%}
-{%- if domain_data -%}
-  {%- assign domain_label = domain_data.label -%}
-{%- else -%}
-  {%- assign integration = site.integrations | where: 'ha_domain', page.domain | first -%}
-  {%- assign domain_label = integration.title | default: page.domain -%}
-{%- endif -%}
+{%- assign domain_entry = site.data.condition_domain_lookup[page.domain] -%}
+{%- assign domain_label = domain_entry.label | default: page.domain -%}
 
 <section class="aside-module grid__item one-whole lap-one-half">
   <div class='section'>

--- a/source/_includes/asides/trigger_integrations.html
+++ b/source/_includes/asides/trigger_integrations.html
@@ -1,20 +1,10 @@
-{%- assign domains = site.triggers | map: 'domain' | uniq | sort -%}
 <section class="aside-module grid__item one-whole lap-one-half">
   <div class='section'>
     <h2 class="h1 title epsilon">{% icon "mdi:puzzle-outline" %} Integrations</h2>
     <ul class='divided'>
-      {%- for domain_key in domains -%}
-        {%- assign domain_data = site.data.trigger_domains | where: 'key', domain_key | first -%}
-        {%- if domain_data -%}
-          {%- assign domain_label = domain_data.label -%}
-          {%- assign domain_icon = domain_data.icon -%}
-        {%- else -%}
-          {%- assign integration = site.integrations | where: 'ha_domain', domain_key | first -%}
-          {%- assign domain_label = integration.title | default: domain_key -%}
-          {%- assign domain_icon = 'mdi:puzzle-outline' -%}
-        {%- endif -%}
-        <li{% if domain_key == page.domain %} class="active"{% endif %}>
-          <a href='/triggers/#{{ domain_key }}'><iconify-icon inline icon='{{ domain_icon }}'></iconify-icon> {{ domain_label }}</a>
+      {%- for entry in site.data.trigger_domain_index -%}
+        <li{% if entry.key == page.domain %} class="active"{% endif %}>
+          <a href='/triggers/#{{ entry.key }}'><iconify-icon inline icon='{{ entry.icon }}'></iconify-icon> {{ entry.label }}</a>
         </li>
       {%- endfor -%}
     </ul>

--- a/source/_includes/asides/trigger_meta.html
+++ b/source/_includes/asides/trigger_meta.html
@@ -1,10 +1,5 @@
-{%- assign domain_data = site.data.trigger_domains | where: 'key', page.domain | first -%}
-{%- if domain_data -%}
-  {%- assign domain_label = domain_data.label -%}
-{%- else -%}
-  {%- assign integration = site.integrations | where: 'ha_domain', page.domain | first -%}
-  {%- assign domain_label = integration.title | default: page.domain -%}
-{%- endif -%}
+{%- assign domain_entry = site.data.trigger_domain_lookup[page.domain] -%}
+{%- assign domain_label = domain_entry.label | default: page.domain -%}
 
 <section class="aside-module grid__item one-whole lap-one-half">
   <div class='section'>

--- a/source/actions/index.html
+++ b/source/actions/index.html
@@ -33,17 +33,10 @@ toc: true
       {%- assign domain_keys = all_actions | map: 'domain' | uniq | sort -%}
       {%- for domain_key in domain_keys -%}
         {%- assign domain_actions = all_actions | where: 'domain', domain_key -%}
-        {%- assign domain_data = site.data.action_domains | where: 'key', domain_key | first -%}
-        {%- if domain_data -%}
-          {%- assign domain_label = domain_data.label -%}
-          {%- assign domain_icon = domain_data.icon -%}
-          {%- assign domain_desc = domain_data.description -%}
-        {%- else -%}
-          {%- assign integration = site.integrations | where: 'ha_domain', domain_key | first -%}
-          {%- assign domain_label = integration.title | default: domain_key -%}
-          {%- assign domain_icon = 'mdi:puzzle-outline' -%}
-          {%- assign domain_desc = nil -%}
-        {%- endif -%}
+        {%- assign domain_entry = site.data.action_domain_lookup[domain_key] -%}
+        {%- assign domain_label = domain_entry.label | default: domain_key -%}
+        {%- assign domain_icon = domain_entry.icon | default: 'mdi:puzzle-outline' -%}
+        {%- assign domain_desc = domain_entry.description -%}
         {%- if domain_actions.size > 0 -%}
         <div class="tf-category" data-category="{{ domain_key }}">
           <h3 id="{{ domain_key }}"><iconify-icon inline icon="{{ domain_icon }}"></iconify-icon> {{ domain_label }}</h3>

--- a/source/conditions/index.html
+++ b/source/conditions/index.html
@@ -33,17 +33,10 @@ toc: true
       {%- assign domain_keys = all_conditions | map: 'domain' | uniq | sort -%}
       {%- for domain_key in domain_keys -%}
         {%- assign domain_conditions = all_conditions | where: 'domain', domain_key -%}
-        {%- assign domain_data = site.data.condition_domains | where: 'key', domain_key | first -%}
-        {%- if domain_data -%}
-          {%- assign domain_label = domain_data.label -%}
-          {%- assign domain_icon = domain_data.icon -%}
-          {%- assign domain_desc = domain_data.description -%}
-        {%- else -%}
-          {%- assign integration = site.integrations | where: 'ha_domain', domain_key | first -%}
-          {%- assign domain_label = integration.title | default: domain_key -%}
-          {%- assign domain_icon = 'mdi:puzzle-outline' -%}
-          {%- assign domain_desc = nil -%}
-        {%- endif -%}
+        {%- assign domain_entry = site.data.condition_domain_lookup[domain_key] -%}
+        {%- assign domain_label = domain_entry.label | default: domain_key -%}
+        {%- assign domain_icon = domain_entry.icon | default: 'mdi:puzzle-outline' -%}
+        {%- assign domain_desc = domain_entry.description -%}
         {%- if domain_conditions.size > 0 -%}
         <div class="tf-category" data-category="{{ domain_key }}">
           <h3 id="{{ domain_key }}"><iconify-icon inline icon="{{ domain_icon }}"></iconify-icon> {{ domain_label }}</h3>

--- a/source/triggers/index.html
+++ b/source/triggers/index.html
@@ -33,17 +33,10 @@ toc: true
       {%- assign domain_keys = all_triggers | map: 'domain' | uniq | sort -%}
       {%- for domain_key in domain_keys -%}
         {%- assign domain_triggers = all_triggers | where: 'domain', domain_key -%}
-        {%- assign domain_data = site.data.trigger_domains | where: 'key', domain_key | first -%}
-        {%- if domain_data -%}
-          {%- assign domain_label = domain_data.label -%}
-          {%- assign domain_icon = domain_data.icon -%}
-          {%- assign domain_desc = domain_data.description -%}
-        {%- else -%}
-          {%- assign integration = site.integrations | where: 'ha_domain', domain_key | first -%}
-          {%- assign domain_label = integration.title | default: domain_key -%}
-          {%- assign domain_icon = 'mdi:puzzle-outline' -%}
-          {%- assign domain_desc = nil -%}
-        {%- endif -%}
+        {%- assign domain_entry = site.data.trigger_domain_lookup[domain_key] -%}
+        {%- assign domain_label = domain_entry.label | default: domain_key -%}
+        {%- assign domain_icon = domain_entry.icon | default: 'mdi:puzzle-outline' -%}
+        {%- assign domain_desc = domain_entry.description -%}
         {%- if domain_triggers.size > 0 -%}
         <div class="tf-category" data-category="{{ domain_key }}">
           <h3 id="{{ domain_key }}"><iconify-icon inline icon="{{ domain_icon }}"></iconify-icon> {{ domain_label }}</h3>


### PR DESCRIPTION
## Proposed change

Split out of #47387 (1 of 5). This is the largest build-time win: **~356 of the 625 seconds of a clean build** (measured with `jekyll build --profile`).

Every action, trigger, and condition page resolved domain labels in its sidebar with `site.integrations | where: 'ha_domain', ... | first` — a linear scan over 1,500+ integration documents. The `site.data.<kind>_domains` data files this was meant to be a fallback for don't exist, so the scan ran for all ~280 domains on every one of the 985 action pages: roughly 420 million document lookups per build.

A new generator (`plugins/domain_index.rb`) computes the domain→label/icon index once per build, and the sidebars, meta sections, and the three index pages read from it. The optional `_data/<kind>_domains.yml` files are still honored if they are added later, with the same precedence as before (data file entry first, integration title as fallback).

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

None of the listed types apply: this is a build performance change with no intended change to rendered content.

## Additional information

- Split from #47387, which has the full investigation and combined measurements.
- Regression tested as part of #47387: the rendered sidebars, domain lists, labels, and icons on the deploy preview were diffed against the live site and are identical.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zeLdNaEP3Bq8akPj4b76d

---
_Generated by [Claude Code](https://claude.ai/code/session_015zeLdNaEP3Bq8akPj4b76d)_