### PR TITLE
Remove unclaimed bronze quality scale from Netio and AquaLogic docs

### DIFF
--- a/source/_integrations/aqualogic.markdown
+++ b/source/_integrations/aqualogic.markdown
@@ -13,7 +13,6 @@ ha_platforms:
   - sensor
   - switch
 ha_integration_type: hub
-ha_quality_scale: bronze
 ---
 
 The **AquaLogic** {% term integration %} provides connectivity to a Hayward/Goldline AquaLogic/ProLogic pool controller. Note that an RS-485 to Ethernet adapter connected to the pool controller is required.

--- a/source/_integrations/netio.markdown
+++ b/source/_integrations/netio.markdown
@@ -12,7 +12,7 @@ ha_integration_type: device
 ha_codeowners:
   - '@agners'
 ha_config_flow: true
-ha_quality_scale: bronze
+ha_quality_scale: legacy
 related:
   - docs: /docs/configuration/
     title: Configuration file


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Netio and AquaLogic docs declare `ha_quality_scale: bronze`, but neither integration claims that scale in core: there is no `quality_scale.yaml`, and the [Netio manifest](https://github.com/home-assistant/core/blob/dev/homeassistant/components/netio/manifest.json) still says `legacy` while the [AquaLogic manifest](https://github.com/home-assistant/core/blob/dev/homeassistant/components/aqualogic/manifest.json) has no `quality_scale` entry at all.

The bronze claims were added in the docs for the recent config flow conversions (#46980 for Netio, #45865 for AquaLogic) without a matching claim in core. This PR reverts the docs to match core until a proper `quality_scale.yaml` and manifest claim are in place: Netio back to `legacy`, and the key removed for AquaLogic.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Targets `next` because the Netio config flow conversion (home-assistant/core#177043) is not yet released; the bronze claims were introduced on `next` in #46980 and #45865.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
