### PR TITLE
Document passive door state and the polling option for ISEO Argo BLE

### DIFF
--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -4,7 +4,7 @@ description: Instructions on how to integrate your ISEO Argo smart lock into Hom
 ha_category:
   - Lock
 ha_release: 2026.9
-ha_iot_class: Local Polling
+ha_iot_class: Local Push
 ha_config_flow: true
 ha_codeowners:
   - '@FezVrasta'
@@ -39,14 +39,31 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 4. Select **Submit** and within 30 seconds, scan the Master Card on the lock to authorize Home Assistant. 
    - **Result**: The lock's LED will blink green when the card is successfully read.
 
+That same Master Card scan also enables the lock's **Door Status Advice** setting, which makes the lock broadcast its door state. Home Assistant reads the door state from those broadcasts, so it does not connect to the lock to check on it.
+
 ## Supported functionality
 
 - **Lock**: Controls the lock (unlock only). Reflects the current locked/unlocked state.
+
+## Door state updates
+
+Home Assistant follows the door state the lock broadcasts in its Bluetooth advertisements. Changes are reported as they happen, and the lock is only connected to when you unlock it.
+
+This requires the lock's **Door Status Advice** setting to be enabled. Setting the integration up enables it for you. If your lock was added before this was the case, you can also enable Door Status Advice for the lock in the official Argo app.
+
+## Configuration options
+
+{% configuration_basic %}
+Connect to the lock to read door status:
+  description: "Connect to the lock every 30 seconds and read the door state, in addition to following its broadcasts. Enable this only if the broadcasts do not reach Home Assistant reliably, for example at the edge of Bluetooth range or with no Bluetooth proxy nearby. It wakes the lock on every check, so it is off by default."
+{% endconfiguration_basic %}
 
 ## Known limitations
 
 - The lock only supports _one active Bluetooth connection_ at a time. Close the Argo app on all phones before unlocking or during setup.
 - The ISEO X1R is a momentary actuator: it re-latches automatically after every unlock. The `lock` action is therefore not supported.
+- Door state requires **Door Status Advice** to be enabled on the lock. Without it, the lock's state is assumed rather than reported.
+- The lock broadcasts in bursts when something happens and then goes quiet for several minutes, so an unlock can take a few seconds while Home Assistant connects to it.
 
 ## Removing the integration
 

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -54,8 +54,8 @@ This requires the lock's **Door Status Advice** setting to be enabled. Setting t
 ## Configuration options
 
 {% configuration_basic %}
-Connect to the lock to read door status:
-  description: "Connect to the lock every 30 seconds and read the door state, in addition to following its broadcasts. Enable this only if the broadcasts do not reach Home Assistant reliably, for example at the edge of Bluetooth range or with no Bluetooth proxy nearby. It wakes the lock on every check, so it is off by default."
+Connect to the lock to read door state:
+  description: "Connect to the lock every 30 seconds and read the door state, in addition to following its broadcasts. Enable this only if the broadcasts do not reach Home Assistant reliably, for example at the edge of Bluetooth range or with no Bluetooth proxy nearby. It wakes the lock on every check, so it is off by default. It does not help with a lock that reports no door state at all: reading over a connection needs **Door Status Advice** just as the broadcasts do."
 {% endconfiguration_basic %}
 
 ## Known limitations


### PR DESCRIPTION
## Proposed change

Documents the move from polling to passive door-state updates, the companion to home-assistant/core#180479.

Adds:

- A **Door state updates** section: Home Assistant follows the door state the lock broadcasts, and only connects to it when unlocking. Covers the one prerequisite, the lock's **Door Status Advice** setting, and notes that setup enables it via the Master Card scan it already asks for, while a lock added earlier can have it enabled from the Argo app.
- A **Configuration options** entry for the new option that adds a periodic connection, for setups where the broadcasts do not reach Home Assistant reliably. It states that this wakes the lock on every check and does not help when the lock reports no door state at all.
- Two **Known limitations**: door state needs Door Status Advice, and the lock broadcasts in bursts before going quiet, so an unlock takes a few seconds while Home Assistant connects.
- `ha_iot_class` changed from `Local Polling` to `Local Push`, matching the manifest change in the parent PR.

**This is stacked on #43913** and contains only the commit on top of it; that PR adds the page itself and should merge first. The diff will show only this change once it does.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/180479
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

