### PR TITLE
Fix the Fronius Modbus TCP notes

### DIFF
--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -125,7 +125,7 @@ Modbus is optional. If it isn't enabled, or the inverter is powered down, no Mod
 
 To enable it on the device's web interface:
 
-- Gen24, Tauro, and Verto: go to **Communication** > **Modbus** and turn on the Modbus TCP server.
+- Gen24, Tauro, and Verto: go to **Communication** > **Modbus** and turn on the Modbus TCP server (on-screen label: **Slave as Modbus TCP**).
 - Devices with a Datamanager: go to **Settings** > **Modbus** and set **Data output via Modbus** to **TCP**. One Datamanager serves every inverter in its SolarNet ring.
 
 {% note %}
@@ -138,8 +138,6 @@ These entities are added per inverter and updated every minute:
 - `MPPT <n> DC current` and `MPPT <n> DC voltage` for each MPP tracker. Disabled by default.
 - `PV energy total`: lifetime energy from the photovoltaic strings only, measured on the DC side.
 - `Battery charging energy total` and `Battery discharging energy total`: on hybrid inverters that expose their battery as dedicated MPP trackers, such as Gen24 with a battery.
-
-The connection is shared with the [Modbus integration](/integrations/modbus/) and any other integration talking to the same device, so using both doesn't open a second connection to the inverter.
 
 ### Controlling the inverter over Modbus
 
@@ -274,7 +272,7 @@ Fronius often provides firmware updates for the datamanager interfaces and the d
 
 The Solar API is read-only, so everything this integration changes on a device goes over [Modbus TCP](#modbus-tcp), and only what the SunSpec models expose: the output power limit and the battery charge, discharge, and reserve setpoints. Every setpoint is a percentage. Fronius exposes no absolute watt setting, and no maximum state of charge.
 
-For anything beyond that, the [Modbus integration](/integrations/modbus/) can address the same device directly. Details about Modbus registers can be found in the device documentation or at the [Fronius website](https://www.fronius.com/).
+Details about Modbus registers can be found in the device documentation or at the [Fronius website](https://www.fronius.com/).
 
 ## Troubleshooting
 

--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -125,7 +125,7 @@ Modbus is optional. If it isn't enabled, or the inverter is powered down, no Mod
 
 To enable it on the device's web interface:
 
-- Gen24, Tauro, and Verto: go to **Communication** > **Modbus** and turn on the Modbus TCP server (on-screen label: **Slave as Modbus TCP**).
+- Gen24, Tauro, and Verto: go to **Communication** > **Modbus** and turn on the Modbus TCP server.
 - Devices with a Datamanager: go to **Settings** > **Modbus** and set **Data output via Modbus** to **TCP**. One Datamanager serves every inverter in its SolarNet ring.
 
 {% note %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Follow-up to #47610 and #47615, which merged before these two points were settled.

**The Modbus integration cannot address a device the Fronius integration is already talking to.** The page claimed it twice, so both claims are removed:

- The *Modbus TCP* section said the connection is shared with the Modbus integration, so using both doesn't open a second connection.
- *Known limitations* pointed at the Modbus integration for anything the SunSpec setpoints don't cover.

**The on-screen label for the Gen24 setting is restored.** Copilot asked to drop the term "slave" even as a device UI label, and #47615 merged with it removed. That leaves nothing on the device for the reader to look for. The surrounding prose still says "turn on the Modbus TCP server", so the term is only quoted as the label, never used as our own wording.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/180241
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

This targets `next` rather than `current` because the text it corrects only exists on `next`.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
