### PR TITLE
Add TSUN integration

### DIFF
--- a/source/_integrations/tsun.markdown
+++ b/source/_integrations/tsun.markdown
@@ -14,20 +14,11 @@ ha_codeowners:
   - '@jptstar'
 ---
 
-The **TSUN** {% term integration %} connects supported
-[TSUN](https://www.tsun-ess.com/) micro-inverters directly to Home Assistant
-over the local network. It provides production and energy measurements without
-requiring a cloud service or proxy. All communication with the micro-inverter
-is read-only.
+The **TSUN** {% term integration %} connects supported [TSUN](https://www.tsun-ess.com/) micro-inverters directly to Home Assistant over the local network. It provides production and energy measurements without requiring a cloud service or proxy. All communication with the micro-inverter is read-only.
 
 ## Supported devices
 
-The integration is protocol-based rather than model-based. Compatibility is
-determined by the local communication protocol exposed by the logger, not by a
-fixed list of models. TSUN micro-inverters using a supported protocol can
-therefore work even when their model has not yet been tested individually. The
-integration validates the protocol response during setup and creates only the
-measurements provided by the detected device.
+The integration is protocol-based rather than model-based. Compatibility is determined by the local communication protocol exposed by the logger, not by a fixed list of models. TSUN micro-inverters using a supported protocol can therefore work even when their model has not yet been tested individually. The integration validates the protocol response during setup and creates only the measurements provided by the detected device.
 
 The following devices have been tested on physical hardware:
 
@@ -36,16 +27,11 @@ The following devices have been tested on physical hardware:
 
 ## Prerequisites
 
-- The micro-inverter logger must be powered on. A solar-powered logger may be
-  unavailable at night.
+- The micro-inverter logger must be powered on. A solar-powered logger may be unavailable at night.
 - Home Assistant must be able to reach the logger on the local network.
 - You need the logger's IP address or hostname.
 
-The default TCP port is `8899`. During setup, Home Assistant tries to read the
-numeric **SN** automatically from the logger's local status page. If it cannot
-be read, the setup form asks you to enter it manually. Use the numeric
-**Device serial number** shown on the local status page or printed on the
-logger label, not the alphanumeric micro-inverter serial number.
+The default TCP port is `8899`. During setup, Home Assistant tries to read the numeric **SN** automatically from the logger's local status page. If it cannot be read, the setup form asks you to enter it manually. Use the numeric **Device serial number** shown on the local status page or printed on the logger label, not the alphanumeric micro-inverter serial number.
 
 {% include integrations/config_flow.md %}
 
@@ -60,54 +46,41 @@ SN:
 
 ## Supported functionality
 
-The integration creates one device for each configured micro-inverter and
-provides the following sensors when supported by that device:
+The integration creates one device for each configured micro-inverter and provides the following sensors when supported by that device:
 
 - AC voltage, current, frequency, and power
 - AC energy today and total AC energy
-- PV voltage, current, power, energy today, and total energy for each detected
-  PV input
+- PV voltage, current, power, energy today, and total energy for each detected PV input
 - Total DC power calculated from the available PV power measurements
 
-The number of PV inputs and the available measurements are detected from the
-device response.
+The number of PV inputs and the available measurements are detected from the device response.
 
 ## Data updates
 
-The integration {% term polling polls %} the micro-inverter every 20 seconds.
-When the logger is not reachable, its entities become unavailable. Home
-Assistant resumes updates automatically when communication is restored.
+The integration {% term polling polls %} the micro-inverter every 20 seconds. When the logger is not reachable, its entities become unavailable. Home Assistant resumes updates automatically when communication is restored.
 
 ## Known limitations
 
 - A solar-powered logger can be unreachable at night.
-- Automatic SN detection depends on the logger's local status page. If this
-  page is unavailable or its credentials have been changed, enter the numeric
-  SN manually.
-- Only the TSOL-MP3000 and TSOL-MX500 have currently been validated on
-  physical hardware.
-- This initial version does not provide network discovery, controls, alarms,
-  or communication diagnostics.
+- Automatic SN detection depends on the logger's local status page. If this page is unavailable or its credentials have been changed, enter the numeric SN manually.
+- Only the TSOL-MP3000 and TSOL-MX500 have currently been validated on physical hardware.
+- This initial version does not provide network discovery, controls, alarms, or communication diagnostics.
 
 ## Troubleshooting
 
 ### The device cannot be set up
 
-1. Configure the integration while the micro-inverter and its logger are
-   powered on.
+1. Configure the integration while the micro-inverter and its logger are powered on.
 2. Confirm that Home Assistant can reach the logger's IP address and TCP port.
 3. Check firewall, VLAN, and Wi-Fi client-isolation settings.
-4. If automatic SN detection fails, enter the numeric **Device serial number**
-   from the logger status page or label.
+4. If automatic SN detection fails, enter the numeric **Device serial number** from the logger status page or label.
 
 ### The sensors are unavailable at night
 
-This is expected when the logger is powered by the PV input. The integration
-will resume polling automatically after the logger starts again.
+This is expected when the logger is powered by the PV input. The integration will resume polling automatically after the logger starts again.
 
 ## Removing the integration
 
-This integration follows standard integration removal. Removing it does not
-change any setting on the micro-inverter.
+This integration follows standard integration removal. Removing it does not change any setting on the micro-inverter.
 
 {% include integrations/remove_device_service.md %}

--- a/source/_integrations/tsun.markdown
+++ b/source/_integrations/tsun.markdown
@@ -34,6 +34,9 @@ The following devices have been tested on physical hardware:
 - TSOL-MP3000, with six PV inputs
 - TSOL-MX500, with one PV input
 
+The currently supported native TSUN protocol variants are 02B0 and 1511.
+Support for the 1097 variant is planned for a future update.
+
 ## Prerequisites
 
 - The micro-inverter logger must be powered on. A solar-powered logger may be

--- a/source/_integrations/tsun.markdown
+++ b/source/_integrations/tsun.markdown
@@ -22,14 +22,17 @@ is read-only.
 
 ## Supported devices
 
+The integration is protocol-based rather than model-based. Compatibility is
+determined by the local communication protocol exposed by the logger, not by a
+fixed list of models. TSUN micro-inverters using a supported protocol can
+therefore work even when their model has not yet been tested individually. The
+integration validates the protocol response during setup and creates only the
+measurements provided by the detected device.
+
 The following devices have been tested on physical hardware:
 
 - TSOL-MP3000, with six PV inputs
 - TSOL-MX500, with one PV input
-
-Other TSUN micro-inverters that use compatible local communication may also
-work. The integration validates the device response during setup and creates
-only the measurements provided by the detected device.
 
 ## Prerequisites
 

--- a/source/_integrations/tsun.markdown
+++ b/source/_integrations/tsun.markdown
@@ -34,8 +34,7 @@ The following devices have been tested on physical hardware:
 - TSOL-MP3000, with six PV inputs
 - TSOL-MX500, with one PV input
 
-The currently supported native TSUN protocol variants are `02B0` and `1511`.
-Support for the `1097` variant is planned for a future update.
+## Prerequisites
 
 - The micro-inverter logger must be powered on. A solar-powered logger may be
   unavailable at night.

--- a/source/_integrations/tsun.markdown
+++ b/source/_integrations/tsun.markdown
@@ -34,10 +34,8 @@ The following devices have been tested on physical hardware:
 - TSOL-MP3000, with six PV inputs
 - TSOL-MX500, with one PV input
 
-The currently supported native TSUN protocol variants are 02B0 and 1511.
-Support for the 1097 variant is planned for a future update.
-
-## Prerequisites
+The currently supported native TSUN protocol variants are `02B0` and `1511`.
+Support for the `1097` variant is planned for a future update.
 
 - The micro-inverter logger must be powered on. A solar-powered logger may be
   unavailable at night.

--- a/source/_integrations/tsun.markdown
+++ b/source/_integrations/tsun.markdown
@@ -1,0 +1,110 @@
+---
+title: TSUN
+description: Monitor supported TSUN micro-inverters over the local network.
+ha_category:
+  - Energy
+ha_config_flow: true
+ha_domain: tsun
+ha_integration_type: device
+ha_iot_class: Local Polling
+ha_platforms:
+  - sensor
+ha_release: 2026.10
+ha_codeowners:
+  - '@jptstar'
+---
+
+The **TSUN** {% term integration %} connects supported
+[TSUN](https://www.tsun-ess.com/) micro-inverters directly to Home Assistant
+over the local network. It provides production and energy measurements without
+requiring a cloud service or proxy. All communication with the micro-inverter
+is read-only.
+
+## Supported devices
+
+The following devices have been tested on physical hardware:
+
+- TSOL-MP3000, with six PV inputs
+- TSOL-MX500, with one PV input
+
+Other TSUN micro-inverters that use compatible local communication may also
+work. The integration validates the device response during setup and creates
+only the measurements provided by the detected device.
+
+## Prerequisites
+
+- The micro-inverter logger must be powered on. A solar-powered logger may be
+  unavailable at night.
+- Home Assistant must be able to reach the logger on the local network.
+- You need the logger's IP address or hostname.
+
+The default TCP port is `8899`. During setup, Home Assistant tries to read the
+numeric **SN** automatically from the logger's local status page. If it cannot
+be read, the setup form asks you to enter it manually. Use the numeric
+**Device serial number** shown on the local status page or printed on the
+logger label, not the alphanumeric micro-inverter serial number.
+
+{% include integrations/config_flow.md %}
+
+{% configuration_basic %}
+Host:
+  description: The IP address or hostname of the micro-inverter logger.
+Port:
+  description: The local TCP port used by the logger. The default is `8899`.
+SN:
+  description: The numeric logger SN used for local communication. This field is shown only when Home Assistant cannot read it automatically.
+{% endconfiguration_basic %}
+
+## Supported functionality
+
+The integration creates one device for each configured micro-inverter and
+provides the following sensors when supported by that device:
+
+- AC voltage, current, frequency, and power
+- AC energy today and total AC energy
+- PV voltage, current, power, energy today, and total energy for each detected
+  PV input
+- Total DC power calculated from the available PV power measurements
+
+The number of PV inputs and the available measurements are detected from the
+device response.
+
+## Data updates
+
+The integration {% term polling polls %} the micro-inverter every 20 seconds.
+When the logger is not reachable, its entities become unavailable. Home
+Assistant resumes updates automatically when communication is restored.
+
+## Known limitations
+
+- A solar-powered logger can be unreachable at night.
+- Automatic SN detection depends on the logger's local status page. If this
+  page is unavailable or its credentials have been changed, enter the numeric
+  SN manually.
+- Only the TSOL-MP3000 and TSOL-MX500 have currently been validated on
+  physical hardware.
+- This initial version does not provide network discovery, controls, alarms,
+  or communication diagnostics.
+
+## Troubleshooting
+
+### The device cannot be set up
+
+1. Configure the integration while the micro-inverter and its logger are
+   powered on.
+2. Confirm that Home Assistant can reach the logger's IP address and TCP port.
+3. Check firewall, VLAN, and Wi-Fi client-isolation settings.
+4. If automatic SN detection fails, enter the numeric **Device serial number**
+   from the logger status page or label.
+
+### The sensors are unavailable at night
+
+This is expected when the logger is powered by the PV input. The integration
+will resume polling automatically after the logger starts again.
+
+## Removing the integration
+
+This integration follows standard integration removal. Removing it does not
+change any setting on the micro-inverter.
+
+{% include integrations/remove_device_service.md %}

--- a/source/_integrations/tsun.markdown
+++ b/source/_integrations/tsun.markdown
@@ -9,7 +9,7 @@ ha_integration_type: device
 ha_iot_class: Local Polling
 ha_platforms:
   - sensor
-ha_release: 2026.10
+ha_release: '2026.10'
 ha_codeowners:
   - '@jptstar'
 ---

--- a/source/_integrations/tsun.markdown
+++ b/source/_integrations/tsun.markdown
@@ -12,6 +12,7 @@ ha_platforms:
 ha_release: '2026.10'
 ha_codeowners:
   - '@jptstar'
+ha_quality_scale: bronze
 ---
 
 The **TSUN** {% term integration %} connects supported [TSUN](https://www.tsun-ess.com/) micro-inverters directly to Home Assistant over the local network. It provides production and energy measurements without requiring a cloud service or proxy. All communication with the micro-inverter is read-only.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->

## Proposed change

Add documentation for the new TSUN integration.

The integration connects compatible TSUN micro-inverters directly to Home Assistant over the local network, without requiring a proxy or cloud service.

The documentation explains:

- protocol-based compatibility and hardware-validated micro-inverters;
- configuration using the local IP address and TCP port;
- automatic reading of the numeric logger SN, with manual entry as a fallback;
- available AC, DC and per-PV measurements;
- the local polling behavior;
- known limitations, troubleshooting and removal instructions.

Compatibility is protocol-based rather than model-based. The TSOL-MP3000 and TSOL-MX500 have been validated on physical hardware, while other TSUN micro-inverters can work when they expose a supported local protocol.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/179122
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/10966
- This PR fixes or closes issue: Not applicable

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards