### PR TITLE
Document the Hikvision event platform and sensor availability

### DIFF
--- a/source/_integrations/hikvision.markdown
+++ b/source/_integrations/hikvision.markdown
@@ -141,16 +141,28 @@ Supported event types are:
 - Exiting Region
 - Entering Region
 
-### State attributes
-
-Each binary sensor reports these attributes:
-
-- `last_tripped_time`: when the event last changed to "on".
-- `detection_target`: what the device classified as the cause of the event, for example `human` or `vehicle`. Only smart events carry a classification, so this attribute is only present when the device sends one. Which events include it, and which values they use, depends on the device model and firmware.
-
 ### Availability
 
 The binary sensors follow the connection to your device's event stream. While the stream is down, for example because the device is powered off or unreachable on your network, the sensors show as unavailable instead of keeping their last state. They return to reporting "off" or "on" once the connection is restored.
+
+## Event
+
+Some Hikvision devices classify what triggered a smart event, so you can tell a person from a passing car. The integration creates an event entity for each of these event types on each channel:
+
+- Motion
+- Line crossing
+- Field detection
+
+Each event entity reports one of these event types when it triggers:
+
+- `human`
+- `pet`
+- `vehicle`
+- `triggered`, when the device does not say what caused the event
+
+Whether your device classifies events, and which of these values it uses, depends on the model and the firmware. Devices that do not classify report `triggered` every time.
+
+Use these entities when you want an automation to react only to a particular kind of trigger, for example to send a notification for a person crossing a line but not for a vehicle. Use the binary sensors instead when you want to know whether an event is currently active.
 
 ## Removing the integration
 

--- a/source/_integrations/hikvision.markdown
+++ b/source/_integrations/hikvision.markdown
@@ -19,7 +19,7 @@ ha_config_flow: true
 
 The **Hikvision** {% term integration %} connects your [Hikvision IP Camera or <abbr title="Network Video Recorder">NVR</abbr>](https://www.hikvision.com/) to Home Assistant, providing:
 
-- Binary sensors that parse the event stream and present camera/NVR events as sensors with either an "off" or "on" state
+- Binary sensors that parse the event stream and present camera/NVR events as sensors with either an "off" or "on" state, and become unavailable while the event stream is disconnected
 - Camera entities with <abbr title="Real Time Streaming Protocol">RTSP</abbr> streaming and <abbr title="Hypertext Transfer Protocol">HTTP</abbr> snapshot capabilities
 
 The platform will automatically add all sensors to Home Assistant that are
@@ -140,6 +140,17 @@ Supported event types are:
 - Recording Failure
 - Exiting Region
 - Entering Region
+
+### State attributes
+
+Each binary sensor reports these attributes:
+
+- `last_tripped_time`: when the event last changed to "on".
+- `detection_target`: what the device classified as the cause of the event, for example `human` or `vehicle`. Only smart events carry a classification, so this attribute is only present when the device sends one. Which events include it, and which values they use, depends on the device model and firmware.
+
+### Availability
+
+The binary sensors follow the connection to your device's event stream. While the stream is down, for example because the device is powered off or unreachable on your network, the sensors show as unavailable instead of keeping their last state. They return to reporting "off" or "on" once the connection is restored.
 
 ## Removing the integration
 

--- a/source/_integrations/hikvision.markdown
+++ b/source/_integrations/hikvision.markdown
@@ -148,7 +148,7 @@ The binary sensors follow the connection to your device's event stream. While th
 
 ## Event
 
-Some Hikvision devices classify what triggered a smart event, so you can tell a person from a passing car. The integration creates an event entity for each of these event types on each channel:
+Some Hikvision devices classify what triggered a smart event, so you can tell a person from a passing car. The integration creates an event entity for each of these kinds of events on each channel:
 
 - Motion
 - Line crossing

--- a/source/_integrations/hikvision.markdown
+++ b/source/_integrations/hikvision.markdown
@@ -13,6 +13,7 @@ ha_domain: hikvision
 ha_platforms:
   - binary_sensor
   - camera
+  - event
 ha_integration_type: device
 ha_config_flow: true
 ---

--- a/source/_integrations/hikvision.markdown
+++ b/source/_integrations/hikvision.markdown
@@ -4,6 +4,7 @@ description: Instructions on how to set up Hikvision cameras and NVRs within Hom
 ha_category:
   - Binary sensor
   - Camera
+  - Event
 ha_release: 0.35
 ha_iot_class: Local Push
 ha_codeowners:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->



Documents two additions to the Hikvision integration:

- **Event platform** (home-assistant/core#180841). Hikvision smart events carry the classification that triggered them, such as `human` or `vehicle`. Each of the event types that can carry one now gets an event entity whose event type is that classification. The page previously did not mention it at all.
- **Availability** (home-assistant/core#180225). The binary sensors now follow the device's event stream and show as unavailable while it is disconnected, instead of holding their last state indefinitely. The page previously said the sensors have only an "off" or "on" state.

An earlier revision of this pull request documented the classification as a `detection_target` state attribute. Following review on home-assistant/core#180225 it became an event entity instead, and this page has been updated to match.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#180841, home-assistant/core#180225
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

