### PR TITLE
Document Schlage access code actions

### DIFF
--- a/source/_actions/schlage.add_code.markdown
+++ b/source/_actions/schlage.add_code.markdown
@@ -29,18 +29,18 @@ To add a PIN code from an automation or a script:
 
 {% options_ui %}
 PIN name:
-  description: Name for PIN code. Must be case insensitively unique to the lock.
+description: Name for PIN code. Must be case insensitively unique to the lock.
 PIN code:
-  description: The PIN code to add. Must be unique to the lock and be between 4 and 8 digits long.
+description: The PIN code to add. Must be unique to the lock and be between 4 and 8 digits long.
 Notify when PIN is used:
-  description: Whether the native Schlage notification should be sent when this PIN is used. On by default.
-  required: false
+description: Whether the native Schlage notification should be sent when this PIN is used. On by default.
+required: false
 Start time:
-  description: When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required.
-  required: false
+description: When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required.
+required: false
 End time:
-  description: When this PIN stops working. Required together with the start time; leaving both empty creates a permanent PIN.
-  required: false
+description: When this PIN stops working. Required together with the start time; leaving both empty creates a permanent PIN.
+required: false
 {% endoptions_ui %}
 
 ### Temporary vs. permanent PINs
@@ -57,52 +57,52 @@ In YAML, refer to this action as `schlage.add_code`. A basic example looks like 
 
 {% example %}
 action: |
-  action: schlage.add_code
-  target:
-    entity_id: lock.front_door
-  data:
-    name: Example Person
-    code: "3333"
+action: schlage.add_code
+target:
+entity_id: lock.front_door
+data:
+name: Example Person
+code: "3333"
 {% endexample %}
 
 To add a temporary PIN in YAML:
 
 {% example %}
 action: |
-  action: schlage.add_code
-  target:
-    entity_id: lock.front_door
-  data:
-    name: Guest
-    code: "1234"
-    start_datetime: "2026-09-01T15:00:00"
-    end_datetime: "2026-09-01T16:00:00"
+action: schlage.add_code
+target:
+entity_id: lock.front_door
+data:
+name: Guest
+code: "1234"
+start_datetime: "2026-09-01T15:00:00"
+end_datetime: "2026-09-01T16:00:00"
 {% endexample %}
 
 ### Options in YAML
 
 {% options_yaml %}
 name:
-  description: Name for PIN code. Must be case insensitively unique to the lock.
-  required: true
-  type: string
+description: Name for PIN code. Must be case insensitively unique to the lock.
+required: true
+type: string
 code:
-  description: The PIN code to add. Must be unique to the lock and be between 4 and 8 digits long.
-  required: true
-  type: string
+description: The PIN code to add. Must be unique to the lock and be between 4 and 8 digits long.
+required: true
+type: string
 notify_on_use:
-  description: Whether the native Schlage notification should be sent when this PIN is used.
-  required: false
-  type: boolean
-  default: true
+description: Whether the native Schlage notification should be sent when this PIN is used.
+required: false
+type: boolean
+default: true
 start_datetime:
-  description: When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required.
-  required: false
-  type: string
+description: When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required.
+required: false
+type: string
 end_datetime:
-  description: When this PIN stops working. Required together with the start time; leaving both empty creates a permanent PIN.
-  required: false
-  type: string
+description: When this PIN stops working. Required together with the start time; leaving both empty creates a permanent PIN.
+required: false
+type: string
 {% endoptions_yaml %}
 
 {% include actions/targets.md domain="lock" %}

--- a/source/_actions/schlage.add_code.markdown
+++ b/source/_actions/schlage.add_code.markdown
@@ -29,11 +29,11 @@ To add a PIN code from an automation or a script:
 
 {% options_ui %}
 PIN name:
-  description: A name for the PIN code. Must be unique to the lock, regardless of capitalization.
+  description: Name for PIN code. Must be case insensitively unique to the lock.
 PIN code:
-  description: The PIN code to add. Must be unique to the lock and between 4 and 8 digits long.
+  description: The PIN code to add. Must be unique to the lock and be between 4 and 8 digits long.
 Notify when PIN is used:
-  description: Send the native Schlage notification when this PIN is used. On by default.
+  description: Whether the native Schlage notification should be sent when this PIN is used. On by default.
   required: false
 Start time:
   description: When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required.
@@ -83,15 +83,15 @@ action: |
 
 {% options_yaml %}
 name:
-  description: A name for the PIN code. Must be unique to the lock, regardless of capitalization.
+  description: Name for PIN code. Must be case insensitively unique to the lock.
   required: true
   type: string
 code:
