### PR TITLE
Peblar updates can be installed from Home Assistant

### DIFF
--- a/source/_integrations/peblar.markdown
+++ b/source/_integrations/peblar.markdown
@@ -244,10 +244,14 @@ This integration provides the following switch entities:
 
 The Peblar integration provides two update entities for the Peblar charger:
 
-- **Firmware**: Indicates if there is a firmware update available for the charger. The firmware can be thought of as the operating system of the charger.
-- **Customization**: Indicates if there is a customization update available for the charger. The customization can be thought of as the user interface of the charger that you see when you log in to the charger's local web interface.
+- **Firmware**: Indicates if there is a firmware update available for the charger, and installs it. The firmware can be thought of as the operating system of the charger.
+- **Customization**: Indicates if there is a customization update available for the charger, and installs it. The customization can be thought of as the user interface of the charger that you see when you log in to the charger's local web interface.
 
-Software updates cannot be installed through Home Assistant. You need to log in to the charger's local web interface to install the updates.
+{% important %}
+If both updates are available, install the customization first. The charger's own web interface does the same, and the firmware update is refused until the customization one is done.
+{% endimportant %}
+
+Installing takes a while. The charger downloads the package, then restarts itself, and it is unreachable for a few minutes in the middle of that. Home Assistant does not report progress, because the charger does not provide any: it reports only whether the update succeeded. The version shown updates once the charger is back.
 
 ## Data updates
 

--- a/source/_integrations/peblar.markdown
+++ b/source/_integrations/peblar.markdown
@@ -248,10 +248,12 @@ The Peblar integration provides two update entities for the Peblar charger:
 - **Customization**: Indicates if there is a customization update available for the charger, and installs it. The customization can be thought of as the user interface of the charger that you see when you log in to the charger's local web interface.
 
 {% important %}
-If both updates are available, install the customization first. The charger's own web interface does the same, and the firmware update is refused until the customization one is done.
+If both updates are available, install the customization update first. Home Assistant does not install a firmware update while a customization update is still available. The charger's own web interface installs them in the same order.
 {% endimportant %}
 
-Installing takes a while. The charger downloads the package, then restarts itself, and it is unreachable for a few minutes in the middle of that. Home Assistant does not report progress, because the charger does not provide any: it reports only whether the update succeeded. The version shown updates once the charger is back.
+Installing an update takes several minutes. The charger first downloads the package and then restarts itself. While it restarts, the charger is unavailable in Home Assistant.
+
+Home Assistant does not show a progress percentage while an update installs, because the charger does not report one. The version numbers are updated once the charger is back online.
 
 ## Data updates
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The page told people that software updates cannot be installed through Home Assistant and sent them to the charger's own web interface. The update entities can install them as of home-assistant/core#180581.

Also adds the two things that are not obvious from looking at the entities:

- Customization goes before firmware. The charger's own web interface installs them in that order, and the integration refuses a firmware install while a customization update is still pending, so someone who tries the other way round gets an error rather than a puzzle.
- Installing takes a while and shows no progress. The charger downloads first, then restarts itself and is unreachable for a few minutes. There is no percentage anywhere, because the charger does not report one: its update status is a success or failure signal only.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#180581
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
