### PR TITLE
Document the Peblar autocharge actions

### DIFF
--- a/source/_actions/peblar.add_vehicle_token.markdown
+++ b/source/_actions/peblar.add_vehicle_token.markdown
@@ -1,0 +1,112 @@
+---
+title: "Add an autocharge vehicle"
+action: peblar.add_vehicle_token
+domain: peblar
+description: "Adds a vehicle to the Peblar charger's autocharge list."
+related:
+  - docs: /integrations/peblar/
+    title: Peblar
+  - action: peblar.list_vehicle_tokens
+  - action: peblar.delete_vehicle_token
+---
+
+The **Add autocharge vehicle** action adds a vehicle to the Peblar charger's autocharge list. Once added, that car authorizes itself as soon as it is plugged in: the charger recognizes the identifier the car's own controller presents, so no card or app is needed.
+
+{% note %}
+Autocharge is only available on Peblar chargers that are equipped with power line communication hardware.
+{% endnote %}
+
+{% include actions/try_it.md %}
+
+{% include actions/ui_header.md %}
+
+To add a vehicle from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. In the **Then do** section, select **Add action**.
+4. From the search box, search for and select **Peblar: Add autocharge vehicle**.
+5. Under **Peblar EV charger**, select the Peblar charger to add the vehicle to.
+6. Enter the **EVCC ID** of the vehicle.
+7. Enter an **Alias** to identify the vehicle, for example, the name of the car.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Peblar EV charger:
+  description: The Peblar EV charger to add the vehicle to.
+  required: true
+EVCC ID:
+  description: The identifier the vehicle presents to the charger.
+  required: true
+Alias:
+  description: A human-readable label for this vehicle.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `peblar.add_vehicle_token`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: peblar.add_vehicle_token
+  data:
+    config_entry_id: "01234567890abcdef01234567890abcd"
+    evcc_id: "NL-ABC-0123456789-1"
+    alias: "The blue one"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry_id:
+  description: >
+    The ID of the Peblar charger config entry to add the vehicle to.
+  required: true
+  type: string
+evcc_id:
+  description: >
+    The identifier the vehicle presents to the charger over the power line.
+  required: true
+  type: string
+alias:
+  description: >
+    A human-readable label for this vehicle, for example, the name of the car.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- Only administrators can run this action.
+- To find a vehicle's identifier, plug the car in and look it up in the charger's local web interface, which shows the last vehicle it saw.
+- A vehicle is added as authorized, so it can charge straight away.
+
+{% include actions/more_examples.md %}
+
+### Automation: add a vehicle when an input text is updated
+
+When you update an input text helper with an identifier and a name, automatically add that vehicle to the charger.
+
+{% details "YAML example for adding a vehicle from an input text" %}
+
+{% example %}
+automation: |
+  triggers:
+    - trigger: state
+      entity_id: input_text.new_vehicle_evcc_id
+  actions:
+    - action: peblar.add_vehicle_token
+      data:
+        config_entry_id: "01234567890abcdef01234567890abcd"
+        evcc_id: "{{ states('input_text.new_vehicle_evcc_id') }}"
+        alias: "{{ states('input_text.new_vehicle_alias') }}"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/peblar.delete_vehicle_token.markdown
+++ b/source/_actions/peblar.delete_vehicle_token.markdown
@@ -1,0 +1,102 @@
+---
+title: "Delete an autocharge vehicle"
+action: peblar.delete_vehicle_token
+domain: peblar
+description: "Deletes a vehicle from the Peblar charger's autocharge list."
+related:
+  - docs: /integrations/peblar/
+    title: Peblar
+  - action: peblar.list_vehicle_tokens
+  - action: peblar.add_vehicle_token
+---
+
+The **Delete autocharge vehicle** action removes a vehicle from the Peblar charger's autocharge list. Once removed, that car no longer authorizes itself when it is plugged in.
+
+{% note %}
+Autocharge is only available on Peblar chargers that are equipped with power line communication hardware.
+{% endnote %}
+
+{% include actions/try_it.md %}
+
+{% include actions/ui_header.md %}
+
+To delete a vehicle from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. In the **Then do** section, select **Add action**.
+4. From the search box, search for and select **Peblar: Delete autocharge vehicle**.
+5. Under **Peblar EV charger**, select the Peblar charger to delete the vehicle from.
+6. Enter the **EVCC ID** of the vehicle to delete.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Peblar EV charger:
+  description: The Peblar EV charger to delete the vehicle from.
+  required: true
+EVCC ID:
+  description: The identifier of the vehicle to delete.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `peblar.delete_vehicle_token`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: peblar.delete_vehicle_token
+  data:
+    config_entry_id: "01234567890abcdef01234567890abcd"
+    evcc_id: "NL-ABC-0123456789-1"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry_id:
+  description: >
+    The ID of the Peblar charger config entry to delete the vehicle from.
+  required: true
+  type: string
+evcc_id:
+  description: >
+    The identifier of the vehicle to delete.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- Only administrators can run this action.
+- Deleting a vehicle is permanent. To restore autocharge for that car, add it again.
+- Use [List autocharge vehicles](/actions/peblar.list_vehicle_tokens/) to look up the identifier of a vehicle you want to remove.
+
+{% include actions/more_examples.md %}
+
+### Automation: revoke autocharge when guest mode ends
+
+When you turn off guest mode, remove the guest's car from the autocharge list.
+
+{% details "YAML example for revoking autocharge for a guest vehicle" %}
+
+{% example %}
+automation: |
+  triggers:
+    - trigger: state
+      entity_id: input_boolean.guest_mode
+      to: "off"
+  actions:
+    - action: peblar.delete_vehicle_token
+      data:
+        config_entry_id: "01234567890abcdef01234567890abcd"
+        evcc_id: "NL-ABC-0123456789-1"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/peblar.list_vehicle_tokens.markdown
+++ b/source/_actions/peblar.list_vehicle_tokens.markdown
@@ -1,0 +1,111 @@
+---
+title: "List autocharge vehicles"
+action: peblar.list_vehicle_tokens
+domain: peblar
+description: "Returns the vehicles configured in the Peblar charger's autocharge list."
+related:
+  - docs: /integrations/peblar/
+    title: Peblar
+  - action: peblar.add_vehicle_token
+  - action: peblar.delete_vehicle_token
+---
+
+The **List autocharge vehicles** action retrieves the vehicles stored in the Peblar charger's autocharge list. The action returns the list as response data, which you can use in an automation or script to inspect which cars are allowed to charge.
+
+Autocharge lets a car authorize itself. The charger recognizes the identifier the car's own controller presents when it is plugged in, so no card or app is needed.
+
+{% note %}
+Autocharge is only available on Peblar chargers that are equipped with power line communication hardware.
+{% endnote %}
+
+{% include actions/try_it.md %}
+
+{% include actions/ui_header.md %}
+
+To retrieve the autocharge list from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. In the **Then do** section, select **Add action**.
+4. From the search box, search for and select **Peblar: List autocharge vehicles**.
+5. Under **Peblar EV charger**, select the Peblar charger to retrieve the vehicles from.
+6. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Peblar EV charger:
+  description: The Peblar EV charger to list autocharge vehicles for.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `peblar.list_vehicle_tokens`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: peblar.list_vehicle_tokens
+  data:
+    config_entry_id: "01234567890abcdef01234567890abcd"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry_id:
+  description: >
+    The ID of the Peblar charger config entry to list autocharge vehicles for.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+### Response data
+
+The action returns an object with a single `vehicles` member. Each vehicle has
+an `evcc_id` and an `alias`:
+
+```yaml
+vehicles:
+  - evcc_id: "NL-ABC-0123456789-1"
+    alias: "The blue one"
+  - evcc_id: "NL-ABC-9876543210-2"
+    alias: "The other one"
+```
+
+## Good to know
+
+- Only administrators can run this action.
+- An identifier belongs to a specific car, so treat it the way you would any other credential.
+
+{% include actions/more_examples.md %}
+
+### Automation: send a notification with the current autocharge list
+
+Retrieve the configured vehicles and send yourself a summary as a notification.
+
+{% details "YAML example for notifying with the autocharge list" %}
+
+{% example %}
+automation: |
+  triggers:
+    - trigger: time
+      at: "08:00:00"
+  actions:
+    - action: peblar.list_vehicle_tokens
+      data:
+        config_entry_id: "01234567890abcdef01234567890abcd"
+      response_variable: vehicles
+    - action: notify.mobile_app_your_phone
+      data:
+        title: "Peblar autocharge vehicles"
+        message: >
+          Currently allowed to charge:
+          {{ vehicles.vehicles | map(attribute='alias') | join(', ') }}
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/peblar.list_vehicle_tokens.markdown
+++ b/source/_actions/peblar.list_vehicle_tokens.markdown
@@ -95,13 +95,13 @@ automation: |
     - action: peblar.list_vehicle_tokens
       data:
         config_entry_id: "01234567890abcdef01234567890abcd"
