### PR TITLE
Fix Google API project setup order

### DIFF
--- a/source/_includes/integrations/google_client_secret.md
+++ b/source/_includes/integrations/google_client_secret.md
@@ -9,8 +9,8 @@
 
 In this case, all you need to do is enable the API:
 
-1. Go the Google Developers Console [{{ api }}]({{ api_link }}) {% if page.api2 %} and [{{ page.api2 }}]({{ page.api2_link }}) {% endif %}.
-2. Confirm the project and **Enable** the API.
+1. Go to the Google Developers Console [{{ api }}]({{ api_link }}) {% if page.api2 %} and [{{ page.api2 }}]({{ page.api2_link }}) {% endif %}.
+2. Confirm that the correct project is selected, then select **Enable**.
 3. Continue with the steps described in the [Configuration](#configuration) section.
 ### Scenario 2: You do not have credentials set up yet
 
@@ -21,12 +21,13 @@ In this case, you need to generate a client secret first:
 This section explains how to generate a client ID and client secret on
 [Google Developers Console]({{ google_dev_console_link }}).
 
-1. First, go to the Google Developers Console to enable [{{ api }}]({{ api_link }}) {% if page.api2 %} and [{{ page.api2 }}]({{ page.api2_link }}) {% endif %}.
-2. Select **Create project**, enter a project name and select **Create**.
-3. **Enable** the {{ api }}.
-4. Navigate to **APIs & Services** (left sidebar) > [Credentials](https://console.cloud.google.com/apis/credentials).
-5. In the left sidebar, select **OAuth consent screen**.
-6. It will take you to the Overview page and ask for **Project Configuration**:
+1. Go to the [Google Developers Console]({{ google_dev_console_link }}).
+2. Select **Create project**, enter a project name, and select **Create**.
+3. When the project opens, make sure it is selected in the console toolbar.
+4. Go to [{{ api }}]({{ api_link }}) {% if page.api2 %} and [{{ page.api2 }}]({{ page.api2_link }}) {% endif %}, then select **Enable**.
+5. Navigate to **APIs & Services** (left sidebar) > [Credentials](https://console.cloud.google.com/apis/credentials).
+6. In the left sidebar, select **OAuth consent screen**.
+7. It will take you to the Overview page and ask for **Project Configuration**:
    - Complete the App Information:
       - Set the **App name** (the name of the application asking for consent) to anything you want, for example, *Home Assistant*.
       - For a **Support email**, choose your email address from the dropdown menu.
@@ -35,15 +36,15 @@ This section explains how to generate a client ID and client secret on
    - Under Contact Information, enter your email address (the same as above is fine). Select **Next**.
    - Read the policy and check the box if you agree. Select **Continue**.
    - Select **Create**.
-7. In the left sidebar, select **Audience**:
+8. In the left sidebar, select **Audience**:
    - Under **Publishing status > Testing**, select **Publish app**.
      > Otherwise, your credentials will expire every 7 days.
-8. In the left sidebar, select **Clients**:
+9. In the left sidebar, select **Clients**:
    - Select **+ Create Client**.
    - For Application type, choose **Web Application** and give this client ID a name (like "Home Assistant Client").
    - Add `https://my.home-assistant.io/redirect/oauth` to **Authorized redirect URIs** then select **Create**.
      > **Note**: This is not a placeholder. It is the URI that must be used.
-9. From the resulting dialog take a note of **Client ID** and **Client Secret** you **can not retrieve it again** after closing the dialog.
+10. From the resulting dialog take a note of **Client ID** and **Client Secret** you **can not retrieve it again** after closing the dialog.
    - Once you have noted these strings, select **Close**.
    - Congratulations! You are now the keeper of a client secret. Guard it in your treasure box. In most cases, your new credentials will be active within a few minutes. However, Google states that activation may take up to five hours in some circumstances.
 {% enddetails %}

--- a/source/_integrations/google_health.markdown
+++ b/source/_integrations/google_health.markdown
@@ -26,30 +26,32 @@ The **Google Health** {% term integration %} allows you to expose health and fit
 
 You need to configure developer credentials to allow Home Assistant to access your Google Account. These credentials are the same as the ones for [Google Photos](/integrations/google_photos), [Nest](/integrations/nest), [Google Tasks](/integrations/google_tasks), and [Google Mail](/integrations/google_mail).
 
-If you have already set up the correct credentials, you can enable the API and then skip the consent screen and credential creation steps.
+If you have already set up the correct credentials, select their Google Cloud project, enable the API, and then skip the consent screen and credential creation steps.
 
 {% details "Generate client ID and client secret" %}
 
 This section explains how to enable the API, configure the consent screen, and generate a client ID and client secret on the Google Developers Console.
 
-1. First, go to the Google Developers Console to enable the [Google Health API](https://console.cloud.google.com/apis/library/health.googleapis.com).
-2. Select a project and select **Continue**. Verify that the API is enabled.
-3. Go to the [Branding page](https://console.cloud.google.com/auth/branding) in the Google Auth Platform Console.
-4. If prompted to configure OAuth, select **Get started** and follow the setup wizard. When the wizard asks for the user type, select **External**, and continue once the OAuth consent configuration is created.
-5. Select **Branding** in the left sidebar. Fill in the required fields:
+1. Go to the [Google Developers Console](https://console.cloud.google.com/apis/library/health.googleapis.com).
+2. Select **Create project**, enter a project name, and select **Create**.
+3. When the project opens, make sure it is selected in the console toolbar.
+4. Go to the [Google Health API](https://console.cloud.google.com/apis/library/health.googleapis.com) and select **Enable**.
+5. Go to the [Branding page](https://console.cloud.google.com/auth/branding) in the Google Auth Platform Console.
+6. If prompted to configure OAuth, select **Get started** and follow the setup wizard. When the wizard asks for the user type, select **External**, and continue once the OAuth consent configuration is created.
+7. Select **Branding** in the left sidebar. Fill in the required fields:
    - **App name**: Enter a name (like *Home Assistant*). This is shown during the OAuth login flow.
    - **User support email**: Select your Google Account email.
    - **Developer contact email**: Enter your email address.
    Leave all other fields empty to avoid triggering Google's verification process. Select **Save**.
-6. Select **Audience** in the left sidebar.
+8. Select **Audience** in the left sidebar.
    - Under **User type**, confirm it shows **External**.
    - Under **Test users**, select **+ Add users** and add your Google Account email address. Select **Save**.
-7. Under **Publishing status**, select **Publish app** to set the status to **In production**. Make sure the status is not **Testing**, or your authentication token will expire every 7 days.
-8. Select **Credentials** in the left sidebar.
-9. Select **Create Credentials** at the top of the page, then select **OAuth client ID**.
-10. Set the Application type to **Web application** and give these credentials a name (like *Home Assistant Credentials*).
-11. Under **Authorized redirect URIs**, enter `https://my.home-assistant.io/redirect/oauth` and select **Create**. This is not a placeholder and is the URI that must be used.
-12. Copy the **Client ID** and **Client Secret** from the pop-up, or select the pencil icon next to your client ID to view them later.
+9. Under **Publishing status**, select **Publish app** to set the status to **In production**. Make sure the status is not **Testing**, or your authentication token will expire every 7 days.
+10. Select **Credentials** in the left sidebar.
+11. Select **Create Credentials** at the top of the page, then select **OAuth client ID**.
+12. Set the Application type to **Web application** and give these credentials a name (like *Home Assistant Credentials*).
+13. Under **Authorized redirect URIs**, enter `https://my.home-assistant.io/redirect/oauth` and select **Create**. This is not a placeholder and is the URI that must be used.
+14. Copy the **Client ID** and **Client Secret** from the pop-up, or select the pencil icon next to your client ID to view them later.
 
 {% enddetails %}
 

--- a/source/_integrations/google_photos.markdown
+++ b/source/_integrations/google_photos.markdown
@@ -30,31 +30,32 @@ You need to configure developer credentials to allow Home Assistant to access yo
 These credentials are the same as the ones for [Nest](/integrations/nest), [Google Tasks](/integrations/google_tasks), and [Google Mail](/integrations/google_mail).
 These are not the same as *Device Auth* credentials previously recommended for [Google Calendar](/integrations/google).
 
-If you have already set up the correct credentials, you can do step 1 and then skip to step 13 on the below instructions.
+If you have already set up the correct credentials, select their Google Cloud project, enable the API, and then skip to step 13 below.
 
 {% details "Generate Client ID and Client Secret" %}
 
 This section explains how to generate a Client ID and Client Secret on
 [Google Developers Console](https://console.cloud.google.com/apis/library/photoslibrary.googleapis.com).
 
-1. First, go to the Google Developers Console to enable [Google Photos Library API](https://console.cloud.google.com/apis/library/photoslibrary.googleapis.com)
-2. The wizard will ask you to choose a project to manage your application. Select a project and select **Continue**.
-3. Verify that your Google Photos Library API was enabled and select **Go to credentials**.
-4. Navigate to **APIs & Services** (left sidebar) > [Credentials](https://console.cloud.google.com/apis/credentials).
-5. Click on the field on the left of the screen, **OAuth Consent Screen**.
-6. Select **External** and **Create**.
-7. Set the **App Name** (the name of the application asking for consent) to anything you want, for example to *Home Assistant*.
-8. You then need to select a **Support email**. To do this, from the dropdown menu, select your email address.
-9. You finally need to complete the section: **Developer contact information**. To do this, enter your email address (the same as above is fine).
-10. Scroll to the bottom and select **Save and Continue**. You don't have to fill out anything else, or it may enable additional review.
-11. You will then be automatically taken to the **Scopes** page. You do not need to add any scopes here, so select **Save and Continue** to move to the **Optional info** page. You do not need to add anything to the **Optional info** page, so select **Save and Continue**, which will take you to the **Summary** page. Select **Back to Dashboard**.
-12. Select **OAuth consent screen** again and set **Publish Status** to **Production**. Otherwise, your credentials will expire every 7 days.
-13. Make sure **Publishing status** is set to production.
-14. Select **Credentials** in the menu on the left-hand side of the screen, then select **Create credentials** (at the top of the screen), then select **OAuth client ID**.
-15. Set the Application type to **Web application** and give this credential set a name (like "Home Assistant Credentials").
-16. Add `https://my.home-assistant.io/redirect/oauth` to **Authorized redirect URIs** then select **Create**. This is not a placeholder and is the URI that must be used.
-17. You will then be presented with a pop-up saying **OAuth client created**, showing **Your Client ID** and **Your Client Secret**. Make a note of these (for example, copy and paste them into a text editor), as you will need them shortly. Once you have noted these strings, select **OK**. If you need to find these credentials again at any point, then navigate to **APIs & Services** > **Credentials**, and you will see **Home Assistant Credentials** (or whatever you named them in the previous step) under **OAuth 2.0 Client IDs**. To view both the **Client ID** and **Client secret**, select the pencil icon. This will take you to the settings page for these credentials, and the information will be on the right-hand side of the page.
-18. Double-check that the **Google Photos Library API** has been automatically enabled. To do this, select **Library** from the menu, then search for **Google Photos Library API**. If it is enabled, you will see **API Enabled** with a green tick next to it. If it is not enabled, then enable it.
+1. Go to the [Google Developers Console](https://console.cloud.google.com/apis/library/photoslibrary.googleapis.com).
+2. Select **Create project**, enter a project name, and select **Create**.
+3. When the project opens, make sure it is selected in the console toolbar.
+4. Go to the [Google Photos Library API](https://console.cloud.google.com/apis/library/photoslibrary.googleapis.com) and select **Enable**.
+5. Navigate to **APIs & Services** (left sidebar) > [Credentials](https://console.cloud.google.com/apis/credentials).
+6. Click on the field on the left of the screen, **OAuth Consent Screen**.
+7. Select **External** and **Create**.
+8. Set the **App Name** (the name of the application asking for consent) to anything you want, for example to *Home Assistant*.
+9. You then need to select a **Support email**. To do this, from the dropdown menu, select your email address.
+10. You finally need to complete the section: **Developer contact information**. To do this, enter your email address (the same as above is fine).
+11. Scroll to the bottom and select **Save and Continue**. You don't have to fill out anything else, or it may enable additional review.
+12. You will then be automatically taken to the **Scopes** page. You do not need to add any scopes here, so select **Save and Continue** to move to the **Optional info** page. You do not need to add anything to the **Optional info** page, so select **Save and Continue**, which will take you to the **Summary** page. Select **Back to Dashboard**.
+13. Select **OAuth consent screen** again and set **Publish Status** to **Production**. Otherwise, your credentials will expire every 7 days.
+14. Make sure **Publishing status** is set to production.
+15. Select **Credentials** in the menu on the left-hand side of the screen, then select **Create credentials** (at the top of the screen), then select **OAuth client ID**.
+16. Set the Application type to **Web application** and give this credential set a name (like "Home Assistant Credentials").
+17. Add `https://my.home-assistant.io/redirect/oauth` to **Authorized redirect URIs** then select **Create**. This is not a placeholder and is the URI that must be used.
+18. You will then be presented with a pop-up saying **OAuth client created**, showing **Your Client ID** and **Your Client Secret**. Make a note of these (for example, copy and paste them into a text editor), as you will need them shortly. Once you have noted these strings, select **OK**. If you need to find these credentials again at any point, then navigate to **APIs & Services** > **Credentials**, and you will see **Home Assistant Credentials** (or whatever you named them in the previous step) under **OAuth 2.0 Client IDs**. To view both the **Client ID** and **Client secret**, select the pencil icon. This will take you to the settings page for these credentials, and the information will be on the right-hand side of the page.
+19. Double-check that the **Google Photos Library API** is enabled. To do this, select **Library** from the menu, then search for **Google Photos Library API**. If it is enabled, you will see **API Enabled** with a green tick next to it. If it is not enabled, then enable it.
 
 {% enddetails %}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Correct the Google API setup sequence so users create and select a Google Cloud project before enabling an API. Update the shared Google credential instructions and the Google Photos and Google Health setup guides.

This is clearly [described in their doc](https://docs.cloud.google.com/service-usage/docs/enable-disable#enabling):
> Select a recent project or use the resource selector on the console toolbar to select the Google Cloud project where you want to enable an API.

And also confirmed in the console. Here you see the same Google Calendar API in two different GCP projects of the same GCP account, where it's enabled on one side and not on the other side:
<img width="2557" height="322" alt="image" src="https://github.com/user-attachments/assets/ddf1ce6d-616a-461a-b7cd-6fd680716ab5" />


The diff is long but it's because I had to change the numbering of each line. GitHub doesn't detect this correctly on all lines and shows the entire line as changed.
<details><summary>Screenshots of the diff in a different tool</summary>
<p>
<img width="2427" height="863" alt="image" src="https://github.com/user-attachments/assets/e21c6ca6-0477-4c79-8ca7-2b00f16292b2" />
<img width="2442" height="846" alt="image" src="https://github.com/user-attachments/assets/36dffcc3-67ef-4af8-be72-05e13de939ea" />
<img width="2440" height="1075" alt="image" src="https://github.com/user-attachments/assets/d5236549-adfa-4763-8d53-5e66bbfbd152" />



</p>
</details> 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards


Related follow-up PR: https://github.com/home-assistant/home-assistant.io/pull/47702
