### PR TITLE
Document the ViCare ventilation quickmode switches

### DIFF
--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -110,7 +110,9 @@ Select entities allow configuring the domestic hot water (<abbr title="domestic 
 
 ### Switch
 
-Ventilation devices expose their quickmodes as switches, such as **Comfort**, **Eco**, **Boost**, and **Silent**. Only the quickmodes reported by the device are created.
+Ventilation devices expose their quickmodes as switches, such as **Intensive**, **Eco**, **Boost**, and **Silent**. Only the quickmodes reported by the device are created.
+
+Quickmodes are mutually exclusive. Turn the active one off before turning another on, otherwise activation fails with "Only one quickmode can be active at a time".
 
 {% include integrations/actions.md %}
 

--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -108,6 +108,10 @@ Number entities are available to adjust values like the predefined temperature f
 
 Select entities allow configuring the domestic hot water (<abbr title="domestic hot water">DHW</abbr>) operating mode of your Viessmann device. Available options depend on the specific device model and may include `balanced`, `economical`, or `off` modes.
 
+### Switch
+
+Ventilation devices expose their quickmodes as switches, such as **Comfort**, **Eco**, **Boost**, and **Silent**. Only the quickmodes reported by the device are created.
+
 {% include integrations/actions.md %}
 
 ## Climate and water heater control


### PR DESCRIPTION
## Proposed change

Documents the ventilation quickmode switches added in home-assistant/core#179430.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#179430
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
