### PR TITLE
Update KNX integration markdown with send_on_init

### DIFF
--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -579,10 +579,12 @@ respond_to_read:
   type: boolean
   default: true
 send_on_init:
-  description: Send the first valid value learned by the expose to the KNX bus. If disabled, the first valid value is initialized locally without sending a telegram and remains available for read responses and periodic sending. Subsequent value changes are sent normally.
+  description: Sends the first valid value learned by the entity exposure to the KNX bus.
+    When disabled, Home Assistant initializes the first valid value locally without sending a telegram.
+    The value remains available for read responses and `periodic_send`. Subsequent value changes are sent normally.
   required: false
   type: boolean
-  default: false   
+  default: false
 {% endconfiguration %}
 
 {% enddetails %}

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -498,6 +498,7 @@ knx:
     - type: binary
       entity_id: binary_sensor.kitchen_window
       address: "0/6/5"
+      send_on_init: true
 
     # state of an entity with default value
     - type: binary
@@ -577,6 +578,11 @@ respond_to_read:
   required: false
   type: boolean
   default: true
+send_on_init:
+  description: Send the first valid value learned by the expose to the KNX bus. If disabled, the first valid value is initialized locally without sending a telegram and remains available for read responses and periodic sending. Subsequent value changes are sent normally.
+  required: false
+  type: boolean
+  default: false   
 {% endconfiguration %}
 
 {% enddetails %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Document the new send_on_init option for KNX entity exposures.

The option allows users to explicitly send the first valid value learned by an expose to the KNX bus.

By default, send_on_init is disabled. In that case, the first valid value is initialized locally without sending a telegram. The initialized value remains available for KNX read responses and periodic_send, while subsequent value changes are sent normally.

When enabled:

knx:
  expose:
    - type: binary
      entity_id: binary_sensor.kitchen_window
      address: "0/6/5"
      send_on_init: true

the first valid value is also sent to the KNX bus when the expose is initialized.

This documents the optional compatibility behavior introduced as a follow-up to:
https://github.com/home-assistant/core/pull/178793
https://github.com/home-assistant/core/pull/179981


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [X] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/core/pull/179981
- This PR fixes or closes issue: fixes #

Related change:
https://github.com/home-assistant/core/pull/178793
https://github.com/home-assistant/core/pull/179981

Frontend support:
https://github.com/XKNX/knx-frontend/pull/439

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
