### PR TITLE
Document the container stop timeout and add stop_grace_period to the compose example

### DIFF
--- a/source/_includes/installation/container.md
+++ b/source/_includes/installation/container.md
@@ -88,7 +88,7 @@ To give the shutdown more time, increase the timeout:
     ```yaml
     services:
       homeassistant:
-      ...
+        ...
         stop_grace_period: 60s
     ```
 
@@ -97,7 +97,7 @@ To give the shutdown more time, increase the timeout:
 The timeout is an upper limit, not a delay: Docker continues as soon as Home Assistant has exited.
 
 {% note %}
-This setting is applied when the container is created. To change it on an existing container, recreate the container, for example with `docker compose up -d`. Restarting a container keeps the timeout it was created with.
+This setting is applied when the container is created, so restarting an existing container keeps the timeout it was created with. After changing the value in `compose.yaml`, `docker compose up -d` recreates the container, because its configuration has changed. If the container is not recreated, use `docker compose up -d --force-recreate`. With the Docker CLI, remove the container and run it again with the new option.
 {% endnote %}
 
 ### Docker compose

--- a/source/_includes/installation/container.md
+++ b/source/_includes/installation/container.md
@@ -62,6 +62,44 @@ If you change the configuration, you have to restart the server. To do that you 
 
 {% endtabbed_block %}
 
+### Allow time for a clean shutdown
+
+When the container is stopped or restarted, Docker sends `SIGTERM` and then forcibly stops the container after a timeout, which is 10 seconds by default. Home Assistant can need longer than that to close its database. If it is stopped before it has finished, the next start logs warnings such as:
+
+```txt
+Ended unfinished session
+The system could not validate that the sqlite3 database at //config/home-assistant_v2.db was shutdown cleanly
+```
+
+To give the shutdown more time, increase the timeout:
+
+{% tabbed_block %}
+
+- title: Docker CLI
+  content: |
+
+    ```bash
+    docker run ... --stop-timeout 60 ...
+    ```
+
+- title: Docker Compose
+  content: |
+
+    ```yaml
+    services:
+      homeassistant:
+      ...
+        stop_grace_period: 60s
+    ```
+
+{% endtabbed_block %}
+
+The timeout is an upper limit, not a delay: Docker continues as soon as Home Assistant has exited.
+
+{% note %}
+This setting is applied when the container is created. To change it on an existing container, recreate the container, for example with `docker compose up -d`. Restarting a container keeps the timeout it was created with.
+{% endnote %}
+
 ### Docker compose
 
 {% tip %}

--- a/source/_includes/installation/container/compose.md
+++ b/source/_includes/installation/container/compose.md
@@ -8,6 +8,7 @@
         - /etc/localtime:/etc/localtime:ro
         - /run/dbus:/run/dbus:ro
       restart: unless-stopped
+      stop_grace_period: 60s
       privileged: true
       network_mode: host
       environment:


### PR DESCRIPTION
## Proposed change

The container installation docs don't mention Docker's stop timeout, and the default of 10 seconds can be shorter than Home Assistant needs to close its recorder database. When that happens the next start logs `Ended unfinished session` and `The system could not validate that the sqlite3 database ... was shutdown cleanly` — which reads as a database or SD-card problem rather than as a container setting.

Two small changes:

1. **`source/_includes/installation/container/compose.md`** — add `stop_grace_period: 60s` to the compose example, so a new container install gets a clean shutdown by default.
2. **`source/_includes/installation/container.md`** — a short **Allow time for a clean shutdown** section after *Restart Home Assistant*, explaining the timeout, quoting the warnings so people can search for them, giving the Docker CLI equivalent (`--stop-timeout`), and noting that the value is applied **when the container is created** — so an existing container has to be recreated, not restarted, for a change to take effect. That last point is easy to miss and makes the setting look like it doesn't work.

Placed after *Restart Home Assistant* because that is where the page documents `docker restart homeassistant`, which is what triggers the problem.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

**Where this came from.** I hit it on a Raspberry Pi 3B running the container install. `docker stop -t 60` and `docker compose up -d` produced a start with neither warning; the default 10-second timeout produced both. That machine had four SQLite recorder corruption events over 18 months which I had been attributing to SD-card wear — and since `docker restart` inherits the same default, every config deploy had been an unclean shutdown. I can't prove the timeout caused the corruption, and I'm not claiming that here; but a container setting is worth documenting before people replace hardware.

**One caveat on the number, so it isn't over-sold.** On my hardware `docker stop -t 60` used the full 60 seconds, meaning Home Assistant did not exit on its own and was still killed at the deadline — yet the database had closed cleanly by then, which is why the warnings disappear. So 60s is enough for database integrity but is not necessarily enough for a fully graceful exit. Happy to change the value or soften the wording if you'd prefer something else.

**Disclosure:** I'm a Home Assistant user, not a Docker or recorder expert. The investigation and this write-up were done with substantial help from Claude Code (Anthropic's CLI); I directed it, reviewed the result, and the observations come from my own machine. The two behaviours above are easy to reproduce on any container install, and I'm happy to re-test anything or drop either commit — the compose-example change is the more opinionated of the two, so if you'd rather have only the explanatory section, say so and I'll remove it.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