-  description: The PIN code to add. Must be unique to the lock and between 4 and 8 digits long.
+  description: The PIN code to add. Must be unique to the lock and be between 4 and 8 digits long.
   required: true
   type: string
 notify_on_use:
-  description: Send the native Schlage notification when this PIN is used.
+  description: Whether the native Schlage notification should be sent when this PIN is used.
   required: false
   type: boolean
   default: true

--- a/source/_actions/schlage.add_code.markdown
+++ b/source/_actions/schlage.add_code.markdown
@@ -6,9 +6,10 @@ description: "Adds a PIN code to a Schlage lock."
 related_actions:
   - schlage.delete_code
   - schlage.get_codes
+  - schlage.update_code
 ---
 
-Use this action to add a new PIN code to a Schlage lock, for example to give a guest or family member their own code.
+Use this action to add a new PIN code to a Schlage lock, for example to give a guest or family member their own code. You can create a permanent PIN or a temporary PIN that is only active during a specific time window.
 
 {% include actions/ui_header.md %}
 
@@ -21,7 +22,8 @@ To add a PIN code from an automation or a script:
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Schlage lock.
 6. From the actions shown for that target, select **Schlage: Add PIN code**.
 7. Enter the **PIN name** and the **PIN code**.
-8. Select **Save**.
+8. To create a temporary PIN, enter a **Start time** and **End time**. Leave both empty for a permanent PIN.
+9. Select **Save**.
 
 ### Options in the UI
 
@@ -33,7 +35,21 @@ PIN code:
 Notify when PIN is used:
   description: Send the native Schlage notification when this PIN is used. On by default.
   required: false
+Start time:
+  description: When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required.
+  required: false
+End time:
+  description: When this PIN stops working. Required together with the start time; leaving both empty creates a permanent PIN.
+  required: false
 {% endoptions_ui %}
+
+### Temporary vs. permanent PINs
+
+When you add a PIN without a start or end time, it becomes a permanent PIN that works until you delete it. If you provide both a start time and an end time, the PIN becomes a temporary PIN that is only active during that window.
+
+You must provide both times together or leave both empty. If you provide only one, you get an error: _Start and end times are required together. Provide both to create a temporary PIN, or neither for a permanent one._
+
+The start time must be before the end time. If the start time is the same as or after the end time, you get an error: _Start time must be before end time._
 
 {% include actions/yaml_header.md %}
 
@@ -47,6 +63,20 @@ action: |
   data:
     name: Example Person
     code: "3333"
+{% endexample %}
+
+To add a temporary PIN in YAML:
+
+{% example %}
+action: |
+  action: schlage.add_code
+  target:
+    entity_id: lock.front_door
+  data:
+    name: Guest
+    code: "1234"
+    start_datetime: "2026-09-01T15:00:00"
+    end_datetime: "2026-09-01T16:00:00"
 {% endexample %}
 
 ### Options in YAML
@@ -65,6 +95,14 @@ notify_on_use:
   required: false
   type: boolean
   default: true
+start_datetime:
+  description: When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required.
+  required: false
+  type: string
+end_datetime:
+  description: When this PIN stops working. Required together with the start time; leaving both empty creates a permanent PIN.
+  required: false
+  type: string
 {% endoptions_yaml %}
 
 {% include actions/targets.md domain="lock" %}

--- a/source/_actions/schlage.delete_code.markdown
+++ b/source/_actions/schlage.delete_code.markdown
@@ -30,10 +30,10 @@ To delete a PIN code from an automation or a script:
 
 {% options_ui %}
 PIN name:
-  description: The name of the PIN code to delete. The name is matched regardless of capitalization.
+  description: Name of PIN code to delete. Either name or access_code_id is required.
   required: false
 Access code ID:
-  description: The access code ID to delete. More stable than the name. Either name or access_code_id is required.
+  description: Access code ID to delete (more stable than name). Either name or access_code_id is required.
   required: false
 {% endoptions_ui %}
 
@@ -65,11 +65,11 @@ action: |
 
 {% options_yaml %}
 name:
-  description: The name of the PIN code to delete. The name is matched regardless of capitalization.
+  description: Name of PIN code to delete. Either name or access_code_id is required.
   required: false
   type: string
 access_code_id:
-  description: The access code ID to delete. More stable than the name. Either name or access_code_id is required.
+  description: Access code ID to delete (more stable than name). Either name or access_code_id is required.
   required: false
   type: string
 {% endoptions_yaml %}

