### PR TITLE
Teslemetry: remove passenger seat belt binary sensor

### DIFF
--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -96,7 +96,6 @@ Entities in the device tracker platform specifically require the `Vehicle locati
 |Binary sensor|Located at home|Yes|Streaming|
 |Binary sensor|Located at work|Yes|Streaming|
 |Binary sensor|Offroad lightbar|No|Streaming|
-|Binary sensor|Passenger seat belt|No|Streaming|
 |Binary sensor|Pin to drive enabled|No|Streaming|
 |Binary sensor|Preconditioning enabled|No|Both|
 |Binary sensor|Preconditioning|No|Polling|


### PR DESCRIPTION
## Proposed change

Removes the documentation row for the Teslemetry passenger seat belt binary sensor. The entity is being removed from Home Assistant because it never reported a usable value, and the underlying signal is not the front passenger belt, so its documentation row goes with it.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/180467
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
