### PR TITLE
Replace link tags with plain paths on the LG TV RS-232 page

### DIFF
--- a/source/_integrations/lg_tv_rs232.markdown
+++ b/source/_integrations/lg_tv_rs232.markdown
@@ -31,11 +31,11 @@ Most LG TVs sold starting roughly 2008, as well as LG commercial signage display
 
 ## Unsupported devices
 
-- LG TVs without a physical RS-232C port. Many entry-level TVs from 2018 onwards dropped the serial port. For those, use the [LG webOS Smart TV]({% link _integrations/webostv.markdown %}) integration instead.
+- LG TVs without a physical RS-232C port. Many entry-level TVs from 2018 onwards dropped the serial port. For those, use the [LG webOS Smart TV](/integrations/webostv/) integration instead.
 
 ## Prerequisites
 
-- A physical serial connection between your TV and the system running Home Assistant. This can be a direct serial (RS-232) cable, a USB-to-serial adapter, or an [ESPHome]({% link _integrations/esphome.markdown %})-based serial proxy.
+- A physical serial connection between your TV and the system running Home Assistant. This can be a direct serial (RS-232) cable, a USB-to-serial adapter, or an [ESPHome](/integrations/esphome/)-based serial proxy.
 - LG TVs use a null-modem (cross-over) cable: the TX and RX lines must be swapped.
 - **RS-232C Control** must be enabled on the TV. On many LG models this option lives in a hidden service (`InStart`) menu. Consult your TV's documentation.
 


### PR DESCRIPTION
## Proposed change

Split out of #47387 (5 of 5). A one-page fix.

`lg_tv_rs232.markdown` was the only page in the site using Jekyll's `{% link %}` tag, and build profiling showed it as the slowest single page at **19 seconds**: each `{% link %}` call iterates every page, static file, and document in the site. The two links now use plain documentation paths (`/integrations/webostv/`, `/integrations/esphome/`), matching how every other page links internally. The rendered output is identical.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Split from #47387, which has the full investigation and combined measurements.
- Regression tested as part of #47387: the rendered page on the deploy preview is identical to the live site, including both link targets.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zeLdNaEP3Bq8akPj4b76d

---
_Generated by [Claude Code](https://claude.ai/code/session_015zeLdNaEP3Bq8akPj4b76d)_