### PR TITLE
Serve doc tooltip data as a static file instead of inlining it into every page

### DIFF
--- a/plugins/doc_data_file.rb
+++ b/plugins/doc_data_file.rb
@@ -1,0 +1,45 @@
+require 'digest/md5'
+
+# Write the generated template function, action, trigger, and condition
+# lookup data to a single static JavaScript file instead of inlining it
+# into every page.
+#
+# The four JSON blobs together are roughly 500 KB. Inlined through
+# scripts.html they were repeated in every generated page, which added
+# gigabytes to the build output and made every visitor download the data
+# again on each page view. As a static file it is generated once and
+# cached by the browser.
+#
+# The file name carries a content hash, so browsers can cache it forever
+# and still pick up new data immediately after a deploy. scripts.html
+# reads the URL from site.data['doc_data_js_path'].
+#
+# Runs at priority :lowest so it executes after the :low generators that
+# produce the JSON (doc_collections_data.rb and template_functions_data.rb).
+module Jekyll
+  class DocDataFileGenerator < Generator
+    safe true
+    priority :lowest
+
+    def generate(site)
+      content = <<~JS
+        window.__templateFunctions = #{site.data['template_functions_json']};
+        window.__actions = #{site.data['actions_json']};
+        window.__triggers = #{site.data['triggers_json']};
+        window.__conditions = #{site.data['conditions_json']};
+      JS
+
+      digest = Digest::MD5.hexdigest(content)[0, 12]
+      file_name = "doc-data-#{digest}.js"
+
+      page = PageWithoutAFile.new(site, site.source, 'static', file_name)
+      page.content = content
+      page.data['layout'] = nil
+      page.data['render_with_liquid'] = false
+      page.data['sitemap'] = false
+      site.pages << page
+
+      site.data['doc_data_js_path'] = "/static/#{file_name}"
+    end
+  end
+end

--- a/plugins/doc_data_file.rb
+++ b/plugins/doc_data_file.rb
@@ -4,12 +4,6 @@ require 'digest/md5'
 # lookup data to a single static JavaScript file instead of inlining it
 # into every page.
 #
-# The four JSON blobs together are roughly 500 KB. Inlined through
-# scripts.html they were repeated in every generated page, which added
-# gigabytes to the build output and made every visitor download the data
-# again on each page view. As a static file it is generated once and
-# cached by the browser.
-#
 # The file name carries a content hash, so browsers can cache it forever
 # and still pick up new data immediately after a deploy. scripts.html
 # reads the URL from site.data['doc_data_js_path'].

--- a/source/_includes/javascripts/scripts.html
+++ b/source/_includes/javascripts/scripts.html
@@ -5,12 +5,7 @@
 <script src="{{ '/javascripts/prism.js' | cache_buster }}" type="text/javascript" defer></script>
 <script src="{{ '/javascripts/prism-signature.js' | cache_buster }}" type="text/javascript" defer></script>
 <script src="{{ '/javascripts/prism-jinja2.js' | cache_buster }}" type="text/javascript" defer></script>
-<script type="text/javascript">
-window.__templateFunctions = {{ site.data.template_functions_json }};
-window.__actions = {{ site.data.actions_json }};
-window.__triggers = {{ site.data.triggers_json }};
-window.__conditions = {{ site.data.conditions_json }};
-</script>
+<script src="{{ site.data.doc_data_js_path }}" type="text/javascript" defer></script>
 <script src="{{ '/javascripts/prism-template-links.js' | cache_buster }}" type="text/javascript" defer></script>
 <script src="{{ '/javascripts/prism-doc-links.js' | cache_buster }}" type="text/javascript" defer></script>
 <script src="{{ '/javascripts/docsearch-options.js' | cache_buster }}" type="text/javascript"></script>


### PR DESCRIPTION
## Proposed change

Split out of #47387 (2 of 5). This is the big output-size and memory win.

The action, trigger, condition, and template function lookup data used by the code-block tooltips (`window.__actions` and friends) was inlined into every generated page — about 517 KB each. Across 4,079 pages that was **~2 GB of the 2.8 GB build output**, it drove the build's peak memory toward 5 GB (the cause of devcontainer crashes), and every visitor re-downloaded the data on each page view.

A new generator (`plugins/doc_data_file.rb`) writes the data once to a content-hashed static file (`/static/doc-data-<hash>.js`) that browsers can cache forever while still picking up new data immediately after a deploy. The file loads with a deferred script tag placed before `prism-template-links.js` and `prism-doc-links.js`, so per the HTML spec's deferred-script ordering it executes before its consumers, exactly like the old inline block.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

None of the listed types apply: this is a build performance change with no intended change to page behavior.

## Additional information

- Split from #47387, which has the full investigation and combined measurements.
- Regression tested as part of #47387:
  - The external data file on the deploy preview is **byte-identical** (529,338 bytes) to the JSON the live site inlines.
  - Both variants were loaded in headless Chromium: data dictionaries populated (985 actions / 192 triggers / 149 conditions / 202 template functions), linked code-block tokens, parameter tooltips, and glossary tooltips all have identical counts, with zero JavaScript errors — confirming the deferred file loads before the scripts that consume it.
- Trade-off for reviewers: one extra HTTP request on first page view, in exchange for ~517 KB less HTML on every page view after that.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zeLdNaEP3Bq8akPj4b76d

---
_Generated by [Claude Code](https://claude.ai/code/session_015zeLdNaEP3Bq8akPj4b76d)_