### PR TITLE
Update quality scale of 14 integrations to match core manifests

### DIFF
--- a/source/_integrations/anthropic.markdown
+++ b/source/_integrations/anthropic.markdown
@@ -25,7 +25,7 @@ related:
     title: Anthropic
   - url: https://claude.ai
     title: Claude
-ha_quality_scale: gold
+ha_quality_scale: platinum
 ---
 
 The **Anthropic** {% term integrations %} adds a conversation agent powered by [Anthropic](https://www.anthropic.com), such as Claude 3.5 Sonnet, in Home Assistant.

--- a/source/_integrations/aqvify.markdown
+++ b/source/_integrations/aqvify.markdown
@@ -19,7 +19,7 @@ related:
     title: Aqvify web
   - url: https://app.aqvify.com/
     title: Aqvify user account
-ha_quality_scale: bronze
+ha_quality_scale: platinum
 ---
 The **Aqvify** {% term integration %} allows users to integrate their [Aqvify](https://www.aqvify.com) water well and tank sensors using the [official public API](https://public.aqvify.com/swagger/index.html).
 

--- a/source/_integrations/blebox.markdown
+++ b/source/_integrations/blebox.markdown
@@ -29,6 +29,7 @@ ha_platforms:
   - switch
   - update
 ha_integration_type: device
+ha_quality_scale: gold
 ha_zeroconf: true
 ha_dhcp: true
 ---

--- a/source/_integrations/ccm15.markdown
+++ b/source/_integrations/ccm15.markdown
@@ -13,6 +13,7 @@ ha_platforms:
   - climate
   - diagnostics
 ha_integration_type: hub
+ha_quality_scale: bronze
 ---
 
 The **CCM15** {% term integration %} allows you to integrate [Midea CCM15](https://mbt.midea.com/hvac-goods/midea-products-category/vrfs/vrf-controller/central-controller-ccm-15) devices in Home Assistant.

--- a/source/_integrations/envertech_evt800.markdown
+++ b/source/_integrations/envertech_evt800.markdown
@@ -10,6 +10,7 @@ ha_codeowners:
   - '@daniel-bergmann-00'
 ha_domain: envertech_evt800
 ha_integration_type: integration
+ha_quality_scale: bronze
 ---
 
 The **Envertech EVT800** {% term integration %} allows you to integrate [Envertech EVT800](https://www.envertec.com/products/microinverter/66.html/) solar inverters in Home Assistant.

--- a/source/_integrations/google_health.markdown
+++ b/source/_integrations/google_health.markdown
@@ -12,7 +12,7 @@ ha_config_flow: true
 ha_platforms:
   - sensor
 ha_integration_type: service
-ha_quality_scale: gold
+ha_quality_scale: platinum
 related:
   - url: https://developers.google.com/health-api
     title: Google Health API

--- a/source/_integrations/hotspring.markdown
+++ b/source/_integrations/hotspring.markdown
@@ -15,6 +15,7 @@ ha_platforms:
   - number
   - sensor
 ha_integration_type: device
+ha_quality_scale: platinum
 ha_zeroconf: true
 ---
 

--- a/source/_integrations/kiosker.markdown
+++ b/source/_integrations/kiosker.markdown
@@ -19,7 +19,7 @@ ha_platforms:
   - switch
 ha_integration_type: device
 ha_zeroconf: true
-ha_quality_scale: bronze
+ha_quality_scale: silver
 ---
 
 [Kiosker](https://kiosker.io) is a powerful yet easy-to-use web kiosk for iPad and iPhone. This integration gives you control over your Kiosker app via the Kiosker API.

--- a/source/_integrations/led_infrared.markdown
+++ b/source/_integrations/led_infrared.markdown
@@ -17,6 +17,7 @@ ha_platforms:
   - event
   - light
 ha_integration_type: device
+ha_quality_scale: platinum
 ---
 
 The **LED Infrared** {% term integration %} lets you control lights with any infrared emitter that has been previously configured in Home Assistant. It can also receive commands from a remote when you have an infrared receiver set up, allowing you to use the remote to trigger automations in Home Assistant.

--- a/source/_integrations/netatmo.markdown
+++ b/source/_integrations/netatmo.markdown
@@ -35,6 +35,7 @@ ha_platforms:
   - sensor
   - switch
 ha_integration_type: hub
+ha_quality_scale: bronze
 ---
 
 [Netatmo](https://www.netatmo.com/) is a smart home brand from the Legrand group that makes connected devices for the home, including weather stations, indoor and outdoor cameras, video doorbells, smart thermostats and radiator valves, air quality monitors, and Legrand and BTicino electrical products such as switches, dimmers, and power plugs.

--- a/source/_integrations/nobo_hub.markdown
+++ b/source/_integrations/nobo_hub.markdown
@@ -15,7 +15,7 @@ ha_platforms:
   - select
   - sensor
 ha_integration_type: hub
-ha_quality_scale: bronze
+ha_quality_scale: platinum
 ha_dhcp: true
 related:
   - docs: /docs/organizing/areas/#creating-an-area

--- a/source/_integrations/scorpiontrack.markdown
+++ b/source/_integrations/scorpiontrack.markdown
@@ -16,7 +16,7 @@ ha_config_flow: true
 ha_integration_type: hub
 ha_codeowners:
   - '@Herbertmt978'
-ha_quality_scale: bronze
+ha_quality_scale: silver
 ---
 
 The **ScorpionTrack** {% term integration %} lets Home Assistant follow the location, speed, and ignition state of vehicles that have been shared through a public ScorpionTrack shared-location link.

--- a/source/_integrations/smlight.markdown
+++ b/source/_integrations/smlight.markdown
@@ -26,7 +26,7 @@ ha_codeowners:
   - '@tl-sl'
 ha_integration_type: device
 ha_dhcp: true
-ha_quality_scale: silver
+ha_quality_scale: platinum
 ---
 
 The **SMLIGHT SLZB** {% term integration %} allows you to monitor and manage your [SLZB](https://smlight.tech/) devices directly from Home Assistant. This integration provides direct access to many features available in the SLZB device's web UI, such as managing firmware updates, monitoring device health through diagnostic sensors, and controlling settings like LED modes or restarting the device.

--- a/source/_integrations/stiebel_eltron.markdown
+++ b/source/_integrations/stiebel_eltron.markdown
@@ -12,6 +12,7 @@ ha_domain: stiebel_eltron
 ha_platforms:
   - climate
 ha_integration_type: device
+ha_quality_scale: silver
 related:
   - docs: /docs/configuration/
     title: Configuration file


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Sync the `ha_quality_scale` front matter of 14 integration docs with the `quality_scale` declared in each integration's `manifest.json` in the core repository (`dev` branch). This makes the quality scale badge shown on the website match what the integrations actually declare.

Pages that declared a lower scale than the manifest:

- [anthropic](https://github.com/home-assistant/core/blob/dev/homeassistant/components/anthropic/manifest.json): gold → platinum
- [aqvify](https://github.com/home-assistant/core/blob/dev/homeassistant/components/aqvify/manifest.json): bronze → platinum
- [google_health](https://github.com/home-assistant/core/blob/dev/homeassistant/components/google_health/manifest.json): gold → platinum
- [kiosker](https://github.com/home-assistant/core/blob/dev/homeassistant/components/kiosker/manifest.json): bronze → silver
- [nobo_hub](https://github.com/home-assistant/core/blob/dev/homeassistant/components/nobo_hub/manifest.json): bronze → platinum
- [scorpiontrack](https://github.com/home-assistant/core/blob/dev/homeassistant/components/scorpiontrack/manifest.json): bronze → silver
- [smlight](https://github.com/home-assistant/core/blob/dev/homeassistant/components/smlight/manifest.json): silver → platinum

Pages that were missing the `ha_quality_scale` key:

- [blebox](https://github.com/home-assistant/core/blob/dev/homeassistant/components/blebox/manifest.json): gold
- [ccm15](https://github.com/home-assistant/core/blob/dev/homeassistant/components/ccm15/manifest.json): bronze
- [envertech_evt800](https://github.com/home-assistant/core/blob/dev/homeassistant/components/envertech_evt800/manifest.json): bronze
- [hotspring](https://github.com/home-assistant/core/blob/dev/homeassistant/components/hotspring/manifest.json): platinum
- [led_infrared](https://github.com/home-assistant/core/blob/dev/homeassistant/components/led_infrared/manifest.json): platinum
- [netatmo](https://github.com/home-assistant/core/blob/dev/homeassistant/components/netatmo/manifest.json): bronze
- [stiebel_eltron](https://github.com/home-assistant/core/blob/dev/homeassistant/components/stiebel_eltron/manifest.json): silver

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Targets `next` because some of the manifest values (google_health, blebox, hotspring, led_infrared) are only on the core `dev` branch and ship with the next release; the rest are already released.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
