### PR TITLE
Cache asset digests in the cache_buster filter

### DIFF
--- a/plugins/cache_buster.rb
+++ b/plugins/cache_buster.rb
@@ -13,7 +13,7 @@ module Jekyll
 
       cached = DIGEST_CACHE[file_name]
       unless cached && cached[0] == mtime
-        cached = [mtime, Digest::MD5.hexdigest(File.read(path))]
+        cached = [mtime, Digest::MD5.file(path).hexdigest]
         DIGEST_CACHE[file_name] = cached
       end
 

--- a/plugins/cache_buster.rb
+++ b/plugins/cache_buster.rb
@@ -1,8 +1,23 @@
 module Jekyll
   module CacheBuster
     require 'digest/md5'
+
+    # Cache digests per file so each asset is read and hashed once per
+    # build instead of once per page. Keyed on the file's mtime, so edits
+    # during `--watch` sessions still produce a fresh digest.
+    DIGEST_CACHE = {}
+
     def cache_buster(file_name)
-      [file_name, '?', Digest::MD5.hexdigest(File.read(File.join('./source', file_name)))].join
+      path = File.join('./source', file_name)
+      mtime = File.mtime(path)
+
+      cached = DIGEST_CACHE[file_name]
+      unless cached && cached[0] == mtime
+        cached = [mtime, Digest::MD5.hexdigest(File.read(path))]
+        DIGEST_CACHE[file_name] = cached
+      end
+
+      [file_name, '?', cached[1]].join
     end
   end
 end


### PR DESCRIPTION
## Proposed change

Split out of #47387 (3 of 5). A small, self-contained build optimization.

The `cache_buster` filter read the referenced asset file from disk and MD5-hashed it on every call. With nine references per page across 4,000+ pages, that was about 37,000 redundant file reads and hashes per build. Digests are now cached per file, keyed on the file's modification time, so edits during `rake preview` watch sessions still produce a fresh digest.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

None of the listed types apply: this is a build performance change with no change to output (the generated URLs are identical).

## Additional information

- Split from #47387, which has the full investigation and combined measurements.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zeLdNaEP3Bq8akPj4b76d

---
_Generated by [Claude Code](https://claude.ai/code/session_015zeLdNaEP3Bq8akPj4b76d)_