### PR TITLE
Document automation groups

### DIFF
--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -66,13 +66,15 @@ The following entities can be grouped:
 {% include integrations/config_flow.md %}
 
 {% note %}
-Automation and notification entities can only be grouped via the UI.
-The older notification actions can only be grouped via YAML configuration.
+Automation groups and notify entity groups can only be created through the UI.
+The older notify action groups can only be configured through YAML.
 {% endnote %}
 
 ## Group behavior
 
 ### Automation, binary sensor, light, and switch groups
+
+For automation entities, `on` and `off` refer to whether the automation is enabled or disabled, not whether it is currently running.
 
 In short, when any group member entity is `on`, the group will also be `on`. A complete overview of how groups behave:
 
@@ -340,7 +342,7 @@ unique_id:
   required: false
   type: string
 all:
-  description: Only available for `automation`, `binary_sensor`, `light`, and `switch` groups. Set this to `true` if the group state should only turn *on* if **all** grouped entities are *on*.
+  description: Only available for `binary_sensor`, `light`, and `switch` groups. Set this to `true` if the group state should only turn *on* if **all** grouped entities are *on*.
   required: false
   type: boolean
   default: false

--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -2,6 +2,7 @@
 title: Group
 description: Instructions on how to set up groups within Home Assistant.
 ha_category:
+  - Automation
   - Binary sensor
   - Button
   - Cover
@@ -24,6 +25,7 @@ ha_codeowners:
 ha_domain: group
 ha_config_flow: true
 ha_platforms:
+  - automation
   - binary_sensor
   - button
   - cover
@@ -45,6 +47,7 @@ This can be useful, for example, in cases where you want to control multiple bul
 
 The following entities can be grouped:
 
+- [automation (automations)](/integrations/automation/)
 - [binary sensor (binary sensors)](/integrations/binary_sensor/)
 - [button (buttons)](/integrations/button/)
 - [cover (covers)](/integrations/cover/)
@@ -63,13 +66,13 @@ The following entities can be grouped:
 {% include integrations/config_flow.md %}
 
 {% note %}
-Notification entities can only be grouped via the UI.
+Automation and notification entities can only be grouped via the UI.
 The older notification actions can only be grouped via YAML configuration.
 {% endnote %}
 
 ## Group behavior
 
-### Binary sensor, light, and switch groups
+### Automation, binary sensor, light, and switch groups
 
 In short, when any group member entity is `on`, the group will also be `on`. A complete overview of how groups behave:
 
@@ -78,7 +81,7 @@ In short, when any group member entity is `on`, the group will also be `on`. A c
 - Otherwise, the group state is `on` if at least one group member is `on`.
 - Otherwise, the group state is `off`.
 
-Binary sensor, light, and switch groups allow you set the "All entities" option. When enabled, the group behavior is inverted, and all members of the group have to be `on` for the group to turn `on` as well. A complete overview of how groups behave when the "All entities" option is enabled:
+Automation, binary sensor, light, and switch groups allow you to set the "All entities" option. When enabled, the group behavior is inverted, and all members of the group have to be `on` for the group to turn `on` as well. A complete overview of how groups behave when the "All entities" option is enabled:
 
 - The group state is `unavailable` if all group members are `unavailable`.
 - Otherwise, the group state is `unknown` if at least one group member is `unknown` or `unavailable`.
@@ -337,7 +340,7 @@ unique_id:
   required: false
   type: string
 all:
-  description: Only available for `binary_sensor`, `light` and `switch` groups. Set this to `true` if the group state should only turn *on* if **all** grouped entities are *on*.
+  description: Only available for `automation`, `binary_sensor`, `light`, and `switch` groups. Set this to `true` if the group state should only turn *on* if **all** grouped entities are *on*.
   required: false
   type: boolean
   default: false


### PR DESCRIPTION
Home Assistant core adds a new Automation group type to the Group integration (config-entry based, UI only), behaving like the existing binary sensor, light, and switch groups.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

  Documents the new **Automation group** type added to the Group integration. This new group type lets you combine multiple automation entities into a single entity, which can be toggled and monitored as a whole, and it can only
  be set up through the UI (config entry), just like notify entity groups.

  It behaves the same as the existing binary sensor, light, and switch groups (state is `on` when any/all member is `on`, based on the "All entities" option).

  Changes:
  - Added `automation` to `ha_category` and `ha_platforms` in the front matter.
  - Added automation to the list of entities that can be grouped.
  - Updated the UI-only note to also mention automation entities.
  - Merged the "Binary sensor, light, and switch groups" behavior section into "Automation, binary sensor, light, and switch groups", since automation groups follow the same on/off/all logic.
  - Updated the `all` option description in the configuration table.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:  https://github.com/home-assistant/core/pull/179276
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [X] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
