### PR TITLE
Update info section about Zigbee 3.0 for clarity

### DIFF
--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -969,8 +969,8 @@ The EZSP (EmberZNet Serial Protocol) interface used by Silicon Labs EmberZNet Zi
 
 ### Zigbee 3.0 support
 
-Some coordinators may not support firmware capable of Zigbee 3.0, but they can still be fully functional and feature-complete for your needs.
+Some older Zigbee Coordinator adapters may not support firmware capable of Zigbee 3.0, but are fully backwards compatible with Zigbee 1.2 so they can still be fully functional and feature-complete depending on your needs. The main difference between Zigbee 1.2 and Zigbee 3.0 is higher security/encryption.
 
 {% note %}
-It is up to hardware manufacturers to make such firmware available to them. If your coordinator was shipped with an older firmware version, you may be able to manually upgrade the firmware.
+It is up to hardware manufacturers to make such firmware available Zigbee Coordinator adapters and devices. If your coordinator was shipped with an older firmware version, you may be able to manually upgrade the firmware to a newer version. Recommendation is to check the community forum for more information.
 {% endnote %}

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -969,7 +969,7 @@ The EZSP (EmberZNet Serial Protocol) interface used by Silicon Labs EmberZNet Zi
 
 ### Zigbee 3.0 support
 
-Some older Zigbee Coordinator adapters may not support firmware capable of Zigbee 3.0, but are fully backwards compatible with Zigbee 1.2 so they can still be fully functional and feature-complete depending on your needs. The main difference between Zigbee 1.2 and Zigbee 3.0 is higher security/encryption.
+Some older Zigbee coordinator adapters may not support Zigbee 3.0 firmware, but they can still be fully functional and feature-complete for Zigbee 1.2 networks, depending on your needs. Zigbee 3.0 also introduces improvements such as updated commissioning and stronger security.
 
 {% note %}
 It is up to hardware manufacturers to make such firmware available Zigbee Coordinator adapters and devices. If your coordinator was shipped with an older firmware version, you may be able to manually upgrade the firmware to a newer version. Recommendation is to check the community forum for more information.

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -969,7 +969,7 @@ The EZSP (EmberZNet Serial Protocol) interface used by Silicon Labs EmberZNet Zi
 
 ### Zigbee 3.0 support
 
-Some older Zigbee coordinator adapters may not support Zigbee 3.0 firmware, but they can still be fully functional and feature-complete for Zigbee 1.2 networks, depending on your needs. Zigbee 3.0 also introduces improvements such as updated commissioning and stronger security.
+Some older Zigbee coordinator adapters may not support Zigbee 3.0 firmware, but they can still be fully functional and feature-complete for Zigbee 1.2 networks, depending on your needs. Zigbee 3.0 does however introduce enhancements under-the-hood such as as improved commissioning and stronger security/encryption.
 
 {% note %}
 It is up to hardware manufacturers to make such firmware available Zigbee Coordinator adapters and devices. If your coordinator was shipped with an older firmware version, you may be able to manually upgrade the firmware to a newer version. Recommendation is to check the community forum for more information.


### PR DESCRIPTION
## Proposed change

Clarify compatibility of old Zigbee Coordinator adapters and devices with Zigbee 3.0 and backward compatible with Zigbee 1.2


## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
