### PR TITLE
Document the Fronius Modbus setpoints

### DIFF
--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -141,6 +141,60 @@ These entities are added per inverter and updated every minute:
 
 The connection is shared with the [Modbus integration](/integrations/modbus/) and any other integration talking to the same device, so using both doesn't open a second connection to the inverter.
 
+### Controlling the inverter over Modbus
+
+Modbus is the only interface that lets Home Assistant change settings on the inverter; the Solar API is read-only. These setpoints are added as `number` entities, and appear under _Configuration_ on the inverter's device page:
+
+- `Power limit`: caps the inverter's output, as a percentage of its nominal power output.
+- `Battery charge power limit` and `Battery discharge power limit`: cap how fast the battery may charge or discharge, as a percentage of its maximum rate.
+- `Battery minimum reserve`: the state of charge the battery is not discharged below.
+
+{% important %}
+Writing has to be allowed on the device first: _Communication_ → _Modbus_ (Gen24, Tauro, Verto) or _Settings_ → _Modbus_ (Datamanager) → turn on **Inverter control via Modbus**.
+
+Until it is, the inverter rejects every write, and the integration creates no control entities at all rather than ones that fail when used. Turn it on, then reload the integration.
+{% endimportant %}
+
+The limits are only applied while they are active, so setting one activates it. `100 %` is what "no limit" means to the device: setting a limit back to `100 %` releases it.
+
+{% note %}
+The inverter decides which control source wins. If _IO control_ or _dynamic power reduction_ has a higher priority than Modbus in the DNO Editor, the inverter may refuse or ignore what Home Assistant sends.
+{% endnote %}
+
+#### The battery limits are power, not a charge level
+
+`Battery charge power limit` limits charging **power** — it is not a "charge to 80 %" setting. The inverter exposes no maximum state of charge over Modbus at all; only the minimum reserve.
+
+A charge ceiling can be built as an automation instead, using the battery's state of charge sensor and the charge power limit:
+
+```yaml
+automation:
+  - alias: "Stop charging the battery at 80%"
+    triggers:
+      - trigger: numeric_state
+        entity_id: sensor.byd_battery_box_premium_hv_state_of_charge
+        above: 80
+    actions:
+      - action: number.set_value
+        target:
+          entity_id: number.gen24_battery_charge_power_limit
+        data:
+          value: 0
+  - alias: "Allow charging the battery again below 75%"
+    triggers:
+      - trigger: numeric_state
+        entity_id: sensor.byd_battery_box_premium_hv_state_of_charge
+        below: 75
+    actions:
+      - action: number.set_value
+        target:
+          entity_id: number.gen24_battery_charge_power_limit
+        data:
+          value: 100
+```
+
+Discharging is limited by its own setpoint, so the battery still supplies the house while charging is held at `0 %`. Because the limit is held by Home Assistant rather than the inverter, the battery charges normally again if Home Assistant stops running.
+
 ## Energy dashboard
 
 Recommended [energy dashboard](/docs/energy/) configuration:
@@ -218,7 +272,9 @@ Fronius often provides firmware updates for the datamanager interfaces and the d
 
 ## Known limitations
 
