### PR TITLE
Document the Fronius Modbus control switches

### DIFF
--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -149,7 +149,7 @@ Modbus is the only interface that lets Home Assistant change settings on the inv
 - `Battery charge power limit` and `Battery discharge power limit`: cap how fast the battery may charge or discharge, as a percentage of its maximum rate.
 - `Battery minimum reserve`: the state of charge the battery is not discharged below.
 
-Each limit has a `switch` that turns it on and off: `Power limiting`, `Battery charge power limiting` and `Battery discharge power limiting`. `Battery grid charging` allows or prevents charging the battery from the grid.
+The `Power limit`, `Battery charge power limit`, and `Battery discharge power limit` setpoints each have a `switch` that turns the limit on and off: `Power limiting`, `Battery charge power limiting`, and `Battery discharge power limiting`. `Battery grid charging` is a separate switch that allows or prevents charging the battery from the grid.
 
 {% important %}
 Writing has to be allowed on the device first. Go to **Communication** > **Modbus** (Gen24, Tauro, and Verto) or **Settings** > **Modbus** (Datamanager), and turn on **Inverter control via Modbus**.
@@ -157,10 +157,10 @@ Writing has to be allowed on the device first. Go to **Communication** > **Modbu
 Until it is, the inverter rejects every write, and the integration creates no control entities at all rather than ones that fail when used. Turn it on, then reload the integration.
 {% endimportant %}
 
-A setpoint is only applied while its switch is on. Setting one while the switch is off stores the value on the inverter without applying it, and turning the switch on then applies what is stored - which is the order Fronius documents.
+A setpoint is only applied while its switch is on. Setting one while the switch is off stores the value on the inverter without applying it, and turning the switch on then applies what is stored, which is the order Fronius documents.
 
 {% important %}
-Turning a limit **off** does not lift it. The inverter hands control back to the next source in its priority list, which may impose a limit of its own - for example **Dynamic power reduction**.
+Turning a limit **off** does not lift it. The inverter hands control back to the next source in its priority list, which may impose a limit of its own, such as **Dynamic power reduction**.
 
 To override such a source instead, leave the limit **on** and set it to `100 %`. That is an active instruction to run unrestricted, where off is "someone else decides".
 {% endimportant %}
@@ -201,7 +201,7 @@ automation:
           value: 100
 ```
 
-`Battery charge power limiting` has to be on for this to take effect. Discharging is limited by its own setpoint, so the battery still supplies the house while charging is held at `0 %`. Because the limit is held by Home Assistant rather than the inverter, the battery charges normally again if Home Assistant stops running.
+`Battery charge power limiting` has to be on for this to take effect. Discharging is limited by its own setpoint, so the battery still supplies the house while charging is held at `0 %`. If Home Assistant stops running, the inverter keeps the last setpoint and switch state until you change them again.
 
 ## Energy dashboard
 

--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -149,13 +149,21 @@ Modbus is the only interface that lets Home Assistant change settings on the inv
 - `Battery charge power limit` and `Battery discharge power limit`: cap how fast the battery may charge or discharge, as a percentage of its maximum rate.
 - `Battery minimum reserve`: the state of charge the battery is not discharged below.
 
+Each limit has a `switch` that turns it on and off: `Power limiting`, `Battery charge power limiting` and `Battery discharge power limiting`. `Battery grid charging` allows or prevents charging the battery from the grid.
+
 {% important %}
 Writing has to be allowed on the device first. Go to **Communication** > **Modbus** (Gen24, Tauro, and Verto) or **Settings** > **Modbus** (Datamanager), and turn on **Inverter control via Modbus**.
 
 Until it is, the inverter rejects every write, and the integration creates no control entities at all rather than ones that fail when used. Turn it on, then reload the integration.
 {% endimportant %}
 
-The limits are only applied while they are active, so setting one activates it. `100 %` is what "no limit" means to the device: setting a limit back to `100 %` releases it.
+A setpoint is only applied while its switch is on. Setting one while the switch is off stores the value on the inverter without applying it, and turning the switch on then applies what is stored - which is the order Fronius documents.
+
+{% important %}
+Turning a limit **off** does not lift it. The inverter hands control back to the next source in its priority list, which may impose a limit of its own - for example **Dynamic power reduction**.
+
+To override such a source instead, leave the limit **on** and set it to `100 %`. That is an active instruction to run unrestricted, where off is "someone else decides".
+{% endimportant %}
 
 {% note %}
 The inverter decides which control source wins. If **IO control** or **Dynamic power reduction** has a higher priority than Modbus in the DNO Editor, the inverter may refuse or ignore what Home Assistant sends.
@@ -193,7 +201,7 @@ automation:
           value: 100
 ```
 
-Discharging is limited by its own setpoint, so the battery still supplies the house while charging is held at `0 %`. Because the limit is held by Home Assistant rather than the inverter, the battery charges normally again if Home Assistant stops running.
+`Battery charge power limiting` has to be on for this to take effect. Discharging is limited by its own setpoint, so the battery still supplies the house while charging is held at `0 %`. Because the limit is held by Home Assistant rather than the inverter, the battery charges normally again if Home Assistant stops running.
 
 ## Energy dashboard
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the switches added in home-assistant/core#180261, and **corrects two statements** I got wrong in #47615.

The page currently says:

> The limits are only applied while they are active, so setting one activates it. `100 %` is what "no limit" means to the device: setting a limit back to `100 %` releases it.

Both halves are wrong:

- **`100 %` does not release a limit.** Turning a limit off hands control back to the next source in the inverter's priority list, which may impose a limit of its own — Fronius documents that the mode is *"auf die nächste Priorität zurückgestellt (z.B.: Dynamische Leistungsreduzierung)"*. Holding a limit on at `100 %` is an active instruction to run unrestricted, and is how such a source gets overridden. The two are different actions, which is exactly why the switches exist.
- **Setting a setpoint no longer activates it**, now that there is a switch. Writing one while the switch is off stores the value on the inverter without applying it; turning the switch on applies what is stored, which is the order Fronius prescribes.

Also adds the four switches to the entity list, and notes that the battery charge-ceiling automation needs `Battery charge power limiting` on to have any effect.

## Type of change

<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/180261
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
