### PR TITLE
Add Auto and Extra to the Vallox profile list

### DIFF
--- a/source/_integrations/vallox.markdown
+++ b/source/_integrations/vallox.markdown
@@ -59,13 +59,13 @@ The date platform allows you to set the filter change date.
 
 For convenient switching of ventilation profiles in the GUI, just click on the `Vallox` fan {% term entity %} to get a drop-down menu to select from. Alternatively, the action `fan/set_preset_mode` can be used.
 
-The following Vallox profiles are supported:
+The following Vallox profiles are supported. Availability depends on the connected unit and the presets it exposes, so some profiles may not appear on all devices:
 
 - `Home`
 - `Away`
 - `Boost`
 - `Fireplace`
-- `Extra`
-- `Auto` (requires firmware v3.1.4 or newer)
+- `Extra` (available on devices/firmware that expose this preset)
+- `Auto` (available on devices/firmware that expose this preset; requires firmware v3.1.4 or newer)
 
 {% include integrations/actions.md %}

--- a/source/_integrations/vallox.markdown
+++ b/source/_integrations/vallox.markdown
@@ -59,11 +59,13 @@ The date platform allows you to set the filter change date.
 
 For convenient switching of ventilation profiles in the GUI, just click on the `Vallox` fan {% term entity %} to get a drop-down menu to select from. Alternatively, the action `fan/set_preset_mode` can be used.
 
-The four standard Vallox profiles are supported:
+The following Vallox profiles are supported:
 
 - `Home`
 - `Away`
 - `Boost`
 - `Fireplace`
+- `Extra`
+- `Auto` (requires firmware v3.1.4 or newer)
 
 {% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Documents the `Auto` profile added to the Vallox integration in home-assistant/core#179212. Vallox units running firmware v3.1.4 or newer support it, and it is now offered as a fan preset mode and as an option for the `vallox.set_profile` action.

While updating the list, `Extra` has been added as well. That profile has been supported by the integration since home-assistant/core#120225, but the list on this page was never updated, so it currently names four of the six profiles the integration supports.

The "four standard" wording no longer fits a list of seven, so it has been reworded.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#179212
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
