### PR TITLE
Update Android TV Remote docs: launching apps by ID is currently unreliable

### DIFF
--- a/source/_integrations/androidtv_remote.markdown
+++ b/source/_integrations/androidtv_remote.markdown
@@ -42,13 +42,45 @@ This {% term integration %} adds a `media_player` with basic playback and volume
 
 Using the `media_player.play_media` {% term action %}, you can launch applications, switch channels, and start activities via `Deep Links`. Only `app`, `url` and `channel` media types are supported.
 
+### Launching activities
+
+The most reliable way to launch an app, or open a specific screen within it, is with a deep link supported by the app.
+
+Examples of deep links for popular applications:
+
+| App | Deep link |
+| --- | --- |
+| YouTube | `https://www.youtube.com` or `vnd.youtube://` or `vnd.youtube.launch://`
+| Netflix | `https://www.netflix.com/title` or `netflix://`
+| Prime Video | `https://app.primevideo.com`
+| Disney+ | `https://www.disneyplus.com`
+| Plex | `plex://`
+| Twitch | `twitch://home` `[home, stream, game, video, clip, search, browse, channel, user]`
+
+Example:
+
+```yaml
+# Open a specific YouTube video:
+action: media_player.play_media
+data:
+  media:
+    media_content_type: url
+    media_content_id: https://www.youtube.com/watch?v=dQw4w9WgXcQ
+target:
+  entity_id: media_player.living_room_tv
+```
+
 ### Launching apps
 
-If the Android TV device has the Google Play Store, you can directly launch any app by its application ID (package name).
+If an app doesn't have a deep link, or the device doesn't have the Google Play Store, you can try to launch it directly by its application ID (package name).
 The app doesn't need to exist in the Google Play Store.
 If it exists, you can find the application ID in the URL of the app's Google Play Store listing.
 For example, if the URL of an app page is `play.google.com/store/apps/details?id=com.example.app123`, the application ID is `com.example.app123`.
 The application ID is also displayed in the media player card when you launch the application on the device.
+
+{% note %}
+A change to the Google Play Store is currently preventing this method from working for many apps. If launching by application ID doesn't work, use a [deep link](#launching-activities) instead.
+{% endnote %}
 
 Examples of application IDs for popular applications:
 
@@ -71,34 +103,6 @@ data:
   media:
     media_content_type: app
     media_content_id: com.google.android.youtube.tv
-target:
-  entity_id: media_player.living_room_tv
-```
-
-### Launching activities
-
-Alternatively, if the device doesn't have the Google Play Store or if you want to open specific activity in the app, you can pass deep links supported by some applications.
-
-Examples of deep links for popular applications:
-
-| App | Deep link |
-| --- | --- |
-| YouTube | `https://www.youtube.com` or `vnd.youtube://` or `vnd.youtube.launch://`
-| Netflix | `https://www.netflix.com/title` or `netflix://`
-| Prime Video | `https://app.primevideo.com`
-| Disney+ | `https://www.disneyplus.com`
-| Plex | `plex://`
-| Twitch | `twitch://home` `[home, stream, game, video, clip, search, browse, channel, user]`
-
-Example:
-
-```yaml
-# Open a specific YouTube video:
-action: media_player.play_media
-data:
-  media:
-    media_content_type: url
-    media_content_id: https://www.youtube.com/watch?v=dQw4w9WgXcQ
 target:
   entity_id: media_player.living_room_tv
 ```
@@ -164,7 +168,8 @@ media_player:
 
 The remote allows you to send key commands and text as input to your Android TV device with the `remote.send_command` action.
 The entity has the `current_activity` attribute that shows the current foreground app on the Android TV.
-You can pass the application ID shown in this `current_activity` as `activity` in the `remote.turn_on` action to launch that app.
+You can pass a [deep link](#launching-activities), or the application ID shown in this `current_activity`, as `activity` in the `remote.turn_on` action to launch that app.
+Launching by application ID currently doesn't work reliably for many apps due to a Google Play Store change, so use a deep link when you have one.
 
 {% details "List of the most common commands" %}
 
@@ -252,7 +257,7 @@ Whether a command does something depends on your Android TV device, its firmware
 
 To send text as keyboard input use the `remote.send_command` and prefix the text to send with `text:`, e.g. `command: text:hello world` to type "hello world" in the selected input field.
 
-If `activity` is specified in `remote.turn_on` it will open the specified URL or the application with the given package name. See [Launching apps section](#launching-apps).
+If `activity` is specified in `remote.turn_on` it will open the specified deep link or launch the application with the given application ID. See the [Launching activities](#launching-activities) and [Launching apps](#launching-apps) sections.
 
 Example actions:
 
@@ -539,7 +544,7 @@ cards:
           action: perform-action
           perform_action: remote.turn_on
           data:
-            activity: com.netflix.ninja
+            activity: netflix://
           target:
             entity_id: remote.living_room_tv
         hold_action:
@@ -551,7 +556,7 @@ cards:
           action: perform-action
           perform_action: remote.turn_on
           data:
-            activity: com.amazon.amazonvideo.livingroom
+            activity: https://app.primevideo.com
           target:
             entity_id: remote.living_room_tv
         hold_action:
@@ -563,7 +568,7 @@ cards:
           action: perform-action
           perform_action: remote.turn_on
           data:
-            activity: com.disney.disneyplus
+            activity: https://www.disneyplus.com
           target:
             entity_id: remote.living_room_tv
         hold_action:
@@ -580,6 +585,7 @@ cards:
 
 ## Limitations and known issues
 
+- Launching apps by their application ID (as opposed to a deep link) currently doesn't work for many apps due to a Google Play Store change. Use a [deep link](#launching-activities) instead when one is available.
 - The integration doesn't work with Fire TV devices because they are missing the [Android TV Remote Service](https://play.google.com/store/apps/details?id=com.google.android.tv.remote.service). Attempts to sideload it haven't been successful.
 - If you cannot use the Google TV mobile app or the Google Home mobile app to send commands to the device, you cannot send commands with this integration either.
 - Commands don't work on Netflix. They don't work from the Google TV mobile app or the Google Home mobile app either.


### PR DESCRIPTION
## Proposed change

A recent Google Play Store change is preventing Android TV Remote from launching apps by their application ID (package name) for many apps — see home-assistant/core#179685, tronikos/androidtvremote2#46, and the related [community thread](https://community.home-assistant.io/t/android-tv-remote-no-longer-launching-apps/1021224). Deep links are not affected.

This updates the Android TV Remote docs to:

- Present deep links (**Launching activities**) as the primary, most reliable way to launch apps, ahead of application ID launching.
- Note under **Launching apps** and in **Limitations and known issues** that launching by application ID currently doesn't work reliably for many apps, and point readers to deep links instead.
- Update the `remote` section text and the dashboard YAML example (Netflix, Prime Video, Disney+ buttons) to use deep links instead of application IDs.

This is a documentation-only change. It doesn't fix the underlying issue.

## Type of change

- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: Related to home-assistant/core#179685 and tronikos/androidtvremote2#46

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
