### PR TITLE
Document the Fronius Modbus TCP support

### DIFF
--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -125,11 +125,11 @@ Modbus is optional. If it isn't enabled, or the inverter is powered down, no Mod
 
 To enable it on the device's web interface:
 
-- **Gen24, Tauro, and Verto**: _Communication_ → _Modbus_ → turn on _Slave as Modbus TCP_.
-- **Devices with a Datamanager**: _Settings_ → _Modbus_ → set _Data output via Modbus_ to _TCP_. One Datamanager serves every inverter in its SolarNet ring.
+- Gen24, Tauro, and Verto: go to **Communication** > **Modbus** and turn on the Modbus TCP server (on-screen label: **Slave as Modbus TCP**).
+- Devices with a Datamanager: go to **Settings** > **Modbus** and set **Data output via Modbus** to **TCP**. One Datamanager serves every inverter in its SolarNet ring.
 
 {% note %}
-Leave the data format setting (_float_ or _int + SF_) as it is. The integration detects it automatically.
+Leave the data format setting (**float** or **int + SF**) as it is. The integration detects it automatically.
 {% endnote %}
 
 These entities are added per inverter and updated every minute:
@@ -154,9 +154,9 @@ Recommended [energy dashboard](/docs/energy/) configuration:
 {% important %}
 The [Modbus TCP](#modbus-tcp) energy values are measured on the DC side, at the MPP trackers.
 
-`PV energy total` is the energy the panels delivered, before inverter conversion losses, so it reads higher than the inverters `Energy total`, which is the AC energy actually fed out. For _"Solar production"_, prefer the AC value - that is the energy that can be used or sold.
+`PV energy total` is the energy the panels delivered, before inverter conversion losses, so it reads higher than the inverter's `Energy total`, which is the AC energy actually fed out. For _"Solar production"_, prefer the AC value. That is the energy you can use or sell.
 
-`Battery charging energy total` and `Battery discharging energy total` are DC values measured at the battery. They are counters read from the device rather than values integrated over time, so they don't drift and are unaffected by Home Assistant restarts - but for the same reason they won't match a Riemann sum of `SolarNet Power battery charge` and `SolarNet Power battery discharge` exactly.
+`Battery charging energy total` and `Battery discharging energy total` are DC values measured at the battery. They are counters read from the device rather than values integrated over time, so they don't drift and are unaffected by Home Assistant restarts. For the same reason, they don't exactly match a Riemann sum of `SolarNet Power battery charge` and `SolarNet Power battery discharge`.
 {% endimportant %}
 
 The energy meter integrated with Fronius devices can be installed (and configured) in two different installation positions: _"feed in path"_ (grid interconnection point) or _"consumption path"_.
@@ -218,7 +218,7 @@ Fronius often provides firmware updates for the datamanager interfaces and the d
 
 ## Known limitations
 
-This integration only reads from Fronius devices. The Solar API is read-only, and the [Modbus TCP](#modbus-tcp) interface is used for reading only. Most Fronius devices do support writing over Modbus TCP - for example to limit output power or control battery charging - so the [Modbus integration](/integrations/modbus/) can be used to control them. Details about Modbus registers can be found in the device documentation or at the [Fronius website](https://www.fronius.com/).
+This integration only reads from Fronius devices. The Solar API is read-only, and the [Modbus TCP](#modbus-tcp) interface is used for reading only. Most Fronius devices do support writing over Modbus TCP, for example to limit output power or control battery charging, so you can use the [Modbus integration](/integrations/modbus/) to control them. Details about Modbus registers can be found in the device documentation or at the [Fronius website](https://www.fronius.com/).
 
 ## Troubleshooting
 

--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -60,6 +60,10 @@ Host:
     description: "The host name or the IP address of the device."
     required: true
     type: string
+Modbus port:
+    description: "The port of the device's Modbus TCP interface. Only used when Modbus is enabled on the device, see [Modbus TCP](#modbus-tcp). The default is `502`."
+    required: false
+    type: integer
 {% endconfiguration_basic %}
 
 ## Monitored data
@@ -113,6 +117,30 @@ Each device adds a set of sensors to Home Assistant.
 
 When an endpoint is not responding correctly the update interval will increase to 10 minutes (3 minutes for power flow) until valid data is received again. This reduces the number of requests to Fronius devices using night mode (shutdown when no PV power is produced).
 
+## Modbus TCP
+
+Most Fronius devices also provide a Modbus TCP interface using the [SunSpec](https://sunspec.org/) information models. It exposes per-string (MPP tracker) data that the Solar API does not, so the integration reads it in addition when it is available.
+
+Modbus is optional. If it isn't enabled, or the inverter is powered down, no Modbus entities are created and the rest of the integration is unaffected. The integration checks again every hour, so entities appear on their own once the device answers.
+
+To enable it on the device's web interface:
+
+- **Gen24, Tauro, and Verto**: _Communication_ → _Modbus_ → turn on _Slave as Modbus TCP_.
+- **Devices with a Datamanager**: _Settings_ → _Modbus_ → set _Data output via Modbus_ to _TCP_. One Datamanager serves every inverter in its SolarNet ring.
+
+{% note %}
+Leave the data format setting (_float_ or _int + SF_) as it is. The integration detects it automatically.
+{% endnote %}
+
+These entities are added per inverter and updated every minute:
+
+- `MPPT <n> DC power` and `MPPT <n> DC energy` for each MPP tracker.
+- `MPPT <n> DC current` and `MPPT <n> DC voltage` for each MPP tracker. Disabled by default.
+- `PV energy total`: lifetime energy from the photovoltaic strings only, measured on the DC side.
+- `Battery charging energy total` and `Battery discharging energy total`: on hybrid inverters that expose their battery as dedicated MPP trackers, such as Gen24 with a battery.
+
+The connection is shared with the [Modbus integration](/integrations/modbus/) and any other integration talking to the same device, so using both doesn't open a second connection to the inverter.
+
 ## Energy dashboard
 
 Recommended [energy dashboard](/docs/energy/) configuration:
@@ -122,6 +150,14 @@ Recommended [energy dashboard](/docs/energy/) configuration:
   - If a battery is connected to an inverter: Use [Riemann sum](/integrations/integration/) over `SolarNet Power photovoltaics` entity.
 - _"Battery systems"_ energy values aren't supported directly by the Solar API. Use [Riemann sum](/integrations/integration/) to integrate `SolarNet Power battery charge` and `SolarNet Power battery discharge` into energy values (kWh).
 - For _"Devices"_ use the Ohmpilots `Energy consumed` entity.
+
+{% important %}
+The [Modbus TCP](#modbus-tcp) energy values are measured on the DC side, at the MPP trackers.
+
+`PV energy total` is the energy the panels delivered, before inverter conversion losses, so it reads higher than the inverters `Energy total`, which is the AC energy actually fed out. For _"Solar production"_, prefer the AC value - that is the energy that can be used or sold.
+
+`Battery charging energy total` and `Battery discharging energy total` are DC values measured at the battery. They are counters read from the device rather than values integrated over time, so they don't drift and are unaffected by Home Assistant restarts - but for the same reason they won't match a Riemann sum of `SolarNet Power battery charge` and `SolarNet Power battery discharge` exactly.
+{% endimportant %}
 
 The energy meter integrated with Fronius devices can be installed (and configured) in two different installation positions: _"feed in path"_ (grid interconnection point) or _"consumption path"_.
 
@@ -182,7 +218,7 @@ Fronius often provides firmware updates for the datamanager interfaces and the d
 
 ## Known limitations
 
-The Solar API used by this integration is read-only. It does not provide any means to control the Fronius devices. Most Fronius devices however do support Modbus TCP directly, so the [Modbus integration](/integrations/modbus/) could be leveraged to control the devices from Home Assistant. Details about Modbus Registers can be found in the devices documentation or at the [Fronius website](https://www.fronius.com/).
+This integration only reads from Fronius devices. The Solar API is read-only, and the [Modbus TCP](#modbus-tcp) interface is used for reading only. Most Fronius devices do support writing over Modbus TCP - for example to limit output power or control battery charging - so the [Modbus integration](/integrations/modbus/) can be used to control them. Details about Modbus registers can be found in the device documentation or at the [Fronius website](https://www.fronius.com/).
 
 ## Troubleshooting
 
@@ -200,6 +236,14 @@ The Solar API used by this integration is read-only. It does not provide any mea
 
 Some data, like photovoltaic production, is only provided by the Fronius device when non-zero.
 When the integration is added at night, there might be no entities added providing photovoltaic related data. Entities will be added on sunrise, when the Fronius devices begin to provide more data.
+
+### No MPPT, PV energy, or battery energy entities
+
+These come from the device's [Modbus TCP](#modbus-tcp) interface.
+
+- Check that Modbus TCP is enabled on the device's web interface.
+- Check that the Modbus port configured in Home Assistant matches the device. Reconfigure the integration to change it.
+- Make sure the inverter is not in a power-saving mode. An inverter that is powered down doesn't answer, and the entities are added once it wakes up.
 
 ## Removing the integration
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->


Documents the optional Modbus TCP (SunSpec) support added to the Fronius integration in home-assistant/core#179995.

- **New `Modbus TCP` section**: what it adds over the Solar API (per-MPP-tracker data), that it is optional and additive, how to enable it on Gen24/Tauro/Verto and on Datamanager devices, and the entities it creates. Notes that the device's *float* / *int + SF* data format setting does not need touching, since the integration detects it.
- **Configuration**: the new `Modbus port` option.
- **Energy dashboard**: an important note that the Modbus energy values are measured on the **DC** side. `PV energy total` is therefore higher than the inverters AC `Energy total` — on a Gen24 with a battery, 5.5 % higher — so the existing AC-based advice for *"Solar production"* still stands. This is the same discrepancy reported in home-assistant/core#102170, where users saw solar production reading 2.5-3 % low against Solar.web precisely because the API value is AC.
- **Known limitations**: the section said the integration cannot read Modbus at all and pointed at the Modbus integration. It now says the integration reads over Modbus but does not write, and still points at the Modbus integration for control.
- **Troubleshooting**: an entry for missing MPPT, PV energy, or battery energy entities.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/179995
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
