### PR TITLE
Document Fing installation prerequisite

### DIFF
--- a/source/_integrations/fing.markdown
+++ b/source/_integrations/fing.markdown
@@ -20,7 +20,7 @@ By connecting through the [Local API](https://www.fing.com/developers/local-api/
 
 ## Prerequisites
 - Install [Fing](https://www.fing.com/) and set up a Fing Agent ([Fing Agent](https://www.fing.com/agent/), Fingbox, or [Fing Desktop](https://www.fing.com/desktop/)).
-- Ensure that the [Local API](https://www.fing.com/developers/local-api/) is enabled on your Fing Agent ([Fing Agent](https://www.fing.com/agent/), Fingbox, or [Fing Desktop](https://www.fing.com/desktop/)).
+- Ensure that the [Local API](https://www.fing.com/developers/local-api/) is enabled on your Fing Agent.
 - You will need your Fing Agent’s IP address, port, and API key to complete the setup.
 
 {% include integrations/config_flow.md %}

--- a/source/_integrations/fing.markdown
+++ b/source/_integrations/fing.markdown
@@ -19,7 +19,7 @@ The **Fing** {% term integration %} allows Home Assistant to retrieve detailed i
 By connecting through the [Local API](https://www.fing.com/developers/local-api/), Fing automatically builds and synchronizes an inventory of devices to detect online presence and trigger automations.
 
 ## Prerequisites
-
+- Install [Fing](https://www.fing.com/) and set up a Fing Agent ([Fing Agent](https://www.fing.com/agent/), Fingbox, or [Fing Desktop](https://www.fing.com/desktop/)).
 - Ensure that the [Local API](https://www.fing.com/developers/local-api/) is enabled on your Fing Agent ([Fing Agent](https://www.fing.com/agent/), Fingbox, or [Fing Desktop](https://www.fing.com/desktop/)).
 - You will need your Fing Agent’s IP address, port, and API key to complete the setup.
 


### PR DESCRIPTION
## Proposed change

Add a prerequisite to the Fing integration documentation stating that Fing must be installed and a Fing Agent must be set up before configuring the integration.

## Related issue

Closes #47430