### PR TITLE
YouTube: document latest short and latest video sensors

### DIFF
--- a/source/_integrations/youtube.markdown
+++ b/source/_integrations/youtube.markdown
@@ -25,7 +25,9 @@ For every channel you add, it will create sensors for:
 - Views count
 - Subscriber count
 - Video count
-- The latest uploaded video
+- The latest upload (videos and Shorts)
+- The latest uploaded Short
+- The latest uploaded video (excludes Shorts)
 
 ## Prerequisites
 


### PR DESCRIPTION
## Proposed change

Add documentation for the new latest upload, latest short, and latest video (non-short) sensors introduced in https://github.com/home-assistant/core/pull/179224.

This is a re-submission of #44375 which referenced the old (now closed) core PR #165630.

## Type of change

- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/179224
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR is for the `next` branch.
- [x] I have followed the [contribution guidelines](https://github.com/home-assistant/home-assistant.io#contributing).
- [x] The content of my PR is intended for the next major release of Home Assistant.