### PR TITLE
Set config_entry_id to required in duckdns.set_txt action

### DIFF
--- a/source/_actions/duckdns.set_txt.markdown
+++ b/source/_actions/duckdns.set_txt.markdown
@@ -28,7 +28,7 @@ To set the TXT record from an automation or a script:
 {% options_ui %}
 Integration ID:
   description: The Duck DNS integration to update. Leaving this empty is deprecated and will not be an option in a future release.
-  required: false
+  required: true
 TXT:
   description: The value for the TXT record. Leave empty to clear the TXT record.
   required: false
@@ -54,7 +54,7 @@ This sets the TXT record of your Duck DNS subdomain to the given value.
 config_entry_id:
   description: >
     The ID of the Duck DNS integration to update. Leaving this empty is deprecated and will not be an option in a future release.
-  required: false
+  required: true
   type: string
 txt:
   description: >

--- a/source/_actions/duckdns.set_txt.markdown
+++ b/source/_actions/duckdns.set_txt.markdown
@@ -27,7 +27,7 @@ To set the TXT record from an automation or a script:
 
 {% options_ui %}
 Integration ID:
-  description: The Duck DNS integration to update. Leaving this empty is deprecated and will not be an option in a future release.
+  description: The Duck DNS integration to update.
   required: true
 TXT:
   description: The value for the TXT record. Leave empty to clear the TXT record.
@@ -53,7 +53,7 @@ This sets the TXT record of your Duck DNS subdomain to the given value.
 {% options_yaml %}
 config_entry_id:
   description: >
-    The ID of the Duck DNS integration to update. Leaving this empty is deprecated and will not be an option in a future release.
+    The ID of the Duck DNS integration to update.
   required: true
   type: string
 txt:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Passing the `config_entry_id` to the action is now a required field

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/177614
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
