### PR TITLE
Document guntamatic heating circuit devices and additional sensors

### DIFF
--- a/source/_integrations/guntamatic.markdown
+++ b/source/_integrations/guntamatic.markdown
@@ -36,7 +36,9 @@ Host:
 
 ## Data updates
 
-The integration polls the Guntamatic heater every 30 seconds. The heater does not support push updates.
+The integration polls the Guntamatic heater every 30 seconds. The heater does not support push updates. All sensors, including those of the heating circuit devices, are refreshed in this single poll.
+
+The heater exposes a small embedded web interface that may also serve other tools or dashboards. Polling the same endpoints from multiple clients at once can affect response times, so avoid adding additional integrations or scripts that read these endpoints at a high rate.
 
 ## Devices
 

--- a/source/_integrations/guntamatic.markdown
+++ b/source/_integrations/guntamatic.markdown
@@ -48,7 +48,6 @@ The heater itself is represented as one device. Each connected heating circuit i
 
 The integration creates a sensor for each data point provided by the heater. The available sensors depend on the heater model and firmware version. Example sensors include boiler temperature, outside temperature, and buffer load. Note that sensors with a value of `-20.00 °C` or `-9.00 °C` are not returned.
 
-
 The following sensors are available for a Guntamatic BMK 20 heater:
 
 - **Boiler temperature**:
@@ -101,7 +100,6 @@ The following sensors are available for a Guntamatic BMK 20 heater:
   - **Example value**: Service Ign.
   - **Unit**: None
 
-
 ### Heating circuit devices
 
 Each connected heating circuit device provides the following sensors:
@@ -126,7 +124,6 @@ Each connected heating circuit device provides the following sensors:
 
 Additional sensors are disabled by default and can be enabled in the entity settings. These include buffer stage temperatures (top/bottom 0–2), auxiliary and extra domestic hot water pumps, extra domestic hot water temperatures, boiler shunt pump, suction fan, primary and secondary air, CO₂ content, interruptions, operating time (in hours) and service date (next service as an ISO date).
 
-
 ## Examples
 
 The following blueprints help you get started with common automations for your heater:
@@ -135,7 +132,6 @@ The following blueprints help you get started with common automations for your h
 - [Guntamatic maintenance reminder](https://github.com/home-assistant/home-assistant.io/blob/next/source/blueprints/integrations/guntamatic/maintenance-reminders.yaml): get a notification when the ash box needs emptying or the periodic service is due soon.
 
 Import them from the blueprint folder and select your Guntamatic sensors when setting up the automation.
-
 
 ## Removing the integration
 

--- a/source/_integrations/guntamatic.markdown
+++ b/source/_integrations/guntamatic.markdown
@@ -124,7 +124,7 @@ Each connected heating circuit device provides the following sensors:
 
 ### Additional sensors
 
-Additional sensors are disabled by default and can be enabled in the entity settings. These include buffer stage temperatures (top/bottom 0–2), auxiliary and extra domestic hot water pumps, extra domestic hot water temperatures, boiler shunt pump, suction fan, primary and secondary air, CO₂ content, interruptions, operating time (in hours) and service interval (in days).
+Additional sensors are disabled by default and can be enabled in the entity settings. These include buffer stage temperatures (top/bottom 0–2), auxiliary and extra domestic hot water pumps, extra domestic hot water temperatures, boiler shunt pump, suction fan, primary and secondary air, CO₂ content, interruptions, operating time (in hours) and service date (next service as an ISO date).
 
 
 ## Examples

--- a/source/_integrations/guntamatic.markdown
+++ b/source/_integrations/guntamatic.markdown
@@ -38,9 +38,13 @@ Host:
 
 The integration polls the Guntamatic heater every 30 seconds. The heater does not support push updates.
 
+## Devices
+
+The heater itself is represented as one device. Each connected heating circuit is represented as an additional device ("Heating circuit N"), so its entities can easily be assigned to the area of the room it heats. Only heating circuits that report data are created.
+
 ## Sensors
 
-The integration creates a sensor for each data point provided by the heater. The available sensors depend on the heater model and firmware version. Example sensors include boiler temperature, outside temperature, buffer load, and heating circuit programs. Note that sensors with a value of `-20.00 °C` or `-9.00 °C` are not returned.
+The integration creates a sensor for each data point provided by the heater. The available sensors depend on the heater model and firmware version. Example sensors include boiler temperature, outside temperature, and buffer load. Note that sensors with a value of `-20.00 °C` or `-9.00 °C` are not returned.
 
 
 The following sensors are available for a Guntamatic BMK 20 heater:
@@ -90,25 +94,35 @@ The following sensors are available for a Guntamatic BMK 20 heater:
     - Timer
   - **Unit**: None
 
-- **Room 0 temperature**:
-  - **Description**: Room temperature sensor reading for heating circuit 0
-  - **Example value**: 60.00
-  - **Unit**: °C
-
-- **Room 1 temperature**:
-  - **Description**: Room temperature sensor reading for heating circuit 1
-  - **Example value**: 24.68
-  - **Unit**: °C
-
-- **Room 2 temperature**:
-  - **Description**: Room temperature sensor reading for heating circuit 2
-  - **Example value**: 21.77
-  - **Unit**: °C
-
 - **Status**:
   - **Description**: Current operating state of the system
   - **Example value**: Service Ign.
   - **Unit**: None
+
+
+### Heating circuit devices
+
+Each connected heating circuit device provides the following sensors:
+
+- **Room temperature**:
+  - **Description**: Room temperature sensor reading for this heating circuit
+  - **Unit**: °C
+
+- **Flow temperature** (diagnostic):
+  - **Description**: Temperature of the water flowing towards this circuit
+  - **Unit**: °C
+
+- **Pump** (diagnostic):
+  - **Description**: Operating mode of the circulation pump
+  - **Possible values**: Auto, Non-stop, Off
+
+- **Program**:
+  - **Description**: Active program of this heating circuit
+  - **Possible values**: Off, Timer, Heat, Setback mode, Setback mode until
+
+### Additional sensors
+
+Additional sensors are disabled by default and can be enabled in the entity settings. These include buffer stage temperatures (top/bottom 0–2), auxiliary and extra domestic hot water pumps, extra domestic hot water temperatures, boiler shunt pump, suction fan, primary and secondary air, CO₂ content, interruptions, operating time (in hours) and service interval (in days).
 
 
 ## Removing the integration

--- a/source/_integrations/guntamatic.markdown
+++ b/source/_integrations/guntamatic.markdown
@@ -97,7 +97,7 @@ The following sensors are available for a Guntamatic BMK 20 heater:
   - **Unit**: None
 
 - **Status**:
-  - **Description**: Current operating state of the system
+  - **Description**: Current operating state of the system.
   - **Example value**: Service Ign.
   - **Unit**: None
 
@@ -107,19 +107,19 @@ The following sensors are available for a Guntamatic BMK 20 heater:
 Each connected heating circuit device provides the following sensors:
 
 - **Room temperature**:
-  - **Description**: Room temperature sensor reading for this heating circuit
+  - **Description**: Room temperature sensor reading for this heating circuit.
   - **Unit**: °C
 
 - **Flow temperature** (diagnostic):
-  - **Description**: Temperature of the water flowing towards this circuit
+  - **Description**: Temperature of the water flowing towards this circuit.
   - **Unit**: °C
 
 - **Pump** (diagnostic):
-  - **Description**: Operating mode of the circulation pump
+  - **Description**: Operating mode of the circulation pump.
   - **Possible values**: Auto, Non-stop, Off
 
 - **Program**:
-  - **Description**: Active program of this heating circuit
+  - **Description**: Active program of this heating circuit.
   - **Possible values**: Off, Timer, Heat, Setback mode, Setback mode until
 
 ### Additional sensors

--- a/source/_integrations/guntamatic.markdown
+++ b/source/_integrations/guntamatic.markdown
@@ -127,6 +127,16 @@ Each connected heating circuit device provides the following sensors:
 Additional sensors are disabled by default and can be enabled in the entity settings. These include buffer stage temperatures (top/bottom 0–2), auxiliary and extra domestic hot water pumps, extra domestic hot water temperatures, boiler shunt pump, suction fan, primary and secondary air, CO₂ content, interruptions, operating time (in hours) and service interval (in days).
 
 
+## Examples
+
+The following blueprints help you get started with common automations for your heater:
+
+- [Guntamatic low buffer load](https://github.com/home-assistant/home-assistant.io/blob/next/source/blueprints/integrations/guntamatic/low-buffer-load.yaml): get a notification when the buffer load drops below a chosen percentage, so you know it is time to refuel.
+- [Guntamatic maintenance reminder](https://github.com/home-assistant/home-assistant.io/blob/next/source/blueprints/integrations/guntamatic/maintenance-reminders.yaml): get a notification when the ash box needs emptying or the periodic service is due soon.
+
+Import them from the blueprint folder and select your Guntamatic sensors when setting up the automation.
+
+
 ## Removing the integration
 
 This integration follows standard integration removal. No extra steps are required.

--- a/source/blueprints/integrations/guntamatic/low-buffer-load.yaml
+++ b/source/blueprints/integrations/guntamatic/low-buffer-load.yaml
@@ -1,0 +1,46 @@
+blueprint:
+  name: Guntamatic low buffer load
+  description: >-
+    Send a notification when the buffer load percentage reported by your
+    Guntamatic heater drops below a chosen level, so you know it is time
+    to refuel.
+  domain: automation
+  input:
+    buffer_load_entity:
+      name: Buffer load sensor
+      description: >-
+        The **Buffer load** sensor of your Guntamatic heater.
+      selector:
+        entity:
+          filter:
+            - domain: sensor
+              multiple: false
+    threshold:
+      name: Low level threshold
+      description: >-
+        You receive a notification when the buffer load drops below this
+        percentage.
+      default: 20
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: "%"
+    notification_action:
+      name: Notification action
+      default: notify.notify
+      selector:
+        action:
+trigger:
+  - platform: numeric_state
+    entity_id: !input buffer_load_entity
+    below: !input threshold
+variables:
+  threshold: !input threshold
+actions:
+  - action: !input notification_action
+    data:
+      title: "Guntamatic: buffer load low"
+      message: >-
+        The buffer load dropped below {{ threshold }}%.
+        Time to refill the fuel storage.

--- a/source/blueprints/integrations/guntamatic/maintenance-reminders.yaml
+++ b/source/blueprints/integrations/guntamatic/maintenance-reminders.yaml
@@ -1,0 +1,74 @@
+blueprint:
+  name: Guntamatic maintenance reminder
+  description: >-
+    Send a notification when the time until the next maintenance task on
+    your Guntamatic heater runs low: emptying the ash box or the periodic
+    service.
+  domain: automation
+  input:
+    ash_empty_in_entity:
+      name: Time until ash emptying sensor
+      description: >-
+        The **Time until ash emptying** diagnostic sensor of your heater.
+      selector:
+        entity:
+          filter:
+            - domain: sensor
+    ash_threshold:
+      name: Ash emptying threshold
+      description: >-
+        You receive a notification when fewer hours remain than this value.
+        Set it to 0 to disable this reminder.
+      default: 48
+      selector:
+        number:
+          min: 0
+          max: 720
+          unit_of_measurement: h
+    service_days_entity:
+      name: Service days sensor
+      description: >-
+        The **Service days** diagnostic sensor of your heater.
+      selector:
+        entity:
+          filter:
+            - domain: sensor
+    service_threshold:
+      name: Service days threshold
+      description: >-
+        You receive a notification when fewer days remain than this value.
+        Set it to 0 to disable this reminder.
+      default: 14
+      selector:
+        number:
+          min: 0
+          max: 365
+          unit_of_measurement: d
+    notification_action:
+      name: Notification action
+      default: notify.notify
+      selector:
+        action:
+mode: parallel
+trigger:
+  - platform: numeric_state
+    id: ash
+    entity_id: !input ash_empty_in_entity
+    below: !input ash_threshold
+  - platform: numeric_state
+    id: service
+    entity_id: !input service_days_entity
+    below: !input service_threshold
+actions:
+  - action: !input notification_action
+    data:
+      title: >-
+        Guntamatic: {% if trigger.id == 'ash' %}ash box{% else %}service{% endif %} due soon
+      message: >-
+        {% if trigger.id == 'ash' %}
+        Empty the ash box within the next
+        {{ states(!input ash_empty_in_entity) }} hours.
+        {% else %}
+        Schedule the periodic service within the next
+        {{ states(!input service_days_entity) }} days.
+        {% endif %}

--- a/source/blueprints/integrations/guntamatic/maintenance-reminders.yaml
+++ b/source/blueprints/integrations/guntamatic/maintenance-reminders.yaml
@@ -25,19 +25,20 @@ blueprint:
           min: 0
           max: 720
           unit_of_measurement: h
-    service_days_entity:
-      name: Service days sensor
+    service_date_entity:
+      name: Service date sensor
       description: >-
-        The **Service days** diagnostic sensor of your heater.
+        The **Service date** diagnostic sensor of your heater.
       selector:
         entity:
           filter:
             - domain: sensor
+              device_class: date
     service_threshold:
-      name: Service days threshold
+      name: Service threshold
       description: >-
-        You receive a notification when fewer days remain than this value.
-        Set it to 0 to disable this reminder.
+        You receive a notification when the service date is fewer days away
+        than this value. Set it to 0 to disable this reminder.
       default: 14
       selector:
         number:
@@ -49,16 +50,23 @@ blueprint:
       default: notify.notify
       selector:
         action:
+variables:
+  service_date_entity: !input service_date_entity
+  service_threshold: !input service_threshold
+  ash_empty_in_entity: !input ash_empty_in_entity
 mode: parallel
 trigger:
   - platform: numeric_state
     id: ash
     entity_id: !input ash_empty_in_entity
     below: !input ash_threshold
-  - platform: numeric_state
+  - platform: template
     id: service
-    entity_id: !input service_days_entity
-    below: !input service_threshold
+    value_template: >-
+      {% set svc = states(service_date_entity) %}
+      {% set thr = service_threshold | int(0) %}
+      {{ thr > 0 and svc not in ['unknown', 'unavailable', 'none', '']
+         and (strptime(svc, '%Y-%m-%d') | as_datetime | as_local - now()).days < thr }}
 actions:
   - action: !input notification_action
     data:
@@ -67,8 +75,8 @@ actions:
       message: >-
         {% if trigger.id == 'ash' %}
         Empty the ash box within the next
-        {{ states(!input ash_empty_in_entity) }} hours.
+        {{ states(ash_empty_in_entity) }} hours.
         {% else %}
-        Schedule the periodic service within the next
-        {{ states(!input service_days_entity) }} days.
+        Schedule the periodic service for {{ states(service_date_entity) }}
+        (within the next {{ ((strptime(states(service_date_entity), '%Y-%m-%d') | as_datetime | as_local - now()).days) }} days).
         {% endif %}


### PR DESCRIPTION
## Proposed change

Documents the new entities added to the guntamatic integration:

- One device per connected heating circuit (room temperature, flow temperature, circulation pump, program), linked to the main heater device
- Enum states for heating circuit programs and pump operating modes
- The additional diagnostic sensors (disabled by default): buffer stages, auxiliary/extra-DHW pumps, interruptions, operating time, service interval
- Updates the quality scale badge to silver

Companion PR: https://github.com/home-assistant/core/pull/179770