### PR TITLE
Say which side the Fronius power limit acts on

### DIFF
--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -149,6 +149,10 @@ Modbus is the only interface that lets Home Assistant change settings on the inv
 
 The `AC power limit`, `Battery charge power limit`, and `Battery discharge power limit` setpoints each have a `switch` that turns the limit on and off: `AC power limiting`, `Battery charge power limiting`, and `Battery discharge power limiting`. `Battery grid charging` is a separate switch that allows or prevents charging the battery from the grid.
 
+{% warning %}
+**Dynamic power reduction** is what implements an export cap agreed with your grid operator, because it measures at the grid connection point. The `AC power limit` cannot do that, as it only knows the inverter's own output. If Modbus outranks **Dynamic power reduction**, holding the `AC power limit` on at `100 %` overrides that cap, which may put the installation outside what the grid operator allows.
+{% endwarning %}
+
 {% important %}
 Writing has to be allowed on the device first. Go to **Communication** > **Modbus** (Gen24, Tauro, and Verto) or **Settings** > **Modbus** (Datamanager), and turn on **Inverter control via Modbus**.
 
@@ -157,23 +161,11 @@ Until it is, the inverter rejects every write, and the integration creates no co
 
 A setpoint is only applied while its switch is on. Setting one while the switch is off stores the value on the inverter without applying it, and turning the switch on then applies what is stored, which is the order Fronius documents.
 
-{% important %}
-Turning a limit **off** does not lift it. The inverter hands control back to the next source in its priority list, which may impose a limit of its own, such as **Dynamic power reduction**.
+Turning a limit **off** does not lift it. The inverter hands control back to the next source in its priority list, which may impose a limit of its own, such as **Dynamic power reduction**. To override such a source instead, leave the limit **on** and set it to `100 %`. That is an active instruction to run unrestricted, where off is "someone else decides".
 
-To override such a source instead, leave the limit **on** and set it to `100 %`. That is an active instruction to run unrestricted, where off is "someone else decides".
-{% endimportant %}
-
-{% note %}
 The inverter decides which control source wins. If **IO control** or **Dynamic power reduction** has a higher priority than Modbus in the DNO Editor, the inverter may refuse or ignore what Home Assistant sends.
-{% endnote %}
 
-{% warning %}
-The reverse is worth knowing too. **Dynamic power reduction** is what implements an export cap agreed with your grid operator, because it measures at the grid connection point. The `AC power limit` cannot do that, as it only knows the inverter's own output. If Modbus outranks it, holding the limit on at `100 %` overrides that cap, which may put the installation outside what the grid operator allows.
-{% endwarning %}
-
-{% note %}
 Depending on the inverter's firmware, an `AC power limit` below `10 %` may force the inverter into standby, stopping feed-in altogether rather than throttling it.
-{% endnote %}
 
 On a hybrid inverter, the `AC power limit` does not restrict **charging** the battery. Charging is not AC output. Surplus photovoltaic power goes into the battery instead of being wasted, which makes the limit useful for peak shaving. **Discharging** does count against it, because that power leaves the inverter on AC.
 

--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -143,11 +143,11 @@ These entities are added per inverter and updated every minute:
 
 Modbus is the only interface that lets Home Assistant change settings on the inverter; the Solar API is read-only. These setpoints are added as `number` entities, and appear under **Configuration** on the inverter's device page:
 
-- `Power limit`: caps the inverter's output, as a percentage of its nominal power output.
+- `AC power limit`: caps the power the inverter puts out on AC, as a percentage of its nominal power output. This is **not** a feed-in limit - everything the inverter delivers counts against it, whether it is used in the house or exported.
 - `Battery charge power limit` and `Battery discharge power limit`: cap how fast the battery may charge or discharge, as a percentage of its maximum rate.
 - `Battery minimum reserve`: the state of charge the battery is not discharged below.
 
-The `Power limit`, `Battery charge power limit`, and `Battery discharge power limit` setpoints each have a `switch` that turns the limit on and off: `Power limiting`, `Battery charge power limiting`, and `Battery discharge power limiting`. `Battery grid charging` is a separate switch that allows or prevents charging the battery from the grid.
+The `AC power limit`, `Battery charge power limit`, and `Battery discharge power limit` setpoints each have a `switch` that turns the limit on and off: `AC power limiting`, `Battery charge power limiting`, and `Battery discharge power limiting`. `Battery grid charging` is a separate switch that allows or prevents charging the battery from the grid.
 
 {% important %}
 Writing has to be allowed on the device first. Go to **Communication** > **Modbus** (Gen24, Tauro, and Verto) or **Settings** > **Modbus** (Datamanager), and turn on **Inverter control via Modbus**.
@@ -165,6 +165,14 @@ To override such a source instead, leave the limit **on** and set it to `100 %`.
 
 {% note %}
 The inverter decides which control source wins. If **IO control** or **Dynamic power reduction** has a higher priority than Modbus in the DNO Editor, the inverter may refuse or ignore what Home Assistant sends.
+{% endnote %}
+
+{% warning %}
+The reverse is worth knowing too. **Dynamic power reduction** is what implements an export cap agreed with your grid operator, because it measures at the grid connection point - the `AC power limit` cannot, as it only knows the inverter's own output. If Modbus outranks it, holding the limit on at `100 %` overrides that cap, which may put the installation outside what the grid operator allows.
+{% endwarning %}
+
+{% note %}
+Depending on the inverter's firmware, an `AC power limit` below `10 %` may force the inverter into standby, stopping feed-in altogether rather than throttling it.
 {% endnote %}
 
 #### The battery limits are power, not a charge level

