### PR TITLE
Document Lyngdorf number, select and sensor platforms

### DIFF
--- a/source/_integrations/lyngdorf.markdown
+++ b/source/_integrations/lyngdorf.markdown
@@ -3,6 +3,9 @@ title: Lyngdorf
 description: Instructions on how to integrate Lyngdorf audio processors into Home Assistant.
 ha_category:
   - Media player
+  - Number
+  - Select
+  - Sensor
 ha_release: 2026.8
 ha_iot_class: Local Push
 ha_config_flow: true
@@ -11,9 +14,13 @@ ha_codeowners:
 ha_domain: lyngdorf
 ha_ssdp: true
 ha_platforms:
+  - diagnostics
   - media_player
+  - number
+  - select
+  - sensor
 ha_integration_type: device
-ha_quality_scale: silver
+ha_quality_scale: gold
 ---
 
 The **Lyngdorf** {% term integration %} allows you to control [Lyngdorf] and [Steinway & Lyngdorf] audio processors and amplifiers from Home Assistant. Lyngdorf Audio is known for its RoomPerfect room correction technology. This integration lets you control power, volume, source selection, sound modes, and audio processing parameters.
@@ -62,6 +69,79 @@ The integration creates the following media player {% term entities %}:
 - **Main zone**: Controls your Lyngdorf device, including power, volume, mute, source selection, and sound mode.
 - **Zone B**: Controls the Zone B output, including power, volume, mute, and source selection. Only created for models with a Zone B output (the TDAI-series does not have one).
 
+On models with a streaming module, the main zone also shows what is playing: track title, artist, album, artwork, and playback position. Transport controls (play, pause, next, previous, seek, shuffle, and repeat) appear when the streaming source offers them, which varies by source. Spotify Connect offers seek and shuffle, for example, while AirPlay does not.
+
+### Numbers
+
+Numbers adjust the audio calibration, and are only created for the controls a model has:
+
+- **Lip sync**: The audio delay, in milliseconds. The device reports its own permitted range.
+- **Trim bass** and **Trim treble**: Tone trims, in decibels.
+- **Trim centre**, **Trim height**, **Trim LFE**, and **Trim surround**: Channel trims, in decibels. Only created on surround models.
+
+### Selects
+
+- **RoomPerfect position**: The RoomPerfect focus position, including the global position.
+- **Voicing**: The RoomPerfect voicing.
+
+### Sensors
+
+Diagnostic sensors report what the device is receiving and playing:
+
+- **Audio input** and **Video input**: The active inputs.
+- **Audio information** and **Video information**: The incoming signal formats.
+- **Streaming source**: The active streaming service.
+- **Zone B audio input** and **Zone B streaming source**: The same for Zone B, where present.
+
+## Use cases
+
+- Switch to a movie voicing and a surround sound mode when a film starts, and back to a music voicing afterwards.
+- Select the RoomPerfect focus position for wherever people are actually sitting, rather than the global position.
+- Raise the lip sync delay for a source whose picture and sound drift apart, and reset it when you switch away.
+- Use the audio information sensor to detect a surround format and dim the lights only for those.
+
+## Examples
+
+Switch voicing and RoomPerfect position when playback starts on the main zone:
+
+```yaml
+{% raw %}automation:
+  - alias: "Cinema mode"
+    triggers:
+      - trigger: state
+        entity_id: media_player.lyngdorf_main_zone
+        to: "playing"
+    actions:
+      - action: select.select_option
+        target:
+          entity_id: select.lyngdorf_voicing
+        data:
+          option: "Movie"
+      - action: select.select_option
+        target:
+          entity_id: select.lyngdorf_roomperfect_position
+        data:
+          option: "Focus 1"{% endraw %}
+```
+
+Correct lip sync for a source that needs it:
+
+```yaml
+{% raw %}automation:
+  - alias: "Fix lip sync on the streaming box"
+    triggers:
+      - trigger: state
+        entity_id: media_player.lyngdorf_main_zone
+        attribute: source
+        to: "HDMI 2"
+    actions:
+      - action: number.set_value
+        target:
+          entity_id: number.lyngdorf_lip_sync
+        data:
+          value: 80{% endraw %}
+```
+
 ## Data updates
 
 The **Lyngdorf** integration uses local push to receive real-time updates from the device over a TCP connection. State changes on the device are pushed to Home Assistant immediately.
@@ -70,6 +150,9 @@ The **Lyngdorf** integration uses local push to receive real-time updates from t
 
 - Only the MP-60 has been tested. Other models may not support all features.
 - Only local network control is supported.
+- Pausing a source that is controlled by another app, such as AirPlay, ends the session rather than pausing it. The device cannot resume it; only the controlling app can start it again. This is how those protocols work, and is not specific to Home Assistant.
+- Now playing information, playback position, and transport controls require a model with a streaming module. The TDAI-2170 and the P-series do not have one.
+- The trims and lip sync apply to the main zone only.
 
 ## Troubleshooting
 

--- a/source/_integrations/lyngdorf.markdown
+++ b/source/_integrations/lyngdorf.markdown
@@ -20,7 +20,7 @@ ha_platforms:
   - select
   - sensor
 ha_integration_type: device
