### PR TITLE
Add diagnostics section to NeoPool integration docs

### DIFF
--- a/source/_integrations/neopool.markdown
+++ b/source/_integrations/neopool.markdown
@@ -126,6 +126,16 @@ The integration {% term polling polls %} the controller over Modbus TCP at a fix
 
 If a poll cycle fails (for example, because the Modbus gateway becomes unreachable), all entities transition to `unavailable` until the next successful poll.
 
+## Diagnostics
+
+This integration provides diagnostic information to help with troubleshooting. To download the diagnostics data:
+
+1. Go to {% my integrations title="**Settings** > **Devices & services**" %}.
+2. Select the NeoPool integration.
+3. Open the three-dot {% icon "mdi:dots-vertical" %} menu and select **Download diagnostics**.
+
+The downloaded file includes the config entry, the latest data read from the controller, and connection statistics. Sensitive values such as the host, port, and the controller's serial number are redacted and appear as `**REDACTED**`.
+
 ## Known limitations
 
 - **Discovery is not supported.** Modbus TCP gateways do not expose a standard discovery protocol that uniquely identifies a NeoPool controller behind the gateway, so the integration must be configured manually.


### PR DESCRIPTION
## Proposed change

Add a **Diagnostics** section to the NeoPool integration documentation, describing how to download config-entry diagnostics from the UI and which sensitive values (host, port, controller serial number) are redacted.

This documents the diagnostics platform added to the integration in home-assistant/core#179661.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch)
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch)
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch)
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch)
- [ ] Removed stale or deprecated documentation

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#179661

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation standards.
