### PR TITLE
Add Persang Infrared integration documentation

### DIFF
--- a/source/_integrations/persang_infrared.markdown
+++ b/source/_integrations/persang_infrared.markdown
@@ -4,7 +4,7 @@ description: Integration to control Persang speakers using an infrared transmitt
 ha_category:
   - Infrared
   - Media player
-ha_release: 2026.9
+ha_release: '2026.10'
 ha_iot_class: Assumed State
 ha_codeowners:
   - '@Dr-Blank'

--- a/source/_integrations/persang_infrared.markdown
+++ b/source/_integrations/persang_infrared.markdown
@@ -51,8 +51,9 @@ The **Persang Infrared** integration provides the following entities.
 
 - The integration uses assumed state, meaning Home Assistant cannot read the actual state of the speaker (for example, whether it is on or off, or what the current volume is).
 - Presses on the physical remote are not tracked. The integration only sends commands through an infrared transmitter, so using the remote directly leaves the entities showing whatever state Home Assistant last set.
-- Turning on and turning off the speaker both send the same IR power toggle command, as is standard with infrared remotes. The same applies to play and pause, and to muting and unmuting. To avoid toggling the speaker away from the requested state, Home Assistant skips the command when it already assumes the speaker is in that state.
+- Turning on and turning off the speaker both send the same IR power toggle command, as is standard with infrared remotes. The same applies to play and pause, and to muting and unmuting. The command is always sent, so if the speaker and Home Assistant disagree, sending the opposite command brings them back in sync.
 - Volume control is step-based only; there is no way to set an absolute volume level.
+- Mute is not restored after a restart.
 - Source selection is not exposed, because the remote has no dedicated source buttons.
 - The remaining remote buttons, such as mode, equalizer, scan, repeat, and the numeric keys, are not exposed yet.
 

--- a/source/_integrations/persang_infrared.markdown
+++ b/source/_integrations/persang_infrared.markdown
@@ -1,0 +1,63 @@
+---
+title: Persang Infrared
+description: Integration to control Persang speakers using an infrared transmitter.
+ha_category:
+  - Infrared
+  - Media player
+ha_release: 2026.9
+ha_iot_class: Assumed State
+ha_codeowners:
+  - '@Dr-Blank'
+ha_domain: persang_infrared
+ha_config_flow: true
+ha_platforms:
+  - media_player
+ha_integration_type: device
+ha_quality_scale: bronze
+---
+
+The **Persang Infrared** {% term integration %} lets you control a Persang Bluetooth speaker using any infrared transmitter previously configured in Home Assistant.
+
+Because the integration communicates over infrared, it operates in a one-way, fire-and-forget fashion: commands are sent to the speaker but there is no feedback channel to confirm the current state. The integration therefore uses assumed states, and restores the last state it sent after a restart.
+
+## Prerequisites
+
+Before setting up the Persang Infrared integration, you need a working infrared transmitter set up in Home Assistant that exposes an [Infrared](/integrations/infrared/) entity. For example, you can use an ESPHome device with an IR LED pointed at your speaker.
+
+{% include integrations/config_flow.md %}
+
+{% configuration_basic %}
+Infrared transmitter:
+  description: The infrared transmitter entity to use for sending commands. This must be an entity provided by a hardware integration (such as ESPHome) that has already been set up with an IR transmitter.
+{% endconfiguration_basic %}
+
+## Supported devices
+
+The IR commands were captured from the remote shipped with a Persang Octane 9 speaker. Persang sells the same remote as a spare part for several of its speakers, so other Persang models are likely to respond to the same commands, but only the Octane 9 has been verified.
+
+If your speaker does not respond, or if you want another Persang remote supported, please [open an issue on the infrared-protocols repository](https://github.com/home-assistant-libs/infrared-protocols/issues) with captured IR signals from your remote.
+
+## Supported functionality
+
+The **Persang Infrared** integration provides the following entities.
+
+### Media player
+
+- **Persang speaker**
+  - **Description**: Represents the speaker and allows you to control it over IR.
+  - **Supported features**: Turn on, turn off, volume up, volume down, mute, play, pause, next track, and previous track.
+
+## Known limitations
+
+- The integration uses assumed state, meaning Home Assistant cannot read the actual state of the speaker (for example, whether it is on or off, or what the current volume is).
+- Presses on the physical remote are not tracked. The integration only sends commands through an infrared transmitter, so using the remote directly leaves the entities showing whatever state Home Assistant last set.
+- Turning on and turning off the speaker both send the same IR power toggle command, as is standard with infrared remotes. The same applies to play and pause, and to muting and unmuting. To avoid toggling the speaker away from the requested state, Home Assistant skips the command when it already assumes the speaker is in that state.
+- Volume control is step-based only; there is no way to set an absolute volume level.
+- Source selection is not exposed, because the remote has no dedicated source buttons.
+- The remaining remote buttons, such as mode, equalizer, scan, repeat, and the numeric keys, are not exposed yet.
+
+## Removing the integration
+
+This integration follows standard integration removal.
+
+{% include integrations/remove_device_service.md %}


### PR DESCRIPTION
## Proposed change

Adds documentation for the new `persang_infrared` integration, which controls a Persang Bluetooth speaker through an infrared emitter entity already set up in Home Assistant.

The integration ships a single media player entity with turn on, turn off, volume up/down, mute, play, pause, next track and previous track. State and mute are assumed and restored across restarts.

The remaining remote buttons (mode, equalizer, scan, repeat, and the numeric keys 0-9) are deliberately not part of the code PR and are listed under known limitations. They are a follow-up PR, and this page will be extended when that lands.

This replaces https://github.com/home-assistant/home-assistant.io/pull/47227, which was closed. That version documented a button platform that the code PR no longer contains.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/178107
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/10912
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