--- a/source/_actions/schlage.delete_code.markdown
+++ b/source/_actions/schlage.delete_code.markdown
@@ -6,9 +6,12 @@ description: "Deletes a PIN code from a Schlage lock."
 related_actions:
   - schlage.add_code
   - schlage.get_codes
+  - schlage.update_code
 ---
 
 Use this action to delete a PIN code from a Schlage lock, for example to revoke access for a guest who no longer needs it.
+
+You can identify the PIN by its name or by its access code ID. Do not provide both — if you do, you get an error: _Provide either name or access_code_id, not both._
 
 {% include actions/ui_header.md %}
 
@@ -20,7 +23,7 @@ To delete a PIN code from an automation or a script:
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Schlage lock.
 6. From the actions shown for that target, select **Schlage: Delete PIN code**.
-7. Enter the **PIN name** of the code to delete.
+7. Enter the **PIN name** or **Access code ID** of the code to delete.
 8. Select **Save**.
 
 ### Options in the UI
@@ -28,6 +31,10 @@ To delete a PIN code from an automation or a script:
 {% options_ui %}
 PIN name:
   description: The name of the PIN code to delete. The name is matched regardless of capitalization.
+  required: false
+Access code ID:
+  description: The access code ID to delete. More stable than the name. Either name or access_code_id is required.
+  required: false
 {% endoptions_ui %}
 
 {% include actions/yaml_header.md %}
@@ -43,12 +50,27 @@ action: |
     name: Example Person
 {% endexample %}
 
+To delete by access code ID:
+
+{% example %}
+action: |
+  action: schlage.delete_code
+  target:
+    entity_id: lock.front_door
+  data:
+    access_code_id: "93ab517c-0000-0000-0000-000000000000"
+{% endexample %}
+
 ### Options in YAML
 
 {% options_yaml %}
 name:
   description: The name of the PIN code to delete. The name is matched regardless of capitalization.
-  required: true
+  required: false
+  type: string
+access_code_id:
+  description: The access code ID to delete. More stable than the name. Either name or access_code_id is required.
+  required: false
   type: string
 {% endoptions_yaml %}
 

--- a/source/_actions/schlage.delete_code.markdown
+++ b/source/_actions/schlage.delete_code.markdown
@@ -30,11 +30,11 @@ To delete a PIN code from an automation or a script:
 
 {% options_ui %}
 PIN name:
-  description: Name of PIN code to delete. Either name or access_code_id is required.
-  required: false
+description: Name of PIN code to delete. Either name or access_code_id is required.
+required: false
 Access code ID:
-  description: Access code ID to delete (more stable than name). Either name or access_code_id is required.
-  required: false
+description: Access code ID to delete (more stable than name). Either name or access_code_id is required.
+required: false
 {% endoptions_ui %}
 
 {% include actions/yaml_header.md %}
@@ -43,35 +43,35 @@ In YAML, refer to this action as `schlage.delete_code`. A basic example looks li
 
 {% example %}
 action: |
-  action: schlage.delete_code
-  target:
-    entity_id: lock.front_door
-  data:
-    name: Example Person
+action: schlage.delete_code
+target:
+entity_id: lock.front_door
+data:
+name: Example Person
 {% endexample %}
 
 To delete by access code ID:
 
 {% example %}
 action: |
-  action: schlage.delete_code
-  target:
-    entity_id: lock.front_door
-  data:
-    access_code_id: "93ab517c-0000-0000-0000-000000000000"
+action: schlage.delete_code
+target:
+entity_id: lock.front_door
+data:
+access_code_id: "93ab517c-0000-0000-0000-000000000000"
 {% endexample %}
 
 ### Options in YAML
 
 {% options_yaml %}
 name:
-  description: Name of PIN code to delete. Either name or access_code_id is required.
-  required: false
-  type: string
+description: Name of PIN code to delete. Either name or access_code_id is required.
+required: false
+type: string
 access_code_id:
-  description: Access code ID to delete (more stable than name). Either name or access_code_id is required.
-  required: false
-  type: string
+description: Access code ID to delete (more stable than name). Either name or access_code_id is required.
+required: false
+type: string
 {% endoptions_yaml %}
 
 {% include actions/targets.md domain="lock" %}

--- a/source/_actions/schlage.get_codes.markdown
+++ b/source/_actions/schlage.get_codes.markdown
@@ -6,6 +6,7 @@ description: "Returns all PIN codes stored on a Schlage lock."
 related_actions:
   - schlage.add_code
   - schlage.delete_code