--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -143,7 +143,7 @@ These entities are added per inverter and updated every minute:
 
 Modbus is the only interface that lets Home Assistant change settings on the inverter; the Solar API is read-only. These setpoints are added as `number` entities, and appear under **Configuration** on the inverter's device page:
 
-- `AC power limit`: caps the power the inverter puts out on AC, as a percentage of its nominal power output. This is **not** a feed-in limit. Everything the inverter delivers counts against it, whether it is used in the house or exported to the grid.
+- `AC power limit`: caps the power the inverter puts out on AC, as a percentage of its nominal power output. This is _not_ a feed-in limit. Everything the inverter delivers counts against it, whether it is used in the house or exported to the grid.
 - `Battery charge power limit` and `Battery discharge power limit`: cap how fast the battery may charge or discharge, as a percentage of its maximum rate.
 - `Battery minimum reserve`: the state of charge the battery is not discharged below.
 

--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -175,7 +175,7 @@ The reverse is worth knowing too. **Dynamic power reduction** is what implements
 Depending on the inverter's firmware, an `AC power limit` below `10 %` may force the inverter into standby, stopping feed-in altogether rather than throttling it.
 {% endnote %}
 
-On a hybrid inverter, the `AC power limit` does not restrict **charging** the battery. Charging is not AC output, so surplus photovoltaic power that the limit holds back goes into the battery instead of being curtailed, which is what makes the limit useful for peak shaving. **Discharging** does count against it, because that power leaves the inverter on AC.
+On a hybrid inverter, the `AC power limit` does not restrict **charging** the battery. Charging is not AC output. Surplus photovoltaic power goes into the battery instead of being wasted, which makes the limit useful for peak shaving. **Discharging** does count against it, because that power leaves the inverter on AC.
 
 #### The battery limits are power, not a charge level
 

--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -143,7 +143,7 @@ These entities are added per inverter and updated every minute:
 
 Modbus is the only interface that lets Home Assistant change settings on the inverter; the Solar API is read-only. These setpoints are added as `number` entities, and appear under **Configuration** on the inverter's device page:
 
-- `AC power limit`: caps the power the inverter puts out on AC, as a percentage of its nominal power output. This is **not** a feed-in limit - everything the inverter delivers counts against it, whether it is used in the house or exported.
+- `AC power limit`: caps the power the inverter puts out on AC, as a percentage of its nominal power output. This is **not** a feed-in limit. Everything the inverter delivers counts against it, whether it is used in the house or exported to the grid.
 - `Battery charge power limit` and `Battery discharge power limit`: cap how fast the battery may charge or discharge, as a percentage of its maximum rate.
 - `Battery minimum reserve`: the state of charge the battery is not discharged below.
 
@@ -168,12 +168,14 @@ The inverter decides which control source wins. If **IO control** or **Dynamic p
 {% endnote %}
 
 {% warning %}
-The reverse is worth knowing too. **Dynamic power reduction** is what implements an export cap agreed with your grid operator, because it measures at the grid connection point - the `AC power limit` cannot, as it only knows the inverter's own output. If Modbus outranks it, holding the limit on at `100 %` overrides that cap, which may put the installation outside what the grid operator allows.
+The reverse is worth knowing too. **Dynamic power reduction** is what implements an export cap agreed with your grid operator, because it measures at the grid connection point. The `AC power limit` cannot do that, as it only knows the inverter's own output. If Modbus outranks it, holding the limit on at `100 %` overrides that cap, which may put the installation outside what the grid operator allows.
 {% endwarning %}
 
 {% note %}
 Depending on the inverter's firmware, an `AC power limit` below `10 %` may force the inverter into standby, stopping feed-in altogether rather than throttling it.
 {% endnote %}
+
+On a hybrid inverter, the `AC power limit` does not restrict **charging** the battery. Charging is not AC output, so surplus photovoltaic power that the limit holds back goes into the battery instead of being curtailed, which is what makes the limit useful for peak shaving. **Discharging** does count against it, because that power leaves the inverter on AC.
 
 #### The battery limits are power, not a charge level
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Follows the rename in home-assistant/core#180364 (`Power limit` → `AC power limit`, `Power limiting` → `AC power limiting`), and adds three things the entity cannot convey on its own.

**It is not a feed-in limit.** `WMaxLimPct` caps what the inverter puts out on AC, whatever that then serves — at a 6 kW cap with 4 kW of household load, 2 kW is exported; with 7 kW of load nothing is exported and the cap still applies. That is easy to read the other way round, so the entity description now says so.

**Overriding *Dynamic power reduction* has consequences.** The page already explains that holding a limit on at `100 %` overrides a lower-priority source. What it did not say is that *Dynamic power reduction* is precisely what implements an export cap agreed with a grid operator — it measures at the grid connection point, which the `AC power limit` cannot. Overriding it may put an installation outside what the operator allows, so that is now a warning.

**Values below `10 %` can stop feed-in entirely.** Fronius documents that, depending on firmware, the inverter may go into standby rather than throttle.

## Type of change

<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/180364
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

