### PR TITLE
Document the image_upload media selector option

### DIFF
--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -1223,12 +1223,39 @@ media:
     - image/*
 ```
 
+When `accept` is set, you can also set `image_upload` to let the user upload an
+image from their device instead of browsing the media that is already available
+to Home Assistant. The uploaded image is stored by Home Assistant and selected
+automatically. Combine it with `clearable` so the user can clear their choice
+and upload a different image.
+
+```yaml
+media:
+  accept:
+    - image/*
+  image_upload: true
+  clearable: true
+```
+
 {% configuration media %}
 accept:
   description: >
     List of media types the user is allowed to select.
   type: list
   required: false
+image_upload:
+  description: >
+    Show an upload field instead of a media browser, allowing the user to upload
+    an image from their device. Requires a non-empty `accept`.
+  type: boolean
+  required: false
+  default: false
+clearable:
+  description: >
+    Show a button that clears the selected media.
+  type: boolean
+  required: false
+  default: false
 {% endconfiguration %}
 
 The output of the media selector is a mapping with information about

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -1226,15 +1226,13 @@ media:
 When `accept` is set, you can also set `image_upload` to let the user upload an
 image from their device instead of browsing the media that is already available
 to Home Assistant. The uploaded image is stored by Home Assistant and selected
-automatically. Combine it with `clearable` so the user can clear their choice
-and upload a different image.
+automatically, and the user can clear their choice to upload a different image.
 
 ```yaml
 media:
   accept:
     - image/*
   image_upload: true
-  clearable: true
 ```
 
 {% configuration media %}
@@ -1247,12 +1245,6 @@ image_upload:
   description: >
     Show an upload field instead of a media browser, allowing the user to upload
     an image from their device. Requires a non-empty `accept`.
-  type: boolean
-  required: false
-  default: false
-clearable:
-  description: >
-    Show a button that clears the selected media.
   type: boolean
   required: false
   default: false


### PR DESCRIPTION
## Proposed change

Documents the `image_upload` media selector option, which
home-assistant/core#180452 exposes to YAML.

`image_upload` turns the field into an upload area, so a blueprint input or an
action field that takes an image can offer "upload from this device" rather than
only browsing what is already on the server. It requires a non-empty `accept`,
which is why the example and the description both show it paired with `accept`.

Targets `next` because the core change ships in a future release.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/180452
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