+  - schlage.update_code
 ---
 
 Use this action to retrieve all PIN codes stored on a Schlage lock. For example, you can use it to check which codes are set before adding or removing one.
@@ -50,17 +51,85 @@ This action has no additional YAML options beyond the target.
 
 ## Response data
 
-The action returns the result for each targeted lock, keyed by entity ID. For each lock, it returns a mapping of the stored codes, keyed by a unique code identifier. Each code has a `name` and the `code` itself.
+The action returns the result for each targeted lock, keyed by entity ID. For each lock, it returns a mapping of the stored codes, keyed by a unique code identifier. Each code has the following fields:
+
+- **name**: The name of the PIN code.
+- **code**: The PIN value.
+- **access_code_id**: A unique access code identifier.
+- **notify_on_use**: Whether the native Schlage notification is sent when this PIN is used.
+- **disabled**: Whether the PIN code is disabled.
+- **schedule**: The schedule for this PIN, or `null` for permanent PINs.
 
 ```yaml
 lock.front_door:
   93ab517c-0000-0000-0000-000000000000:
     name: Example Person
     code: "3333"
+    access_code_id: "93ab517c-0000-0000-0000-000000000000"
+    notify_on_use: true
+    disabled: false
+    schedule: null
   82958b77-0000-0000-0000-000000000000:
-    name: Example person 2
-    code: "2222"
+    name: Guest
+    code: "1234"
+    access_code_id: "82958b77-0000-0000-0000-000000000000"
+    notify_on_use: true
+    disabled: false
+    schedule:
+      type: temporary
+      start_datetime: "2026-09-01T15:00:00+00:00"
+      end_datetime: "2026-09-01T16:00:00+00:00"
 ```
+
+### Schedule formats
+
+The `schedule` field describes when a PIN is active. It is `null` for permanent PINs, or one of the following shapes:
+
+**Temporary** — set via the `start_datetime` and `end_datetime` fields:
+
+```json
+{
+  "type": "temporary",
+  "start_datetime": "2026-09-01T15:00:00+00:00",
+  "end_datetime": "2026-09-01T16:00:00+00:00"
+}
+```
+
+**Recurring** — a single recurring schedule set through the Schlage app:
+
+```json
+{
+  "type": "recurring",
+  "days_of_week": {
+    "sun": false, "mon": true, "tue": true, "wed": true,
+    "thu": true, "fri": true, "sat": false
+  },
+  "start_hour": 8,
+  "start_minute": 0,
+  "end_hour": 17,
+  "end_minute": 0
+}
+```
+
+**Recurring multi** — two time windows, also set through the Schlage app:
+
+```json
+{
+  "type": "recurring_multi",
+  "windows": [
+    {
+      "days_of_week": { "sun": false, "mon": true, "tue": true, "wed": true, "thu": true, "fri": true, "sat": false },
+      "start_hour": 8, "start_minute": 0, "end_hour": 12, "end_minute": 0
+    },
+    {
+      "days_of_week": { "sun": false, "mon": true, "tue": true, "wed": true, "thu": true, "fri": true, "sat": false },
+      "start_hour": 13, "start_minute": 0, "end_hour": 17, "end_minute": 0
+    }
+  ]
+}
+```
+
+Recurring and recurring_multi schedules are configured through the Schlage app and cannot be set through Home Assistant service actions.
 
 {% include actions/try_it.md %}
 

--- a/source/_actions/schlage.get_codes.markdown
+++ b/source/_actions/schlage.get_codes.markdown
@@ -35,10 +35,10 @@ In YAML, refer to this action as `schlage.get_codes`. A basic example looks like
 
 {% example %}
 action: |
-  action: schlage.get_codes
-  target:
-    entity_id: lock.front_door
-  response_variable: codes
+action: schlage.get_codes
+target:
+entity_id: lock.front_door
+response_variable: codes
 {% endexample %}
 
 This stores the PIN codes of `lock.front_door` in a variable named `codes`.