-This integration only reads from Fronius devices. The Solar API is read-only, and the [Modbus TCP](#modbus-tcp) interface is used for reading only. Most Fronius devices do support writing over Modbus TCP, for example to limit output power or control battery charging, so you can use the [Modbus integration](/integrations/modbus/) to control them. Details about Modbus registers can be found in the device documentation or at the [Fronius website](https://www.fronius.com/).
+The Solar API is read-only, so everything this integration changes on a device goes over [Modbus TCP](#modbus-tcp), and only what the SunSpec models expose: the output power limit and the battery charge, discharge and reserve setpoints. Every setpoint is a percentage - Fronius exposes no absolute watt setting, and no maximum state of charge.
+
+For anything beyond that, the [Modbus integration](/integrations/modbus/) can address the same device directly. Details about Modbus registers can be found in the device documentation or at the [Fronius website](https://www.fronius.com/).
 
 ## Troubleshooting
 
@@ -236,6 +292,13 @@ This integration only reads from Fronius devices. The Solar API is read-only, an
 
 Some data, like photovoltaic production, is only provided by the Fronius device when non-zero.
 When the integration is added at night, there might be no entities added providing photovoltaic related data. Entities will be added on sunrise, when the Fronius devices begin to provide more data.
+
+### No power limit or battery setpoints
+
+These are the `number` entities described under [Modbus TCP](#modbus-tcp).
+
+- Check that **Inverter control via Modbus** is enabled on the device's web interface, under the same _Modbus_ settings where Modbus TCP is turned on. Without it the inverter rejects every write, so the integration doesn't offer the entities.
+- Reload the integration after changing the setting.
 
 ### No MPPT, PV energy, or battery energy entities
 

--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -125,7 +125,7 @@ Modbus is optional. If it isn't enabled, or the inverter is powered down, no Mod
 
 To enable it on the device's web interface:
 
-- Gen24, Tauro, and Verto: go to **Communication** > **Modbus** and turn on the Modbus TCP server (on-screen label: **Slave as Modbus TCP**).
+- Gen24, Tauro, and Verto: go to **Communication** > **Modbus** and turn on the Modbus TCP server.
 - Devices with a Datamanager: go to **Settings** > **Modbus** and set **Data output via Modbus** to **TCP**. One Datamanager serves every inverter in its SolarNet ring.
 
 {% note %}
@@ -143,14 +143,14 @@ The connection is shared with the [Modbus integration](/integrations/modbus/) an
 
 ### Controlling the inverter over Modbus
 
-Modbus is the only interface that lets Home Assistant change settings on the inverter; the Solar API is read-only. These setpoints are added as `number` entities, and appear under _Configuration_ on the inverter's device page:
+Modbus is the only interface that lets Home Assistant change settings on the inverter; the Solar API is read-only. These setpoints are added as `number` entities, and appear under **Configuration** on the inverter's device page:
 
 - `Power limit`: caps the inverter's output, as a percentage of its nominal power output.
 - `Battery charge power limit` and `Battery discharge power limit`: cap how fast the battery may charge or discharge, as a percentage of its maximum rate.
 - `Battery minimum reserve`: the state of charge the battery is not discharged below.
 
 {% important %}
-Writing has to be allowed on the device first: _Communication_ → _Modbus_ (Gen24, Tauro, Verto) or _Settings_ → _Modbus_ (Datamanager) → turn on **Inverter control via Modbus**.
+Writing has to be allowed on the device first. Go to **Communication** > **Modbus** (Gen24, Tauro, and Verto) or **Settings** > **Modbus** (Datamanager), and turn on **Inverter control via Modbus**.
 
 Until it is, the inverter rejects every write, and the integration creates no control entities at all rather than ones that fail when used. Turn it on, then reload the integration.
 {% endimportant %}
@@ -158,12 +158,12 @@ Until it is, the inverter rejects every write, and the integration creates no co
 The limits are only applied while they are active, so setting one activates it. `100 %` is what "no limit" means to the device: setting a limit back to `100 %` releases it.
 
 {% note %}
-The inverter decides which control source wins. If _IO control_ or _dynamic power reduction_ has a higher priority than Modbus in the DNO Editor, the inverter may refuse or ignore what Home Assistant sends.
+The inverter decides which control source wins. If **IO control** or **Dynamic power reduction** has a higher priority than Modbus in the DNO Editor, the inverter may refuse or ignore what Home Assistant sends.
 {% endnote %}
 
 #### The battery limits are power, not a charge level
 
-`Battery charge power limit` limits charging **power** — it is not a "charge to 80 %" setting. The inverter exposes no maximum state of charge over Modbus at all; only the minimum reserve.
+`Battery charge power limit` limits charging _power_. It is not a "charge to 80 %" setting. The inverter exposes no maximum state of charge over Modbus at all; only the minimum reserve.
 
 A charge ceiling can be built as an automation instead, using the battery's state of charge sensor and the charge power limit:
 
@@ -272,7 +272,7 @@ Fronius often provides firmware updates for the datamanager interfaces and the d
 
 ## Known limitations
 
-The Solar API is read-only, so everything this integration changes on a device goes over [Modbus TCP](#modbus-tcp), and only what the SunSpec models expose: the output power limit and the battery charge, discharge and reserve setpoints. Every setpoint is a percentage - Fronius exposes no absolute watt setting, and no maximum state of charge.
+The Solar API is read-only, so everything this integration changes on a device goes over [Modbus TCP](#modbus-tcp), and only what the SunSpec models expose: the output power limit and the battery charge, discharge, and reserve setpoints. Every setpoint is a percentage. Fronius exposes no absolute watt setting, and no maximum state of charge.
 
 For anything beyond that, the [Modbus integration](/integrations/modbus/) can address the same device directly. Details about Modbus registers can be found in the device documentation or at the [Fronius website](https://www.fronius.com/).
 
@@ -297,7 +297,7 @@ When the integration is added at night, there might be no entities added providi
 
 These are the `number` entities described under [Modbus TCP](#modbus-tcp).
 
-- Check that **Inverter control via Modbus** is enabled on the device's web interface, under the same _Modbus_ settings where Modbus TCP is turned on. Without it the inverter rejects every write, so the integration doesn't offer the entities.
+- Check that **Inverter control via Modbus** is enabled on the device's web interface, under the same **Modbus** settings where Modbus TCP is turned on. Without it the inverter rejects every write, so the integration doesn't offer the entities.
 - Reload the integration after changing the setting.
 
 ### No MPPT, PV energy, or battery energy entities


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the `number` entities added in home-assistant/core#180241 — the output power limit and the battery charge, discharge and reserve setpoints.

**This is stacked on #47610** and branches from it, so the two Modbus sections cannot conflict. Until #47610 merges, its commit shows here too; afterwards this PR is just the second commit, `Document the Fronius Modbus setpoints`. Please merge #47610 first.

Covers the three things a user cannot work out from the entities alone:

- **"Inverter control via Modbus" has to be enabled on the device**, or the inverter rejects every write and the integration deliberately creates no control entities. Explained in the section and in troubleshooting.
- **Setting a limit activates it**, and `100 %` is what "no limit" means to the device.
- **The battery limits are power, not a charge level.** Fronius exposes no maximum state of charge over Modbus, so a charge ceiling has to be an automation — one is included, using the state of charge sensor and the charge power limit.

Also notes that control priority (IO control, dynamic power reduction) can outrank Modbus, and rewrites *Known limitations*, which said the integration only reads.

## Type of change

<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/180241
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
