### PR TITLE
Document use_stream_for_stills option for TP-Link camera stills

### DIFF
--- a/source/_integrations/tplink.markdown
+++ b/source/_integrations/tplink.markdown
@@ -80,6 +80,16 @@ Camera account password:
 
 {% endconfiguration_basic %}
 
+{% include integrations/option_flow.md %}
+
+{% configuration_basic %}
+
+Use HD stream for still images:
+  description: |
+    Checkbox for Tapo cameras with live view enabled. When enabled, still images (thumbnails and the camera's `camera_proxy`) and the MJPEG fallback use the same high-definition stream that live view uses, instead of the lower-resolution stream used by default. This uses more bandwidth, so it is off by default to keep existing setups unaffected on metered or slow networks. Toggling this option reloads the integration automatically; no restart is required.
+
+{% endconfiguration_basic %}
+
 ## Supported Devices
 
 See [Supported Devices in python-kasa](https://python-kasa.readthedocs.io/en/stable/SUPPORTED.html) for an up to date list that includes hardware and firmware versions.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Documents the new `use_stream_for_stills` option added by the TP-Link camera platform. Previously, still images (thumbnails / `camera_proxy`) and the MJPEG fallback always requested the SD stream (640x360, stream2), while live view already used the HD stream (2560x1440, stream1). The new option, exposed via the integration's options flow (**Settings** > **Devices & services** > the TP-Link entry's Configure button), lets stills and the MJPEG fallback use the same HD stream as live view. It is off by default so existing setups are unaffected, since enabling it uses more bandwidth.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#180356
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
