### PR TITLE
Add Hydro-Quebec Peak Events integration documentation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -473,6 +473,7 @@ source/_integrations/husqvarna_automower_ble.markdown @alistair23
 source/_integrations/huum.markdown @frwickst @vincentwolsink
 source/_integrations/hvv_departures.markdown @vigonotion
 source/_integrations/hydrawise.markdown @dknowles2 @thomaskistler @ptcryan
+source/_integrations/hydroquebec_peak.markdown @Beat-YT
 source/_integrations/hyperion.markdown @dermotduffy
 source/_integrations/hypontech.markdown @jcisio
 source/_integrations/ialarm.markdown @RyuzakiKK

--- a/source/_integrations/hydroquebec_peak.markdown
+++ b/source/_integrations/hydroquebec_peak.markdown
@@ -1,0 +1,90 @@
+---
+title: Hydro-Québec Peak Events
+description: Instructions on how to integrate Hydro-Québec peak events into Home Assistant.
+ha_category:
+  - Energy
+  - Sensor
+ha_release: '2026.10'
+ha_iot_class: Cloud Polling
+ha_config_flow: true
+ha_codeowners:
+  - '@Beat-YT'
+ha_domain: hydroquebec_peak
+ha_platforms:
+  - sensor
+ha_integration_type: service
+ha_quality_scale: bronze
+related:
+  - url: https://www.hydroquebec.com/residential/energy-wise/offers-to-save-this-winter/
+    title: Hydro-Québec winter savings offers
+  - url: https://www.hydroquebec.com/documents-data/open-data/
+    title: Hydro-Québec open data
+  - url: https://donnees.hydroquebec.com/explore/dataset/evenements-pointe/information/
+    title: Peak demand events – Winter dataset
+---
+
+The **Hydro-Québec Peak Events** {% term integration %} tracks winter peak demand events (_événements de pointe_) published by [Hydro-Québec](https://www.hydroquebec.com/), the electricity utility of Québec, Canada.
+
+During Québec winters (December 1 to March 31), Hydro-Québec announces peak events when electricity demand is high due to cold weather. Customers enrolled in a peak savings offer — such as the Winter Credit Option or Rate Flex D — reduce their consumption during these events and receive bill credits or lower rates in return. This integration exposes the event schedule so your automations can prepare for and react to peak events, for example by preheating your home before an event and lowering thermostats while one is in progress.
+
+The integration uses [Hydro-Québec's public open data](https://www.hydroquebec.com/documents-data/open-data/). It does not connect to your Hydro-Québec account and requires no credentials.
+
+{% include integrations/config_flow.md %}
+
+{% configuration_basic %}
+Offer:
+  description: The Hydro-Québec peak savings offer you are enrolled in. The list is retrieved from Hydro-Québec's open data for the current season and includes residential and business offers.
+{% endconfiguration_basic %}
+
+To track more than one offer, add the integration again and select another offer. Each configured offer appears as its own device with its own set of entities.
+
+## Supported functionality
+
+For each configured offer, the integration provides the following entities. Events are published by Hydro-Québec a few hours before they occur, typically the day before.
+
+### Sensors
+
+- **Event begins**
+  - **Description**: Start time of the peak event in progress, or of the next upcoming event. Unknown when no event is scheduled.
+- **Event ends**
+  - **Description**: End time of the peak event in progress, or of the next upcoming event. Unknown when no event is scheduled.
+
+## Example automations
+
+Preheat the home before a peak event by using the **Event begins** sensor with a time offset:
+
+{% raw %}
+
+```yaml
+automation:
+  - alias: "Preheat before peak event"
+    triggers:
+      - trigger: time
+        at:
+          entity_id: sensor.credit_hivernal_residentiel_cpc_d_event_begins
+          offset: "-03:00:00"
+    actions:
+      - action: climate.set_temperature
+        target:
+          entity_id: climate.living_room
+        data:
+          temperature: 22
+```
+
+{% endraw %}
+
+## Data updates
+
+The integration {% term polling "polls" %} Hydro-Québec's open data every 15 minutes. The feed is served from a content delivery network and the integration uses conditional requests, so polling is lightweight. Entity states also update at event boundaries and at midnight, independently of polling.
+
+## Known limitations
+
+- Event availability, timing, and lead time are determined entirely by Hydro-Québec. The integration displays the data as published. Outside the winter season (December through March), no events are published for most offers.
+- This integration covers Hydro-Québec peak events only. It is not related to the Hilo demand response program, which is a separate service with its own eligibility and scheduling.
+- The integration provides the event schedule only. It does not report your consumption or the credits you earn; those are available in your Hydro-Québec account.
+
+## Removing the integration
+
+This integration follows standard integration removal. No extra steps are required.
+
+{% include integrations/remove_device_service.md %}

--- a/source/_integrations/hydroquebec_peak.markdown
+++ b/source/_integrations/hydroquebec_peak.markdown
@@ -45,33 +45,73 @@ For each configured offer, the integration provides the following entities. Even
 ### Sensors
 
 - **Event begins**
-  - **Description**: Start time of the peak event in progress, or of the next upcoming event. Unknown when no event is scheduled.
+  - **Description**: Start time of the peak event in progress, or of the next upcoming event. The state is `unknown` when no event is scheduled.
 - **Event ends**
-  - **Description**: End time of the peak event in progress, or of the next upcoming event. Unknown when no event is scheduled.
+  - **Description**: End time of the peak event in progress, or of the next upcoming event. The state is `unknown` when no event is scheduled.
 
-## Example automations
+## Hydro-Québec Peak Events automation examples
+
+### Automation: Preheat the home before a peak event
 
 Preheat the home before a peak event by using the **Event begins** sensor with a time offset:
 
-{% raw %}
+{% note %}
+This example uses a time trigger with an offset, which requires the YAML editor. The visual automation editor does not support the offset field on time triggers.
+{% endnote %}
 
-```yaml
-automation:
-  - alias: "Preheat before peak event"
-    triggers:
-      - trigger: time
-        at:
-          entity_id: sensor.credit_hivernal_residentiel_cpc_d_event_begins
-          offset: "-03:00:00"
-    actions:
-      - action: climate.set_temperature
-        target:
-          entity_id: climate.living_room
-        data:
-          temperature: 22
-```
+{% example %}
+automation: |
+  alias: "Preheat before a peak event"
+  triggers:
+    - trigger: time
+      at:
+        entity_id: sensor.hydroquebec_peak_cpc_d_event_begins
+        offset: "-03:00:00"
+  actions:
+    - action: climate.set_temperature
+      target:
+        entity_id: climate.living_room
+      data:
+        temperature: 23
+{% endexample %}
 
-{% endraw %}
+### Automation: Lower the thermostat when a peak event starts
+
+Lower the thermostat when a peak event begins by using a time trigger directly on the **Event begins** sensor:
+
+{% example %}
+automation: |
+  alias: "Lower the thermostat when a peak event starts"
+  triggers:
+    - trigger: time
+      at:
+        entity_id: sensor.hydroquebec_peak_cpc_d_event_begins
+  actions:
+    - action: climate.set_temperature
+      target:
+        entity_id: climate.living_room
+      data:
+        temperature: 18
+{% endexample %}
+
+### Automation: Restore the temperature when a peak event ends
+
+Restore the thermostat to a normal temperature when a peak event ends by using a time trigger on the **Event ends** sensor:
+
+{% example %}
+automation: |
+  alias: "Restore the thermostat when a peak event ends"
+  triggers:
+    - trigger: time
+      at:
+        entity_id: sensor.hydroquebec_peak_cpc_d_event_ends
+  actions:
+    - action: climate.set_temperature
+      target:
+        entity_id: climate.living_room
+      data:
+        temperature: 21
+{% endexample %}
 
 ## Data updates
 

--- a/source/_integrations/hydroquebec_peak.markdown
+++ b/source/_integrations/hydroquebec_peak.markdown
@@ -51,67 +51,11 @@ For each configured offer, the integration provides the following entities. Even
 
 ## Hydro-Québec Peak Events automation examples
 
-### Automation: Preheat the home before a peak event
+### Automation: Run actions around a peak event
 
-Preheat the home before a peak event by using the **Peak event begins** sensor with a time offset:
+This blueprint runs actions at three moments: a configurable time before a peak event begins, when the event begins, and when the event ends. For example, the automation can preheat the home ahead of the event, lower the thermostats when it begins, and restore the normal temperature when it ends. Hydro-Québec recommends preheating about two hours before an event begins.
 
-{% note %}
-This example uses a time trigger with an offset, which requires the YAML editor. The visual automation editor does not support the offset field on time triggers.
-{% endnote %}
-
-{% example %}
-automation: |
-  alias: "Preheat before a peak event"
-  triggers:
-    - trigger: time
-      at:
-        entity_id: sensor.cpc_d_peak_event_begins
-        offset: "-03:00:00"
-  actions:
-    - action: climate.set_temperature
-      target:
-        entity_id: climate.living_room
-      data:
-        temperature: 23
-{% endexample %}
-
-### Automation: Lower the thermostat when a peak event starts
-
-Lower the thermostat when a peak event begins by using a time trigger directly on the **Peak event begins** sensor:
-
-{% example %}
-automation: |
-  alias: "Lower the thermostat when a peak event starts"
-  triggers:
-    - trigger: time
-      at:
-        entity_id: sensor.cpc_d_peak_event_begins
-  actions:
-    - action: climate.set_temperature
-      target:
-        entity_id: climate.living_room
-      data:
-        temperature: 18
-{% endexample %}
-
-### Automation: Restore the temperature when a peak event ends
-
-Restore the thermostat to a normal temperature when a peak event ends by using a time trigger on the **Peak event ends** sensor:
-
-{% example %}
-automation: |
-  alias: "Restore the thermostat when a peak event ends"
-  triggers:
-    - trigger: time
-      at:
-        entity_id: sensor.cpc_d_peak_event_ends
-  actions:
-    - action: climate.set_temperature
-      target:
-        entity_id: climate.living_room
-      data:
-        temperature: 21
-{% endexample %}
+{% my blueprint_import badge blueprint_url="https://www.home-assistant.io/blueprints/integrations/hydroquebec_peak_event_actions.yaml" %}
 
 ## Data updates
 

--- a/source/_integrations/hydroquebec_peak.markdown
+++ b/source/_integrations/hydroquebec_peak.markdown
@@ -115,7 +115,7 @@ automation: |
 
 ## Data updates
 
-The integration {% term polling "polls" %} Hydro-Québec's open data every 15 minutes. The feed is served from a content delivery network and the integration uses conditional requests, so polling is lightweight. Entity states also update at event boundaries and at midnight, independently of polling.
+The integration {% term polling polls %} Hydro-Québec's open data every 15 minutes. Between updates, the sensors also refresh automatically when an event starts or ends, and at midnight, so the information stays current.
 
 ## Known limitations
 

--- a/source/_integrations/hydroquebec_peak.markdown
+++ b/source/_integrations/hydroquebec_peak.markdown
@@ -44,7 +44,7 @@ For each configured offer, the integration provides the following entities. Even
 
 ### Sensors
 
-- **Event begins**
+- **Peak event begins**
   - **Description**: Start time of the peak event in progress, or of the next upcoming event. The state is `unknown` when no event is scheduled.
 - **Event ends**
   - **Description**: End time of the peak event in progress, or of the next upcoming event. The state is `unknown` when no event is scheduled.

--- a/source/_integrations/hydroquebec_peak.markdown
+++ b/source/_integrations/hydroquebec_peak.markdown
@@ -46,7 +46,7 @@ For each configured offer, the integration provides the following entities. Even
 
 - **Peak event begins**
   - **Description**: Start time of the peak event in progress, or of the next upcoming event. The state is `unknown` when no event is scheduled.
-- **Event ends**
+- **Peak event ends**
   - **Description**: End time of the peak event in progress, or of the next upcoming event. The state is `unknown` when no event is scheduled.
 
 ## Hydro-Québec Peak Events automation examples

--- a/source/_integrations/hydroquebec_peak.markdown
+++ b/source/_integrations/hydroquebec_peak.markdown
@@ -53,7 +53,7 @@ For each configured offer, the integration provides the following entities. Even
 
 ### Automation: Preheat the home before a peak event
 
-Preheat the home before a peak event by using the **Event begins** sensor with a time offset:
+Preheat the home before a peak event by using the **Peak event begins** sensor with a time offset:
 
 {% note %}
 This example uses a time trigger with an offset, which requires the YAML editor. The visual automation editor does not support the offset field on time triggers.
@@ -65,7 +65,7 @@ automation: |
   triggers:
     - trigger: time
       at:
-        entity_id: sensor.hydroquebec_peak_cpc_d_event_begins
+        entity_id: sensor.cpc_d_peak_event_begins
         offset: "-03:00:00"
   actions:
     - action: climate.set_temperature
@@ -77,7 +77,7 @@ automation: |
 
 ### Automation: Lower the thermostat when a peak event starts
 
-Lower the thermostat when a peak event begins by using a time trigger directly on the **Event begins** sensor:
+Lower the thermostat when a peak event begins by using a time trigger directly on the **Peak event begins** sensor:
 
 {% example %}
 automation: |
@@ -85,7 +85,7 @@ automation: |
   triggers:
     - trigger: time
       at:
-        entity_id: sensor.hydroquebec_peak_cpc_d_event_begins
+        entity_id: sensor.cpc_d_peak_event_begins
   actions:
     - action: climate.set_temperature
       target:
@@ -96,7 +96,7 @@ automation: |
 
 ### Automation: Restore the temperature when a peak event ends
 
-Restore the thermostat to a normal temperature when a peak event ends by using a time trigger on the **Event ends** sensor:
+Restore the thermostat to a normal temperature when a peak event ends by using a time trigger on the **Peak event ends** sensor:
 
 {% example %}
 automation: |
@@ -104,7 +104,7 @@ automation: |
   triggers:
     - trigger: time
       at:
-        entity_id: sensor.hydroquebec_peak_cpc_d_event_ends
+        entity_id: sensor.cpc_d_peak_event_ends
   actions:
     - action: climate.set_temperature
       target:

--- a/source/_integrations/hydroquebec_peak.markdown
+++ b/source/_integrations/hydroquebec_peak.markdown
@@ -25,7 +25,7 @@ related:
 
 The **Hydro-Québec Peak Events** {% term integration %} tracks winter peak demand events (_événements de pointe_) published by [Hydro-Québec](https://www.hydroquebec.com/), the electricity utility of Québec, Canada.
 
-During Québec winters (December 1 to March 31), Hydro-Québec announces peak events when electricity demand is high due to cold weather. Customers enrolled in a peak savings offer — such as the Winter Credit Option or Rate Flex D — reduce their consumption during these events and receive bill credits or lower rates in return. This integration exposes the event schedule so your automations can prepare for and react to peak events, for example by preheating your home before an event and lowering thermostats while one is in progress.
+Peak events occur during Québec winters (December 1 to March 31). Hydro-Québec announces them when cold weather drives electricity demand high. Customers enrolled in a peak savings offer, such as the Winter Credit Option or Rate Flex D, reduce their consumption during these events. In return, they receive bill credits or lower rates. This integration exposes the event schedule so your automations can prepare for and react to peak events. For example, you can preheat your home before an event starts and lower thermostats while one is in progress.
 
 The integration uses [Hydro-Québec's public open data](https://www.hydroquebec.com/documents-data/open-data/). It does not connect to your Hydro-Québec account and requires no credentials.
 

--- a/source/blueprints/integrations/hydroquebec_peak_event_actions.yaml
+++ b/source/blueprints/integrations/hydroquebec_peak_event_actions.yaml
@@ -1,0 +1,99 @@
+blueprint:
+  name: "Hydro-Québec Peak Events: run actions around a peak event"
+  description: >
+    Run actions before a Hydro-Québec peak event begins, when it begins, and
+    when it ends. For example, preheat the home ahead of the event, lower the
+    thermostats when it begins, and restore the normal temperature when it
+    ends.
+
+
+    Hydro-Québec recommends preheating about 2 hours before an event begins.
+  domain: automation
+  author: Beat-YT
+  input:
+    event_begin:
+      name: Peak event begins sensor
+      description: The Peak event begins sensor of the offer you are enrolled in.
+      selector:
+        entity:
+          filter:
+            - integration: hydroquebec_peak
+              domain: sensor
+              device_class: timestamp
+    event_end:
+      name: Peak event ends sensor
+      description: The Peak event ends sensor of the same offer.
+      selector:
+        entity:
+          filter:
+            - integration: hydroquebec_peak
+              domain: sensor
+              device_class: timestamp
+    lead_time:
+      name: Lead time
+      description: How long before the event begins to run the "Before the event" actions.
+      default: "-02:00:00"
+      selector:
+        select:
+          options:
+            - label: 30 minutes before
+              value: "-00:30:00"
+            - label: 1 hour before
+              value: "-01:00:00"
+            - label: 1 hour 30 minutes before
+              value: "-01:30:00"
+            - label: 2 hours before
+              value: "-02:00:00"
+            - label: 3 hours before
+              value: "-03:00:00"
+            - label: 4 hours before
+              value: "-04:00:00"
+    before_actions:
+      name: Before the event
+      description: Actions to run ahead of the event, for example preheat the home.
+      default: []
+      selector:
+        action:
+    begin_actions:
+      name: When the event begins
+      description: Actions to run when the event begins, for example lower the thermostats.
+      default: []
+      selector:
+        action:
+    end_actions:
+      name: When the event ends
+      description: Actions to run when the event ends, for example restore the normal temperature.
+      default: []
+      selector:
+        action:
+
+triggers:
+  - trigger: time
+    id: before
+    at:
+      entity_id: !input event_begin
+      offset: !input lead_time
+  - trigger: time
+    id: begin
+    at: !input event_begin
+  - trigger: time
+    id: end
+    at: !input event_end
+
+actions:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: before
+        sequence: !input before_actions
+      - conditions:
+          - condition: trigger
+            id: begin
+        sequence: !input begin_actions
+      - conditions:
+          - condition: trigger
+            id: end
+        sequence: !input end_actions
+
+mode: queued
+max_exceeded: silent


### PR DESCRIPTION
## Proposed change

Add documentation for the new Hydro-Québec Peak Events integration (`hydroquebec_peak`).

This integration tracks winter peak demand events published by Hydro-Québec through their public open data. It exposes event timestamps so automations can prepare for peaks — for example, preheating a home before an event starts. No Hydro-Québec account or credentials are required.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/179602
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/10984
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards