### PR TITLE
Render the table of contents once per page

### DIFF
--- a/source/_includes/site/sidebar.html
+++ b/source/_includes/site/sidebar.html
@@ -81,7 +81,7 @@
       <section id="toc-module" class="aside-module grid__item one-whole lap-one-half">
         <div class='section'>
           <h2 class="h1 title epsilon">{% icon "mdi:toc" %} On this page</h2>
-          {{ content | toc_only }}
+          {{ rendered_toc }}
         </div>
       </section>
     {%- endunless -%}

--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -2,6 +2,14 @@
 {% assign root = url_parts[1] %}
 {% assign doc = url_parts[2] %}
 
+{%- comment -%} Render the table of contents once; it is shown both in the
+top bar and in the sidebar. {%- endcomment -%}
+{%- if page.toc -%}
+  {%- unless page.no_toc -%}
+    {%- assign rendered_toc = content | toc_only -%}
+  {%- endunless -%}
+{%- endif -%}
+
 {% include site/head.html %}
   <body {% if page.body_id %} id="{{ page.body_id }}"{% elsif page.layout == "landingpage" %} id="landingpage"{% endif %} class="{% if root == 'docs' or root == 'dashboards' or root == 'voice_control' or root == 'installation' or root == 'getting-started' or root == 'common-tasks' or root == 'template-functions' or root == 'actions' or root == 'triggers' or root == 'conditions' %}documentation-page{% endif %} {% if root == 'integrations' or page.function_name or page.action or page.trigger or page.condition %}integration-page{% endif %} {% if page.blog_index %}blog-index{% endif %} {% if root == 'blog' %}blog-post {% if doc == 'categories' %}blog-category{% endif %}{% endif %}">
     <header class='site-header {% if page.dark_header %}dark{% endif %}'>
@@ -60,7 +68,7 @@
                 <section class="aside-module grid__item one-whole">
                   <div class='section'>
                     <label for="toc-toggle"><span class="title epsilon">{% icon "mdi:toc" %} On this page</span> <input type="checkbox" id="toc-toggle"/> <span class="toc-current"></span></label>
-                    {{ content | toc_only }}
+                    {{ rendered_toc }}
                   </div>
                 </section>
               </aside>


### PR DESCRIPTION
## Proposed change

Split out of #47387 (4 of 5). A small, self-contained build optimization.

Pages with a table of contents rendered it twice — once for the top bar and once for the sidebar module — and each `toc_only` call parses the full page HTML with Nokogiri. The default layout now renders the table of contents once into a variable and reuses it in both places, removing one full HTML parse for each of the ~3,700 pages that have a table of contents.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

None of the listed types apply: this is a build performance change with no intended change to rendered content.

## Additional information

- Split from #47387, which has the full investigation and combined measurements.
- Regression tested as part of #47387: table of contents links on the deploy preview match the live site exactly (both in the HTML diff and in a headless-browser count of `#toc` links).

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zeLdNaEP3Bq8akPj4b76d

---
_Generated by [Claude Code](https://claude.ai/code/session_015zeLdNaEP3Bq8akPj4b76d)_