### PR TITLE
Add high power consumption blueprint for WattWächter Plus

### DIFF
--- a/source/_integrations/wattwaechter.markdown
+++ b/source/_integrations/wattwaechter.markdown
@@ -90,6 +90,10 @@ Use the **Total consumption** sensor for grid consumption and the **Total feed-i
 
 ### Get notified on high power consumption
 
+Run an action, such as sending a notification, when your power consumption stays above a threshold for a set duration:
+
+{% my blueprint_import badge blueprint_url="https://www.home-assistant.io/blueprints/integrations/wattwaechter_high_power_alert.yaml" %}
+
 {% details "Example YAML automation" %}
 {% raw %}
 

--- a/source/blueprints/integrations/wattwaechter_high_power_alert.yaml
+++ b/source/blueprints/integrations/wattwaechter_high_power_alert.yaml
@@ -1,0 +1,60 @@
+blueprint:
+  name: WattWächter Plus - High power consumption alert
+  description: >
+    Run an action, such as sending a notification, when a WattWächter Plus
+    power sensor stays above a threshold for a chosen duration.
+  domain: automation
+  author: SmartCircuits
+  homeassistant:
+    min_version: 2024.10.0
+
+  input:
+    power_sensor:
+      name: Power sensor
+      description: Select the WattWächter Plus power sensor to monitor.
+      selector:
+        entity:
+          filter:
+            - integration: wattwaechter
+              domain: sensor
+              device_class: power
+
+    threshold:
+      name: Power threshold
+      description: Trigger when the power stays above this value (in watts).
+      default: 4000
+      selector:
+        number:
+          min: 0
+          max: 25000
+          step: 100
+          unit_of_measurement: W
+          mode: box
+
+    duration:
+      name: Duration
+      description: >
+        How long the power must stay above the threshold before triggering.
+      default:
+        minutes: 5
+      selector:
+        duration:
+
+    actions:
+      name: Actions
+      description: >
+        The actions to run when the threshold is exceeded (for example, send a
+        notification).
+      default: []
+      selector:
+        action:
+
+mode: single
+
+triggers:
+  - trigger: numeric_state
+    entity_id: !input power_sensor
+    above: !input threshold
+    for: !input duration
+
+actions: !input actions


### PR DESCRIPTION
## Proposed change

Adds an importable automation blueprint for the WattWächter Plus integration ("High power consumption alert") and links it from the integration's Examples section via a blueprint import badge.

This provides the WattWächter Plus integration with a hosted blueprint as required by the Gold-tier `docs-examples` quality scale rule (the previous inline-only YAML example did not satisfy it).

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: related to the WattWächter Plus gold quality scale bump home-assistant/core#176783
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

