### PR TITLE
Document the VeSync fan level sensor

### DIFF
--- a/source/_integrations/vesync.markdown
+++ b/source/_integrations/vesync.markdown
@@ -129,7 +129,7 @@ All VeSync air purifiers expose the remaining filter lifetime, and some also exp
 
 | Sensor                  | Description                                                                            | Example   |
 | ----------------------- | -------------------------------------------------------------------------------------- | --------- |
-| `fan_level`             | The speed the fan is running at. Reported in every mode, including `auto` and `sleep`, where the device chooses the level itself and the fan entity reports no percentage. | 2 |
+| `fan_level`             | The level the fan is running at. Unlike the fan entity's percentage, this is reported in every mode, including `auto` and `sleep`. | 2 |
 | `filter_life`           | Remaining percentage of the filter. (LV-PUR131S, Core200S/300s/400s/600s/EverestAir)   | 142       |
 | `air_quality`           | The current air quality reading. (LV-PUR131S, Core300s/400s/600s)                      | excellent |
 | `pm2_5`                 | The current air quality reading. (Core300s/400s/600s/EverestAir)                       | 8         |

--- a/source/_integrations/vesync.markdown
+++ b/source/_integrations/vesync.markdown
@@ -129,6 +129,7 @@ All VeSync air purifiers expose the remaining filter lifetime, and some also exp
 
 | Sensor                  | Description                                                                            | Example   |
 | ----------------------- | -------------------------------------------------------------------------------------- | --------- |
+| `fan_level`             | The speed the fan is running at. Reported in every mode, including `auto` and `sleep`, where the device chooses the level itself and the fan entity reports no percentage. | 2 |
 | `filter_life`           | Remaining percentage of the filter. (LV-PUR131S, Core200S/300s/400s/600s/EverestAir)   | 142       |
 | `air_quality`           | The current air quality reading. (LV-PUR131S, Core300s/400s/600s)                      | excellent |
 | `pm2_5`                 | The current air quality reading. (Core300s/400s/600s/EverestAir)                       | 8         |


### PR DESCRIPTION
## Proposed change

Documents the `fan_level` sensor added to the VeSync integration in
home-assistant/core#180037.

The fan entity only reports a percentage in `manual` and `normal` modes, so on a purifier left in
`auto` — the usual way to run one — the running speed was not visible anywhere. The new sensor
reports it in every mode. This adds the row to the "Fan & air quality sensors" table.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration or feature I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a breaking change or deprecation (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- This PR fixes or closes issue: fixes #
- Link to parent pull request in the codebase: home-assistant/core#180037
- Link to parent pull request in the Brands repository: 

## Checklist

- [x] I have read and followed the [Documentation Standards](https://developers.home-assistant.io/docs/documenting/standards/).
