### PR TITLE
Document the Homematic IP carbon dioxide sensors

### DIFF
--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -180,6 +180,7 @@ Floor heating actuators are operated through the climate group and don't need th
 - Fine dust sensor (`HmIP-SFD`)
 - Soil moisture sensor (`ELV-SH-SMSI`)
 - Door lock pad (`HmIP-DLP`)
+- Carbon dioxide sensors (`HmIP-SCTH230`, `HmIP-WGTC`, `HmIPW-SCTHD`)
 
 ### Switches
 


### PR DESCRIPTION
## Proposed change

Documents the carbon dioxide sensors added in home-assistant/core#179187: `HmIP-SCTH230`, `HmIP-WGTC` and `HmIPW-SCTHD` now contribute a CO2 sensor entity.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch)
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch)
- [x] Added documentation for a new integration feature (`next` branch)
- [ ] Added yaml configuration for an existing integration (`next` branch)
- [ ] Added documentation for a new integration (`next` branch)
- [ ] Removed stale or deprecated documentation

## Additional information

- This PR is related to home-assistant/core#179187

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I have added documentation for a new integration feature and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation standards.
