### PR TITLE
Adjust recommended Zigbee adapters

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -118,8 +118,8 @@ The following adapters are made by other manufacturers. They are not official Ho
   - [ITead SONOFF Zigbee 3.0 USB Dongle Plus Model "ZBDongle-E" (EFR32MG21 variant)](https://itead.cc/product/zigbee-3-0-usb-dongle/)
   - [SMLIGHT SLZB-07](https://smlight.tech/product/slzb-07/) (EFR32MG21-based USB dongle)
 - Texas Instruments based radios (via the [zigpy-znp](https://github.com/zigpy/zigpy-znp) library for zigpy)
-  - [CC2652P/CC2652R/CC2652RB USB stick, module, or dev board hardware flashed with Z-Stack coordinator firmware](https://www.zigbee2mqtt.io/guide/adapters/)
-  - [CC1352P/CC1352R USB stick, module, or dev board hardware flashed with Z-Stack coordinator firmware](https://www.zigbee2mqtt.io/guide/adapters/)
+  - [CC2652P/CC2652R/CC2652RB-based USB adapters flashed with Z-Stack coordinator firmware](https://www.zigbee2mqtt.io/guide/adapters/)
+  - [CC1352P/CC1352R-based USB adapters flashed with Z-Stack coordinator firmware](https://www.zigbee2mqtt.io/guide/adapters/)
 - dresden elektronik deCONZ based Zigbee radios (via the [zigpy-deconz](https://github.com/zigpy/zigpy-deconz) library for zigpy)
   - [ConBee III (a.k.a. ConBee 3) USB adapter from dresden elektronik](https://phoscon.de/conbee3)
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -96,12 +96,25 @@ ZHA uses an open-source Python library called [zigpy](https://github.com/zigpy/z
 
 The hardware-independent design of this integration provides support for many Zigbee coordinators available from different manufacturers, as long as the coordinator is compatible with the [zigpy](https://github.com/zigpy/zigpy) library.
 
-### Recommended Zigbee radio adapters and modules
+### Recommended: official Home Assistant hardware
+
+Official Home Assistant hardware is the recommended choice for ZHA. It is designed and built by Nabu Casa, a commercial partner of the [Open Home Foundation](https://www.openhomefoundation.org), together with the team that develops ZHA. The Zigbee firmware is maintained by that same team, with optimizations for ZHA and support for large Zigbee networks. You can keep it up to date from within Home Assistant.
+
+They all use Silicon Labs EmberZNet based radios with the EZSP protocol (via the [bellows](https://github.com/zigpy/bellows) library for zigpy).
+
+- [Home Assistant Connect ZBT-2](/connect/zbt-2/): USB adapter with an EFR32MG24 radio. If you are setting up a new Zigbee network, this is the one to get.
+- Home Assistant Connect ZBT-1: USB adapter with an EFR32MG21 radio. Discontinued and replaced by the Connect ZBT-2, but fully supported if you already have one.
+- Home Assistant Yellow: hub with an integrated MGM210P radio, which is based on the EFR32MG21. Currently out of stock, but fully supported if you already have one.
+
+{% tip %}
+Home Assistant Green does not have a built-in Zigbee radio. To use ZHA with Green, or with any other computer running Home Assistant, add a Zigbee adapter such as the [Home Assistant Connect ZBT-2](/connect/zbt-2/).
+{% endtip %}
+
+### Other tested and compatible Zigbee adapters
+
+The following adapters are made by other manufacturers. They are not official Home Assistant hardware, but they are known to work well with ZHA. Home Assistant does not update the firmware on these adapters. To keep them up to date, use the tools their manufacturer provides.
 
 - Silicon Labs EmberZNet based radios using the EZSP protocol (via the [bellows](https://github.com/zigpy/bellows) library for zigpy)
-  - [Home Assistant Connect ZBT-2](/connect/zbt-2/) (EFR32MG24-based USB adapter)
-  - Home Assistant Connect ZBT-1 (EFR32MG21-based USB dongle)
-  - Home Assistant Yellow with integrated MGM210P radio, which is based on the EFR32MG21
   - [ITead SONOFF Zigbee 3.0 USB Dongle Plus Model "ZBDongle-E" (EFR32MG21 variant)](https://itead.cc/product/zigbee-3-0-usb-dongle/)
   - [SMLIGHT SLZB-07](https://smlight.tech/product/slzb-07/) (EFR32MG21-based USB dongle)
 - Texas Instruments based radios (via the [zigpy-znp](https://github.com/zigpy/zigpy-znp) library for zigpy)

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -123,7 +123,7 @@ The following adapters are made by other manufacturers. They are not official Ho
 - dresden elektronik deCONZ based Zigbee radios (via the [zigpy-deconz](https://github.com/zigpy/zigpy-deconz) library for zigpy)
   - [ConBee III (a.k.a. ConBee 3) USB adapter from dresden elektronik](https://phoscon.de/conbee3)
 
-### Other supported but not recommended Zigbee radio adapters or modules
+### Supported but not recommended Zigbee adapters
 
 The following hardware is supported, but _not recommended_. Specific models and details are noted where available in each section.
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -73,7 +73,7 @@ This {% term integration %} currently supports the following device types within
 
 The ZHA integration is a hardware-independent Zigbee gateway implementation that can replace most proprietary Zigbee gateways (or bridges, hubs, or controllers). ZHA creates a single Zigbee network to which you can add most Zigbee-based devices.
 
-ZHA uses an open-source Python library called [zigpy](https://github.com/zigpy/zigpy), so any coordinator that is compatible with zigpy can be used with ZHA. If you do not have a coordinator yet, the [Home Assistant Connect ZBT-2](/connect/zbt-2/) is the recommended choice. For all the options, refer to [compatible hardware](#compatible-hardware).
+If you do not have a coordinator yet, the [Home Assistant Connect ZBT-2](/connect/zbt-2/) is the recommended choice. For all the options, refer to [compatible hardware](#compatible-hardware).
 
 ### Zigbee terminology
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -188,8 +188,6 @@ The following hardware is supported, but _not recommended_. Specific models and 
 
 {% enddetails %}
 
-If you find an opportunity to improve this information, refer to the section on how to [add support for new and unsupported devices](#how-to-add-support-for-new-and-unsupported-devices).
-
 ## Configuration requirements
 
 {% important %}

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -102,9 +102,9 @@ Official Home Assistant hardware is the recommended choice for ZHA. It is design
 
 They all use Silicon Labs EmberZNet based radios with the EZSP protocol (via the [bellows](https://github.com/zigpy/bellows) library for zigpy).
 
-- [Home Assistant Connect ZBT-2](/connect/zbt-2/): USB adapter with an EFR32MG24 radio. If you are setting up a new Zigbee network, this is the one to get.
-- Home Assistant Connect ZBT-1: USB adapter with an EFR32MG21 radio. Discontinued and replaced by the Connect ZBT-2, but fully supported if you already have one.
-- Home Assistant Yellow: hub with an integrated MGM210P radio, which is based on the EFR32MG21. Currently out of stock, but fully supported if you already have one.
+- [Home Assistant Connect ZBT-2](/connect/zbt-2/): USB adapter. If you are setting up a new Zigbee network, this is the one to get.
+- Home Assistant Connect ZBT-1: USB adapter. Discontinued and replaced by the Connect ZBT-2, but fully supported if you already have one.
+- Home Assistant Yellow: hub with a built-in Zigbee radio. Currently out of stock, but fully supported if you already have one.
 
 {% tip %}
 Home Assistant Green does not have a built-in Zigbee radio. To use ZHA with Green, or with any other computer running Home Assistant, add a Zigbee adapter such as the [Home Assistant Connect ZBT-2](/connect/zbt-2/).

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -73,7 +73,7 @@ This {% term integration %} currently supports the following device types within
 
 The ZHA integration is a hardware-independent Zigbee gateway implementation that can replace most proprietary Zigbee gateways (or bridges, hubs, or controllers). ZHA creates a single Zigbee network to which you can add most Zigbee-based devices.
 
-ZHA uses an open-source Python library called [zigpy](https://github.com/zigpy/zigpy), so any coordinator that is compatible with zigpy can be used with ZHA. Review [compatible hardware](#compatible-hardware) recommendations before purchasing Zigbee devices.
+ZHA uses an open-source Python library called [zigpy](https://github.com/zigpy/zigpy), so any coordinator that is compatible with zigpy can be used with ZHA. If you do not have a coordinator yet, the [Home Assistant Connect ZBT-2](/connect/zbt-2/) is the recommended choice. For all the options, refer to [compatible hardware](#compatible-hardware).
 
 ### Zigbee terminology
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -98,7 +98,7 @@ The hardware-independent design of this integration provides support for many Zi
 
 ### Recommended: official Home Assistant hardware
 
-Official Home Assistant hardware is the recommended choice for ZHA. It is designed and built by Nabu Casa, a commercial partner of the [Open Home Foundation](https://www.openhomefoundation.org), together with the team that develops ZHA. The Zigbee firmware is maintained by that same team, with optimizations for ZHA and support for large Zigbee networks. You can keep it up to date from within Home Assistant.
+Official Home Assistant hardware is the recommended choice for ZHA. It is designed and built by Nabu Casa, a commercial partner of the [Open Home Foundation](https://www.openhomefoundation.org), together with the team at Home Assistant responsible for Zigbee. The Zigbee firmware is maintained by that same team, with optimizations for ZHA and support for large Zigbee networks. You can keep it up to date from within Home Assistant.
 
 They all use Silicon Labs EmberZNet based radios with the EZSP protocol (via the [bellows](https://github.com/zigpy/bellows) library for zigpy).
 

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -100,8 +100,6 @@ The hardware-independent design of this integration provides support for many Zi
 
 Official Home Assistant hardware is the recommended choice for ZHA. It is designed and built by Nabu Casa, a commercial partner of the [Open Home Foundation](https://www.openhomefoundation.org), together with the team at Home Assistant responsible for Zigbee. The Zigbee firmware is maintained by that same team, with optimizations for ZHA and support for large Zigbee networks. You can keep it up to date from within Home Assistant.
 
-They all use Silicon Labs EmberZNet based radios with the EZSP protocol (via the [bellows](https://github.com/zigpy/bellows) library for zigpy).
-
 - [Home Assistant Connect ZBT-2](/connect/zbt-2/): USB adapter. If you are setting up a new Zigbee network, this is the one to get.
 - Home Assistant Connect ZBT-1: USB adapter. Discontinued and replaced by the Connect ZBT-2, but fully supported if you already have one.
 - Home Assistant Yellow: hub with a built-in Zigbee radio. Currently out of stock, but fully supported if you already have one.


### PR DESCRIPTION
## Proposed change

This PR adds a dedicated "recommended" section on what hardware to use for the Zigbee integration (ZHA).

As official Home Assistant hardware has specific firmware optimizations for ZHA, is updatable directly from within Home Assistant Core, offers the best user experience, and various other benefits, this hardware is now recommended.
The recommended section also starts with a short explanation on why these adapters are recommended.

All other supported adapters that generally work well are moved into a dedicated section titled "Other tested and compatible Zigbee adapters". The bad adapters are kept in a (renamed) section called "Supported but not recommended Zigbee adapters".


### Other small changes

- The intro sentence at the start of ZHA docs now also directly reference the recommended device to get: Connect ZBT-2, with a link to the section that contains all other compatible hardware for more choices.
- For Texas Instruments based radios, a reference to "dev boards" and just "modules" was removed
- A link to the "new device / quirk support" section was also removed from the hardware/coordinator section, as it's unrelated.
- A "tip" in the recommended hardware section is also added: that HA Green does not have a built-in Zigbee radio 

### Questions

There are some questions that came to my mind but they're not too important.
1. ✅ ~~Should we remove the following sentence, as this is rather technical and not really relevant for most end-users?~~
    > "They all use Silicon Labs EmberZNet based radios with the EZSP protocol (via the [bellows](https://github.com/zigpy/bellows) library for zigpy)."
2. ✅ ~~Should the radio types be kept for HA hardware? (EFR32MG24, EFR32MG21, MGM210P/EFR32MG21)~~
3. I've currently included the following sentences after the ZBT-2, ZBT-1, and Yellow to give a bit more context. Should these be kept, removed, or replaced?
    1. "[...] If you are setting up a new Zigbee network, this is the one to get."
    2. "[...] Discontinued and replaced by the Connect ZBT-2, but fully supported if you already have one."
    3. "[...] Currently out of stock, but fully supported if you already have one."
4. Is the text in the "recommended" section good?
    - i.e.: "Official Home Assistant hardware", "built by Nabu Casa, a commercial partner of the [OHF]..."
5. Just to confirm, we do want to keep mentioning ZBT-1 and HA Yellow as recommended hardware, even if they're no longer really sold right now?
    - The ZBT-2 is at the top and specifically called out for "the one to get"
    - The ZBT-1 is mentioned as "discontinued" and HA Yellow as "out-of-stock"
    - They are both still great options and continue to receive firmware updates with bugfixes and new features, so I think it makes sense to keep them in this section.
    - The starts of ZHA docs also specifically only lists ZBT-2, referencing to this "compatible hardware" section for further choices.
6. Anything else to further trim from the text? Or just other suggestions in general?


### Future PR(s)

In a future PR, we may want to rework the "Other tested and compatible Zigbee adapters" section a bit. Right now, it has two concrete recommendations for SiLabs hardware, one concrete recommendation for the Conbee III, and generic chip recommendations for Texas Instruments based radios only.

Instead, we may want to show a concrete (alphabetically sorted?) list of other known supported USB adapters here.

And as a general note, ZHA docs seem to have become verbose in some parts with overly technical documentation that is not really relevant and can confuse users. We may want to drop quite a bit of this at some point in the future.


## Screenshot of main "recommended section" change + preview link

Preview link to new recommended section in ZHA docs: https://deploy-preview-47508--home-assistant-docs.netlify.app/integrations/zha/#compatible-hardware

<details open><summary>Screenshot of changes (<b>CLICK TO EXPAND/CLOSE</b>)</summary>
<p>

### Introduction (top of ZHA docs)

The introduction now mainly recommends the ZBT-2 as the way to go, with a link to refer to the "Compatible hardware" section for other recommended and tested options:

<img width="427" height="129" alt="Screenshot of introduction to ZHA docs mainly recommending ZBT-2" src="https://github.com/user-attachments/assets/ac4741b0-b6c8-472e-8dfd-1f46a14e1998" />


### Compatible hardware section (a bit below)

The compatible hardware section mainly recommends official Home Assistant hardware now, with ZBT-2 for new installs:

<img width="431" height="580" alt="Screenshot showing the new sections with recommended hardware" src="https://github.com/user-attachments/assets/974d49f9-e1a1-42b7-9f8c-5f33921dad27" />

</p>
</details> 

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
