### PR TITLE
Add firmware update entity docs for WattWächter Plus

### DIFF
--- a/source/_integrations/wattwaechter.markdown
+++ b/source/_integrations/wattwaechter.markdown
@@ -4,6 +4,7 @@ description: Instructions on how to integrate WattWächter Plus into Home Assist
 ha_category:
   - Energy
   - Sensor
+  - Update
 ha_release: 2026.7
 ha_iot_class: Local Polling
 ha_config_flow: true

--- a/source/_integrations/wattwaechter.markdown
+++ b/source/_integrations/wattwaechter.markdown
@@ -79,7 +79,7 @@ The integration adds an update entity that reports the firmware version installe
 
 ## Data updates
 
-The integration {% term polling polls %} your WattWächter Plus device locally every 2 minutes (120 seconds). Each poll fetches the meter data (SML/OBIS readings), system information, and the available firmware update status.
+The integration {% term polling polls %} your WattWächter Plus device locally every 2 minutes (120 seconds). Each poll fetches the meter data (SML/OBIS readings), system information, and the firmware update status.
 
 ## Actions
 

--- a/source/_integrations/wattwaechter.markdown
+++ b/source/_integrations/wattwaechter.markdown
@@ -12,6 +12,7 @@ ha_codeowners:
 ha_domain: wattwaechter
 ha_platforms:
   - sensor
+  - update
 ha_zeroconf: true
 ha_integration_type: device
 ha_quality_scale: silver
@@ -72,9 +73,13 @@ The following sensors are created with the diagnostic entity category and are di
 - **Wi-Fi signal (dBm)**: The wireless signal strength of the device.
 - **Wi-Fi SSID**: The wireless network name the device is connected to.
 
+### Firmware updates
+
+The integration adds an update entity that reports the firmware version installed on your WattWächter Plus and whether a newer version is available. When an update is offered, you can review the release notes and install it directly from Home Assistant. The device downloads and applies the firmware itself.
+
 ## Data updates
 
-The integration {% term polling polls %} your WattWächter Plus device locally every 2 minutes (120 seconds). Each poll fetches the meter data (SML/OBIS readings) and system information.
+The integration {% term polling polls %} your WattWächter Plus device locally every 2 minutes (120 seconds). Each poll fetches the meter data (SML/OBIS readings), system information, and the available firmware update status.
 
 ## Actions
 


### PR DESCRIPTION
## Proposed change

Documents the firmware update entity added to the WattWächter Plus integration by home-assistant/core#180203.

Adds the `update` platform to the integration's frontmatter and a "Firmware updates" section describing the entity (installed and latest firmware version, release notes, and the install action). Also notes that each poll now checks the available firmware update status in the "Data updates" section.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#180203
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