@@ -101,8 +101,13 @@ The `schedule` field describes when a PIN is active. It is `null` for permanent 
 {
   "type": "recurring",
   "days_of_week": {
-    "sun": false, "mon": true, "tue": true, "wed": true,
-    "thu": true, "fri": true, "sat": false
+    "sun": false,
+    "mon": true,
+    "tue": true,
+    "wed": true,
+    "thu": true,
+    "fri": true,
+    "sat": false
   },
   "start_hour": 8,
   "start_minute": 0,
@@ -118,12 +123,34 @@ The `schedule` field describes when a PIN is active. It is `null` for permanent 
   "type": "recurring_multi",
   "windows": [
     {
-      "days_of_week": { "sun": false, "mon": true, "tue": true, "wed": true, "thu": true, "fri": true, "sat": false },
-      "start_hour": 8, "start_minute": 0, "end_hour": 12, "end_minute": 0
+      "days_of_week": {
+        "sun": false,
+        "mon": true,
+        "tue": true,
+        "wed": true,
+        "thu": true,
+        "fri": true,
+        "sat": false
+      },
+      "start_hour": 8,
+      "start_minute": 0,
+      "end_hour": 12,
+      "end_minute": 0
     },
     {
-      "days_of_week": { "sun": false, "mon": true, "tue": true, "wed": true, "thu": true, "fri": true, "sat": false },
-      "start_hour": 13, "start_minute": 0, "end_hour": 17, "end_minute": 0
+      "days_of_week": {
+        "sun": false,
+        "mon": true,
+        "tue": true,
+        "wed": true,
+        "thu": true,
+        "fri": true,
+        "sat": false
+      },
+      "start_hour": 13,
+      "start_minute": 0,
+      "end_hour": 17,
+      "end_minute": 0
     }
   ]
 }

--- a/source/_actions/schlage.update_code.markdown
+++ b/source/_actions/schlage.update_code.markdown
@@ -1,0 +1,125 @@
+---
+title: "Update a PIN code on a Schlage lock"
+action: schlage.update_code
+domain: schlage
+description: "Updates an existing PIN code on a Schlage lock."
+related_actions:
+  - schlage.add_code
+  - schlage.delete_code
+  - schlage.get_codes
+---
+
+Use this action to update an existing PIN code on a Schlage lock. You can change the name, PIN value, notification settings, or schedule of a code that is already on the lock.
+
+{% include actions/ui_header.md %}
+
+To update a PIN code from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Schlage lock.
+6. From the actions shown for that target, select **Schlage: Update a PIN code**.
+7. Enter the **Access code ID** of the code you want to update. You can get IDs from the **Schlage: Get PIN codes** action.
+8. Configure the fields you want to change. Leave any field you don't want to change empty.
+9. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Access code ID:
+  description: The unique ID of the access code to update. You can get IDs from the **Schlage: Get PIN codes** action.
+PIN name:
+  description: New name for the PIN code. Must be unique to the lock, regardless of capitalization.
+  required: false
+PIN code:
+  description: New PIN code value. Must be unique to the lock and between 4 and 8 digits long.
+  required: false
+Notify when PIN is used:
+  description: Send the native Schlage notification when this PIN is used.
+  required: false
+Disabled:
+  description: Whether the PIN code should be disabled.
+  required: false
+Start time:
+  description: When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required. Omitting both preserves the code's existing schedule.
+  required: false
+End time:
+  description: When this PIN stops working. Required together with the start time. Omitting both preserves the code's existing schedule.
+  required: false
+{% endoptions_ui %}
+
+### Preserving the existing schedule
+
+When you update a PIN code, you can leave the start and end time fields empty to keep the code's existing schedule unchanged. If you provide only one of the two time fields, you get an error: _Start and end times are required together. Provide both to create a temporary PIN, or neither for a permanent one._
+
+If you provide both a start time and an end time, the new times replace the existing schedule. The start time must be before the end time. If the start time is the same as or after the end time, you get an error: _Start time must be before end time._
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `schlage.update_code`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: schlage.update_code
+  target:
+    entity_id: lock.front_door
+  data:
+    access_code_id: "abc123"
+    name: Updated Name
+{% endexample %}
+
+To change a PIN's schedule in YAML:
+
+{% example %}
+action: |
+  action: schlage.update_code
+  target:
+    entity_id: lock.front_door
+  data:
+    access_code_id: "abc123"
+    start_datetime: "2026-09-01T15:00:00"
+    end_datetime: "2026-09-01T16:00:00"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+access_code_id:
+  description: The unique ID of the access code to update.
+  required: true
+  type: string
+name:
+  description: New name for the PIN code. Must be unique to the lock, regardless of capitalization.
+  required: false
+  type: string
+code:
+  description: New PIN code value. Must be unique to the lock and between 4 and 8 digits long.
+  required: false
+  type: string
+notify_on_use:
+  description: Send the native Schlage notification when this PIN is used.
+  required: false
+  type: boolean
+disabled:
+  description: Whether the PIN code should be disabled.
+  required: false
+  type: boolean
+start_datetime:
+  description: When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required. Omitting both preserves the code's existing schedule.
+  required: false
+  type: string
+end_datetime:
+  description: When this PIN stops working. Required together with the start time. Omitting both preserves the code's existing schedule.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="lock" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/schlage.update_code.markdown
+++ b/source/_actions/schlage.update_code.markdown
@@ -31,13 +31,13 @@ To update a PIN code from an automation or a script:
 Access code ID:
   description: The unique ID of the access code to update. You can get IDs from the **Schlage: Get PIN codes** action.
 PIN name:
-  description: New name for the PIN code. Must be unique to the lock, regardless of capitalization.
+  description: New name for the PIN code.
   required: false
 PIN code:
-  description: New PIN code value. Must be unique to the lock and between 4 and 8 digits long.
+  description: New PIN code value (4-8 digits).
   required: false
 Notify when PIN is used:
-  description: Send the native Schlage notification when this PIN is used.
+  description: Whether the native Schlage notification should be sent when this PIN is used.
   required: false
 Disabled:
   description: Whether the PIN code should be disabled.
@@ -91,15 +91,15 @@ access_code_id:
   required: true
   type: string
 name:
-  description: New name for the PIN code. Must be unique to the lock, regardless of capitalization.
+  description: New name for the PIN code.
   required: false
   type: string
 code:
-  description: New PIN code value. Must be unique to the lock and between 4 and 8 digits long.
+  description: New PIN code value (4-8 digits).
   required: false
   type: string
 notify_on_use:
-  description: Send the native Schlage notification when this PIN is used.
+  description: Whether the native Schlage notification should be sent when this PIN is used.
   required: false
   type: boolean
 disabled:

--- a/source/_actions/schlage.update_code.markdown
+++ b/source/_actions/schlage.update_code.markdown
@@ -29,25 +29,25 @@ To update a PIN code from an automation or a script:
 
 {% options_ui %}
 Access code ID:
-  description: The unique ID of the access code to update. You can get IDs from the **Schlage: Get PIN codes** action.
+description: The unique ID of the access code to update. You can get IDs from the **Schlage: Get PIN codes** action.
 PIN name:
-  description: New name for the PIN code.
-  required: false
+description: New name for the PIN code.
+required: false
 PIN code:
-  description: New PIN code value (4-8 digits).
-  required: false
+description: New PIN code value (4-8 digits).
+required: false
 Notify when PIN is used:
-  description: Whether the native Schlage notification should be sent when this PIN is used.
-  required: false
+description: Whether the native Schlage notification should be sent when this PIN is used.
+required: false
 Disabled:
-  description: Whether the PIN code should be disabled.
-  required: false
+description: Whether the PIN code should be disabled.
+required: false
 Start time:
-  description: When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required. Omitting both preserves the code's existing schedule.
-  required: false
+description: When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required. Omitting both preserves the code's existing schedule.
+required: false
 End time:
-  description: When this PIN stops working. Required together with the start time. Omitting both preserves the code's existing schedule.
-  required: false
+description: When this PIN stops working. Required together with the start time. Omitting both preserves the code's existing schedule.
+required: false
 {% endoptions_ui %}
 
 ### Preserving the existing schedule
@@ -62,58 +62,58 @@ In YAML, refer to this action as `schlage.update_code`. A basic example looks li
 
 {% example %}
 action: |
-  action: schlage.update_code
-  target:
-    entity_id: lock.front_door
-  data:
-    access_code_id: "abc123"
-    name: Updated Name
+action: schlage.update_code
+target:
+entity_id: lock.front_door
+data:
+access_code_id: "abc123"
+name: Updated Name
 {% endexample %}
 
 To change a PIN's schedule in YAML:
 
 {% example %}
 action: |
-  action: schlage.update_code
-  target:
-    entity_id: lock.front_door
-  data:
-    access_code_id: "abc123"
-    start_datetime: "2026-09-01T15:00:00"
-    end_datetime: "2026-09-01T16:00:00"
+action: schlage.update_code
+target:
+entity_id: lock.front_door
+data:
+access_code_id: "abc123"
+start_datetime: "2026-09-01T15:00:00"
+end_datetime: "2026-09-01T16:00:00"
 {% endexample %}
 
 ### Options in YAML
 
 {% options_yaml %}
 access_code_id:
-  description: The unique ID of the access code to update.
-  required: true
-  type: string
+description: The unique ID of the access code to update.
+required: true
+type: string
 name:
-  description: New name for the PIN code.
-  required: false
-  type: string
+description: New name for the PIN code.
+required: false
+type: string
 code:
-  description: New PIN code value (4-8 digits).
-  required: false
-  type: string
+description: New PIN code value (4-8 digits).
+required: false
+type: string
 notify_on_use:
-  description: Whether the native Schlage notification should be sent when this PIN is used.
-  required: false
-  type: boolean
+description: Whether the native Schlage notification should be sent when this PIN is used.
+required: false
+type: boolean
 disabled:
-  description: Whether the PIN code should be disabled.
-  required: false
-  type: boolean
+description: Whether the PIN code should be disabled.
+required: false
+type: boolean
 start_datetime:
-  description: When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required. Omitting both preserves the code's existing schedule.
-  required: false
-  type: string
+description: When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required. Omitting both preserves the code's existing schedule.
+required: false
+type: string
 end_datetime:
-  description: When this PIN stops working. Required together with the start time. Omitting both preserves the code's existing schedule.
-  required: false
-  type: string
+description: When this PIN stops working. Required together with the start time. Omitting both preserves the code's existing schedule.
+required: false
+type: string
 {% endoptions_yaml %}
 
 {% include actions/targets.md domain="lock" %}

--- a/source/_integrations/schlage.markdown
+++ b/source/_integrations/schlage.markdown
@@ -71,6 +71,60 @@ Once you have enabled the Schlage integration, you should see the following swit
 
 {% include integrations/actions.md %}
 
