### PR TITLE
Adjust image lightbox captions and navigation

### DIFF
--- a/sass/homeassistant/base/_image_lightbox.scss
+++ b/sass/homeassistant/base/_image_lightbox.scss
@@ -21,6 +21,23 @@ article.post {
   outline-offset: -3px;
 }
 
+.pswp__caption {
+  box-sizing: border-box;
+  color: #ffffff;
+  font-size: 0.95rem;
+  inset: auto 0 0;
+  line-height: 1.5;
+  padding: 2rem 1rem 1rem;
+  pointer-events: none;
+  position: absolute;
+  text-align: center;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
+}
+
+.pswp__caption[hidden] {
+  display: none;
+}
+
 .pswp--click-to-zoom.pswp--zoomed-in .pswp__img,
 .pswp--click-to-zoom.pswp--zoomed-in .pswp__img:active {
   cursor: zoom-out;

--- a/source/javascripts/image-lightbox.js
+++ b/source/javascripts/image-lightbox.js
@@ -126,14 +126,8 @@
     });
   }
 
-  function getInteractiveImages() {
-    return Array.from(
-      document.querySelectorAll("img[data-lightbox-image='true']")
-    );
-  }
-
-  function getLightboxItems(images) {
-    return images.map((image) => ({
+  function getLightboxItem(image) {
+    return {
       src: getImageSource(image),
       srcset: image.getAttribute("srcset") || undefined,
       width: image.naturalWidth,
@@ -141,7 +135,7 @@
       msrc: getImageSource(image),
       alt: image.getAttribute("alt") || "",
       element: image,
-    }));
+    };
   }
 
   function getZoomLevel(zoomLevelObject, scale) {
@@ -179,6 +173,10 @@
             arrowPrevTitle: "Previous image",
             arrowNextTitle: "Next image",
             errorMsg: "The image could not be loaded.",
+            allowPanToNext: false,
+            arrowKeys: false,
+            loop: false,
+            preload: [0, 0],
             trapFocus: true,
             returnFocus: true,
             ...(prefersReducedMotion
@@ -200,6 +198,36 @@
 
           lightbox.on("uiRegister", () => {
             lightbox.pswp.element.setAttribute("aria-label", "Image viewer");
+
+            lightbox.pswp.ui.registerElement({
+              name: "caption",
+              order: 9,
+              isButton: false,
+              appendTo: "root",
+              onInit: (captionElement, pswp) => {
+                captionElement.className = "pswp__caption";
+                captionElement.id = "image-lightbox-caption";
+
+                const updateCaption = () => {
+                  const caption = pswp.currSlide?.data.alt || "";
+
+                  captionElement.textContent = caption;
+                  captionElement.hidden = !caption;
+
+                  if (caption) {
+                    pswp.element.setAttribute(
+                      "aria-describedby",
+                      captionElement.id
+                    );
+                  } else {
+                    pswp.element.removeAttribute("aria-describedby");
+                  }
+                };
+
+                pswp.on("change", updateCaption);
+                updateCaption();
+              },
+            });
           });
 
           return lightbox;
@@ -222,21 +250,10 @@
   }
 
   function openImage(image, event) {
-    const images = getInteractiveImages();
-    const index = images.indexOf(image);
-
-    if (index === -1) {
-      return;
-    }
-
     event.preventDefault();
 
     getLightbox().then((lightbox) => {
-      lightbox.loadAndOpen(
-        index,
-        getLightboxItems(images),
-        getInitialPoint(event)
-      );
+      lightbox.loadAndOpen(0, [getLightboxItem(image)], getInitialPoint(event));
     });
   }
 


### PR DESCRIPTION

## Proposed change

Follow-up to https://github.com/home-assistant/home-assistant.io/pull/47352

This updates the image lightbox behavior after feedback.

The lightbox now shows the image alt text as a caption when alt text is present. The caption is registered as part of the PhotoSwipe UI and connected to the dialog with `aria-describedby` only when caption text exists.

The lightbox also opens only the selected image instead of building a page-level gallery. This removes previous and next navigation for documentation images. Related PhotoSwipe navigation options are disabled as well: swipe-to-next, arrow-key navigation, looping, and preloading adjacent slides.

| Before | After |
|--------|--------|
| [Getting started: Automations](https://www.home-assistant.io/getting-started/automation/#to-automatically-turn-on-the-lights-before-sunset) | [Getting started: Automations](https://deploy-preview-47491--home-assistant-docs.netlify.app//getting-started/automation/#to-automatically-turn-on-the-lights-before-sunset) (to see the captions, discard the Netlify banner) |


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