-      response_variable: vehicles
+      response_variable: autocharge_list
     - action: notify.mobile_app_your_phone
       data:
         title: "Peblar autocharge vehicles"
         message: >
           Currently allowed to charge:
-          {{ vehicles.vehicles | map(attribute='alias') | join(', ') }}
+          {{ autocharge_list.vehicles | map(attribute='alias') | join(', ') }}
 {% endexample %}
 
 {% enddetails %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the three autocharge actions added in home-assistant/core#180606: `peblar.list_vehicle_tokens`, `peblar.add_vehicle_token` and `peblar.delete_vehicle_token`.

Autocharge lets a car authorize itself. The charger recognizes the identifier the car's own controller presents when it is plugged in, so no card or app is involved. Each page says so, and each carries the hardware requirement: autocharge needs power line communication hardware, which is what the integration checks before it does anything.

Also written down, because it is the first thing anyone will ask: how to find a vehicle's identifier. For now that means plugging the car in and reading it from the charger's own web interface, which shows the last vehicle it saw. The charger has an endpoint for that, but it is gated on the same hardware, so it is not wired up yet.

The three pages follow the RFID ones, with the points from the reviews on #45015 and #45014 applied up front: the `options_ui` blocks mirror `strings.json` field for field, the charger field is labelled "Peblar EV charger", each page has a `Good to know` noting these are administrator only, and they close with the `stuck` and `related` includes.

`remark` and `textlint` pass on all three.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#180606
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
