### PR TITLE
Rain Bird: correct the 2.x limitation, clarify the controller password

### DIFF
--- a/source/_integrations/rainbird.markdown
+++ b/source/_integrations/rainbird.markdown
@@ -50,8 +50,15 @@ irrigations schedules on a calendar.
 Host:
   description: "The IP address of your Rain Bird device. You can find the IP address under the device in the Rain Bird app under **Controller Settings** > **Network Info**."
 Password:
-  description: "The password used to authenticate the Rain Bird device."
+  description: "The **controller password**, which you set when the Rain Bird WiFi controller was first configured. This is not the password for your Rain Bird account. It is 4-8 letters or numbers; if you set it up with the Rain Bird 2.0 app, it is the 6-digit PIN."
 {% endconfiguration_basic %}
+
+The controller password is specific to the controller and protects its network
+and sharing settings. Rain Bird documents it here:
+
+- [WiFi controller password and what it protects](https://wifi.rainbird.com/articles/wifi-controller-password-and-what-it-protects/)
+- [How do I change my controller password?](https://wifi.rainbird.com/articles/how-do-i-change-my-controller-password/)
+- [Forgotten controller passwords](https://wifi.rainbird.com/articles/forgotten-controller-passwords/)
 
 ## Configuration options
 
@@ -107,9 +114,10 @@ The Rain Bird integration provides the following entities.
 
 ## Known Limitations
 
-The new Rain Bird 2.0 App and Firmware is not compatible with Home Assistant.
-The upgrade process will migrate devices to require use of the new Rain Bird
-IQ4 cloud, and Home Assistant will not be able to access the device.
+Controllers updated by the Rain Bird 2.x app and newer firmware serve their local
+API over HTTPS instead of HTTP. Home Assistant 2026.3.1 or later tries both, so
+these controllers are supported and are still controlled locally, with no cloud
+requirement. On earlier versions, setup fails with a connection error.
 
 The Rain Bird LNK WiFi can only receive one incoming request at a time. It may
 not be possible for Home Assistant to send commands to the device while you


### PR DESCRIPTION
## Proposed change

Two corrections to the Rain Bird integration documentation.

**Known limitations.** The note saying the Rain Bird 2.0 app and firmware are not compatible is out of date. Controllers updated by the 2.x app serve their local API over HTTPS rather than HTTP, and Home Assistant 2026.3.1 or later tries both, so they are supported and still controlled locally with no cloud requirement.

**Password.** The field now identifies the credential as the controller password, set when the WiFi controller was first configured and distinct from the Rain Bird account password. It is 4-8 letters or numbers; the 2.0 app presents it as a 6-digit PIN. Adds links to the Rain Bird articles covering what it protects, how to change it, and what to do when it is forgotten.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #
