### PR TITLE
Document arming the Homematic IP alarm when a sensor blocks it

### DIFF
--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -105,6 +105,34 @@ To do this, navigate to **Access Control** in the Homematic IP app and enable th
 
 Currently, you can only use the HmIP-DLD in Home Assistant without a PIN. Make sure no PIN is set for the device in the Homematic IP app.
 
+## Arm the alarm system while a sensor reports a problem
+
+Newer Homematic IP alarm systems refuse to arm while a window is open or a device is unreachable. Arming is a two-step decision, mirroring what the Homematic IP app does:
+
+1. Arm normally. If a sensor blocks it, the alarm control panel stays disarmed and Home Assistant reports an error naming the devices that blocked it. Those devices also appear in the panel's `blocking_devices` attribute, so a dashboard or automation can show them.
+2. If you still want to arm, use the `homematicip_cloud.arm_anyway` action with its `mode` field set to `home` or `away`. The blocking devices are then left unmonitored until you arm the system again.
+
+The access point fills `blocking_devices` in response to an arming request, so it is empty until you try to arm. While the system is armed anyway, it lists the entry points that are currently unmonitored.
+
+```yaml
+actions:
+  - action: homematicip_cloud.arm_anyway
+    target:
+      entity_id: alarm_control_panel.hmip_alarm_control_panel
+    data:
+      mode: away
+```
+
+To show what is blocking before deciding, read the attribute in a template:
+
+{% raw %}
+
+```jinja2
+{{ state_attr('alarm_control_panel.hmip_alarm_control_panel', 'blocking_devices') }}
+```
+
+{% endraw %}
+
 ## Supported devices
 
 The list below shows which Home Assistant entities each supported Homematic IP device contributes. Devices are grouped by Home Assistant entity platform; a single physical device often contributes entities on more than one platform (for example, a wall thermostat appears under *Climate*, *Sensors*, and *Binary sensors* for the battery state). If your device isn't listed, see [My device isn't recognized](#my-device-isnt-recognized).

--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -109,10 +109,10 @@ Currently, you can only use the HmIP-DLD in Home Assistant without a PIN. Make s
 
 Newer Homematic IP alarm systems refuse to arm while a window is open or a device is unreachable. Arming is a two-step decision, mirroring what the Homematic IP app does:
 
-1. Arm normally. If a sensor blocks it, the alarm control panel stays disarmed and Home Assistant reports an error naming the devices that blocked it. Those devices also appear in the panel's `blocking_devices` attribute, so a dashboard or automation can show them.
+1. Arm normally. If a sensor blocks it, the alarm control panel stays disarmed and Home Assistant reports an error naming the devices that blocked it. The *Arming blocked* binary sensor turns on and lists the same devices in its `blocking_devices` attribute.
 2. If you still want to arm, use the `homematicip_cloud.arm_anyway` action with its `mode` field set to `home` or `away`. The blocking devices are then left unmonitored until you arm the system again.
 
-The access point fills `blocking_devices` in response to an arming request, so it is empty until you try to arm. While the system is armed anyway, it lists the entry points that are currently unmonitored.
+The action checks again before it arms and refuses when something else has started blocking in the meantime.
 
 ```yaml
 actions:
@@ -123,12 +123,53 @@ actions:
       mode: away
 ```
 
-To show what is blocking before deciding, read the attribute in a template:
+The card below shows the blocking devices and the buttons only while arming is blocked.
 
 {% raw %}
 
-```jinja2
-{{ state_attr('alarm_control_panel.hmip_alarm_control_panel', 'blocking_devices') }}
+```yaml
+type: vertical-stack
+cards:
+  - type: alarm-panel
+    entity: alarm_control_panel.hmip_alarm_control_panel
+    states:
+      - arm_home
+      - arm_away
+  - type: conditional
+    conditions:
+      - condition: state
+        entity: binary_sensor.hmip_access_point_arming_blocked
+        state: "on"
+    card:
+      type: vertical-stack
+      cards:
+        - type: markdown
+          content: >-
+            Arming was refused by: **{{
+            state_attr('binary_sensor.hmip_access_point_arming_blocked',
+            'blocking_devices') | join(', ') }}**
+        - type: horizontal-stack
+          cards:
+            - type: button
+              name: Arm home anyway
+              icon: mdi:shield-home
+              tap_action:
+                action: perform-action
+                perform_action: homematicip_cloud.arm_anyway
+                target:
+                  entity_id: alarm_control_panel.hmip_alarm_control_panel
+                data:
+                  mode: home
+            - type: button
+              name: Arm away anyway
+              icon: mdi:shield-lock
+              tap_action:
+                action: perform-action
+                perform_action: homematicip_cloud.arm_anyway
+                target:
+                  entity_id: alarm_control_panel.hmip_alarm_control_panel
+                data:
+                  mode: away
 ```
 
 {% endraw %}
@@ -144,6 +185,7 @@ The list below shows which Home Assistant entities each supported Homematic IP d
 ### Binary sensors
 
 - Access point cloud connection (`HmIP-HAP`, `HmIP-HAP-B1`)
+- Arming blocked, set when the alarm system refuses to arm (`HmIP-HAP`, `HmIP-HAP-B1`)
 - Window and door contacts, including the rotary handle sensor (`HmIP-SWDO`, `HmIP-SWDO-PL`, `HmIP-SWDO-I`, `HmIP-SWDM`, `HmIP-SWDM-B2`, `HmIP-SRH`)
 - Contact interfaces (`HmIP-FCI1`, `HmIP-FCI6`, `HmIP-SCI`)
 - Smoke detectors (`HmIP-SWSD`, `HmIP-SWSD-2`)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Newer Homematic IP alarm systems are request-based: they answer HTTP 200 but stay disarmed when a window is open or a device is unreachable. Home Assistant reports that as an error naming the blocking devices (home-assistant/core#179139, merged), and offers `homematicip_cloud.arm_anyway` plus a `blocking_devices` attribute to act on it (home-assistant/core#179151).

The action itself renders automatically from `services.yaml`/`strings.json`. This documents the parts that cannot be auto-generated: that arming is a two-step decision, that arming anyway leaves those entry points unmonitored, and that `blocking_devices` is empty until the panel is asked to arm.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#179151
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