-ha_quality_scale: gold
+ha_quality_scale: silver
 ---
 
 The **Lyngdorf** {% term integration %} allows you to control [Lyngdorf] and [Steinway & Lyngdorf] audio processors and amplifiers from Home Assistant. Lyngdorf Audio is known for its RoomPerfect room correction technology. This integration lets you control power, volume, source selection, sound modes, and audio processing parameters.

--- a/source/_integrations/lyngdorf.markdown
+++ b/source/_integrations/lyngdorf.markdown
@@ -4,6 +4,7 @@ description: Instructions on how to integrate Lyngdorf audio processors into Hom
 ha_category:
   - Media player
   - Number
+  - Remote
   - Select
   - Sensor
 ha_release: 2026.8
@@ -17,6 +18,7 @@ ha_platforms:
   - diagnostics
   - media_player
   - number
+  - remote
   - select
   - sensor
 ha_integration_type: device
@@ -78,6 +80,21 @@ Numbers adjust the audio calibration, and are only created for the controls a mo
 - **Lip sync**: The audio delay, in milliseconds. The device reports its own permitted range.
 - **Trim bass** and **Trim treble**: Tone trims, in decibels.
 - **Trim centre**, **Trim height**, **Trim LFE**, and **Trim surround**: Channel trims, in decibels. Only created on surround models.
+
+### Remote
+
+A remote entity drives the processor's own on-screen menus, for the models that
+have remote keys. The TDAI series does not, so no remote entity is created there.
+
+Send keys with the `remote.send_command` action. The available keys are `up`,
+`down`, `left`, `right`, `enter`, `back`, `exit`, `menu`, `info`, `settings`,
+`multiview`, and the digits `0` to `9`. Not every model has every key, and
+sending one the device does not have reports the keys it does support rather than
+sending anything.
+
+`num_repeats` repeats the whole sequence rather than each key, so `["1", "2"]`
+with two repeats sends `1 2 1 2`. `delay_secs` is not used, because the
+integration already paces its own commands to the device.
 
 ### Selects
 
@@ -142,6 +159,23 @@ automation:
           value: 80
 ```
 
+Open the setup menu and step down to the second entry:
+
+```yaml
+script:
+  lyngdorf_open_setup:
+    sequence:
+      - action: remote.send_command
+        target:
+          entity_id: remote.lyngdorf
+        data:
+          command:
+            - menu
+            - down
+            - down
+            - enter
+```
+
 ## Data updates
 
 The **Lyngdorf** integration uses local push to receive real-time updates from the device over a TCP connection. State changes on the device are pushed to Home Assistant immediately.
@@ -153,6 +187,7 @@ The **Lyngdorf** integration uses local push to receive real-time updates from t
 - Pausing a source that is controlled by another app, such as AirPlay, ends the session rather than pausing it. The device cannot resume it; only the controlling app can start it again. This is how those protocols work, and is not specific to Home Assistant.
 - Now playing information, playback position, and transport controls require a model with a streaming module. The TDAI-2170 and the P-series do not have one.
 - The trims and lip sync apply to the main zone only.
+- The remote keys drive the device's own menus only. There is no way to read what is on screen, so an automation cannot know where in a menu it is.
 
 ## Troubleshooting
 

--- a/source/_integrations/lyngdorf.markdown
+++ b/source/_integrations/lyngdorf.markdown
@@ -105,7 +105,7 @@ Diagnostic sensors report what the device is receiving and playing:
 Switch voicing and RoomPerfect position when playback starts on the main zone:
 
 ```yaml
-{% raw %}automation:
+automation:
   - alias: "Cinema mode"
     triggers:
       - trigger: state
@@ -121,13 +121,13 @@ Switch voicing and RoomPerfect position when playback starts on the main zone:
         target:
           entity_id: select.lyngdorf_roomperfect_position
         data:
-          option: "Focus 1"{% endraw %}
+          option: "Focus 1"
 ```
 
 Correct lip sync for a source that needs it:
 
 ```yaml
-{% raw %}automation:
+automation:
   - alias: "Fix lip sync on the streaming box"
     triggers:
       - trigger: state
@@ -139,7 +139,7 @@ Correct lip sync for a source that needs it:
         target:
           entity_id: number.lyngdorf_lip_sync
         data:
-          value: 80{% endraw %}
+          value: 80
 ```
 
 ## Data updates


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the entity platforms the Lyngdorf integration is gaining, and the streaming functionality its media player is gaining.

- Number entities for lip sync and the six trims, noting that they are only created for the controls a model has.
- Select entities for RoomPerfect position and voicing.
- Diagnostic sensors for the active inputs, incoming signal formats and streaming source.
- Now playing information, playback position and transport controls on models with a streaming module.

Adds use cases and examples, and records two limitations worth knowing: pausing a source controlled by another app, such as AirPlay, ends the session rather than pausing it, because the device cannot resume what another controller started; and the streaming features need a model with a streaming module, which the TDAI-2170 and the P-series do not have.

This replaces #47460, which was closed automatically when a code pull request it was linked to was itself closed and split into several smaller ones. The content is unchanged apart from a rebase; the quality scale line is left alone here and will move with the core bump.

Corresponding code pull requests:

- home-assistant/core#179446 — select
- home-assistant/core#179448 — number
- home-assistant/core#179471 — now playing, position and transport
- home-assistant/core#179478 — diagnostics
- home-assistant/core#179411 — reconfiguration flow

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
