### PR TITLE
Add config options information to Comelit

### DIFF
--- a/source/_integrations/comelit.markdown
+++ b/source/_integrations/comelit.markdown
@@ -58,6 +58,23 @@ There is support for the following devices within Home Assistant:
         description: Comelit VEDO System.
 {% endconfiguration_basic %}
 
+## Configuration options
+
+{% include integrations/option_flow.md %}
+
+The device does not report how long a cover takes to fully open or close, so Home Assistant estimates its position based on the elapsed time since it started moving. You can set this travel time individually for each cover, since it depends on the type of cover, for example, a window opens and closes faster than a door-height shutter.
+
+1. Select the cover you want to configure.
+2. Enter the estimated time it takes for the cover to fully open or close.
+3. Select **Submit** to save the changes.
+
+{% configuration_basic %}
+Cover:
+  description: The cover {% term entity %} to set the travel time for.
+Travel time:
+  description: The estimated time, in seconds, for the cover to fully open or close. Enter a value between 1 and 120 seconds. The default is 25 seconds.
+{% endconfiguration_basic %}
+
 ## Examples
 
 ### Automation: Activate the alarm when you leave home

--- a/source/_integrations/comelit.markdown
+++ b/source/_integrations/comelit.markdown
@@ -127,7 +127,7 @@ The **Comelit SimpleHome** {% term integration %} provides the following entitie
 ### Comelit Serial Bridge
 
 - Climate
-- Cover
+- Cover - open, close, stop, and set position
 - Dehumidifier
 - Humidifier
 - Light


### PR DESCRIPTION

  
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add config options information to Comelit


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/179616
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