+### Integration actions
+
+The Schlage integration provides actions to manage the access codes (PINs) stored on your lock. The codes are stored on the lock itself; temporary schedules are enforced by the lock via the Schlage cloud service.
+
+- [`schlage.add_code`](#action-schlageadd_code) — add a new access code
+- [`schlage.update_code`](#action-schlageupdate_code) — update an existing access code
+- [`schlage.delete_code`](#action-schlagedelete_code) — remove an access code
+- [`schlage.get_codes`](#action-schlageget_codes) — list all access codes with their current state
+
+#### `schlage.add_code`
+
+Adds a new access code to the lock.
+
+| Data attribute | Optional | Description |
+| -------------- | -------- | ----------- |
+| `name` | no | Name for the PIN. Must be unique to the lock (case insensitive). |
+| `code` | no | The PIN code to add. Must be unique to the lock and be between 4 and 8 digits long. |
+| `notify_on_use` | yes | Whether the native Schlage notification should be sent when this PIN is used. Defaults to `true`. |
+| `start_datetime` | yes | When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required. |
+| `end_datetime` | yes | When this PIN stops working. Required together with the start time; leaving both empty creates a permanent PIN. |
+
+To create a temporary PIN, provide both a start and an end time. Leave both empty for a permanent PIN.
+
+#### `schlage.update_code`
+
+Updates an existing access code on the lock.
+
+| Data attribute | Optional | Description |
+| -------------- | -------- | ----------- |
+| `access_code_id` | no | The ID of the access code to update, as returned by the `schlage.get_codes` action. |
+| `name` | yes | New name for the PIN. |
+| `code` | yes | New PIN code. Must be unique to the lock and be between 4 and 8 digits long. |
+| `notify_on_use` | yes | Whether the native Schlage notification should be sent when this PIN is used. |
+| `disabled` | yes | Whether the PIN should be disabled without deleting it. |
+| `start_datetime` | yes | New activation time. Providing dates replaces the schedule; both a start and an end time are required. |
+| `end_datetime` | yes | New deactivation time. Required together with the start time. |
+
+The schedule is only modified when dates are provided. Updating other fields (such as the name) leaves an existing temporary schedule untouched. To remove a temporary schedule, update the code with both a new start and end time that span the desired period, or delete and re-add the code as permanent.
+
+#### `schlage.delete_code`
+
+Removes an access code from the lock.
+
+| Data attribute | Optional | Description |
+| -------------- | -------- | ----------- |
+| `name` | yes | Name of the PIN to delete. |
+| `access_code_id` | yes | The ID of the access code to delete, as returned by the `schlage.get_codes` action. |
+
+One of `name` or `access_code_id` must be provided.
+
+#### `schlage.get_codes`
+
+Returns all access codes currently stored on the lock, including each code's `name`, `code`, `access_code_id`, `notify_on_use`, `disabled` state, and its `schedule` (`always` or `temporary`).
+
 ## Removing the integration
 
 This integration follows standard integration removal. No extra steps are required.

--- a/source/_integrations/schlage.markdown
+++ b/source/_integrations/schlage.markdown
@@ -71,60 +71,6 @@ Once you have enabled the Schlage integration, you should see the following swit
 
 {% include integrations/actions.md %}
 
-### Integration actions
-
-The Schlage integration provides actions to manage the access codes (PINs) stored on your lock. The codes are stored on the lock itself; temporary schedules are enforced by the lock via the Schlage cloud service.
-
-- [`schlage.add_code`](#action-schlageadd_code) — add a new access code
-- [`schlage.update_code`](#action-schlageupdate_code) — update an existing access code
-- [`schlage.delete_code`](#action-schlagedelete_code) — remove an access code
-- [`schlage.get_codes`](#action-schlageget_codes) — list all access codes with their current state
-
-#### `schlage.add_code`
-
-Adds a new access code to the lock.
-
-| Data attribute | Optional | Description |
-| -------------- | -------- | ----------- |
-| `name` | no | Name for the PIN. Must be unique to the lock (case insensitive). |
-| `code` | no | The PIN code to add. Must be unique to the lock and be between 4 and 8 digits long. |
-| `notify_on_use` | yes | Whether the native Schlage notification should be sent when this PIN is used. Defaults to `true`. |
-| `start_datetime` | yes | When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required. |
-| `end_datetime` | yes | When this PIN stops working. Required together with the start time; leaving both empty creates a permanent PIN. |
-
-To create a temporary PIN, provide both a start and an end time. Leave both empty for a permanent PIN.
-
-#### `schlage.update_code`
-
-Updates an existing access code on the lock.
-
-| Data attribute | Optional | Description |
-| -------------- | -------- | ----------- |
-| `access_code_id` | no | The ID of the access code to update, as returned by the `schlage.get_codes` action. |
-| `name` | yes | New name for the PIN. |
-| `code` | yes | New PIN code. Must be unique to the lock and be between 4 and 8 digits long. |
-| `notify_on_use` | yes | Whether the native Schlage notification should be sent when this PIN is used. |
-| `disabled` | yes | Whether the PIN should be disabled without deleting it. |
-| `start_datetime` | yes | New activation time. Providing dates replaces the schedule; both a start and an end time are required. |
-| `end_datetime` | yes | New deactivation time. Required together with the start time. |
-
-The schedule is only modified when dates are provided. Updating other fields (such as the name) leaves an existing temporary schedule untouched. To remove a temporary schedule, update the code with both a new start and end time that span the desired period, or delete and re-add the code as permanent.
-
-#### `schlage.delete_code`
-
-Removes an access code from the lock.
-
-| Data attribute | Optional | Description |
-| -------------- | -------- | ----------- |
-| `name` | yes | Name of the PIN to delete. |
-| `access_code_id` | yes | The ID of the access code to delete, as returned by the `schlage.get_codes` action. |
-
-One of `name` or `access_code_id` must be provided.
-
-#### `schlage.get_codes`
-
-Returns all access codes currently stored on the lock, including each code's `name`, `code`, `access_code_id`, `notify_on_use`, `disabled` state, and its `schedule` (`always` or `temporary`).
-
 ## Removing the integration
 
 This integration follows standard integration removal. No extra steps are required.


### PR DESCRIPTION
## Proposed change

Documents the new temporary access code actions for the Schlage integration. Companion to home-assistant/core PR #180503.

The Schlage integration now supports temporary access codes with a native schedule:

- `add_code` accepts optional `start_datetime` and `end_datetime`. Providing **both** creates a temporary PIN active in that window. Providing **neither** creates a permanent PIN. Providing exactly one raises a validation error.
- New `update_code` action: modify a code's name, PIN, notification setting, disabled state, and schedule. Schedule changes only apply when dates are explicitly provided.
- `delete_code` now also accepts `access_code_id`.
- `get_codes` returns the full code state, including the schedule.

The schedule is enforced by the lock itself via the Schlage cloud API (native temporary schedules), not by Home Assistant conditions.

## Type of change

- [ ] Spelling, grammar or other readability improvements
- [x] Documentation updates for an integration
- [ ] New feature documentation
- [ ] Removed screenshots
- [ ] New screenshots

## Additional information

- Requires home-assistant/core #180503 — this documentation describes functionality that does not exist in Home Assistant until that PR merges.
- Related discussion: https://github.com/home-assistant/architecture/discussions/1000

## Link to parent pull request

Link to the parent pull request: home-assistant/core#180503

## Checklist

- [x] I have followed the [code of conduct](https://www.home-assistant.io/code_of_conduct/)
- [x] I have followed the [documentation standards](https://developers.home-assistant.io/documentation/)
- [x] This is not a duplicate
