### PR TITLE
Document authorizing a Peblar charge session

### DIFF
--- a/source/_actions/peblar.authorize_charge_session.markdown
+++ b/source/_actions/peblar.authorize_charge_session.markdown
@@ -73,7 +73,7 @@ uid:
   type: string
 description:
   description: >
-    The label of the RFID token to present, instead of its UID. Provide this or `uid`, not both.
+    The label of the RFID token to present, instead of its UID. Provide this or `uid`. You must provide one of the two.
   required: false
   type: string
 {% endoptions_yaml %}

--- a/source/_actions/peblar.authorize_charge_session.markdown
+++ b/source/_actions/peblar.authorize_charge_session.markdown
@@ -1,0 +1,116 @@
+---
+title: "Authorize a charge session"
+action: peblar.authorize_charge_session
+domain: peblar
+description: "Presents a token to the Peblar charger, as if it were held against the reader."
+related:
+  - docs: /integrations/peblar/
+    title: Peblar
+  - action: peblar.list_rfid_tokens
+  - action: peblar.add_rfid_token
+---
+
+The **Authorize charge session** action presents a token to the Peblar charger, as if the card or key fob were held against the reader. Use it to let a charging session start without walking up to the charger.
+
+{% important %}
+This action toggles. A session that is waiting for authorization gets it, and a session that is already running is stopped. That is what holding a card against the reader does, and this action does the same thing.
+{% endimportant %}
+
+The token has to be in the charger's standalone authorization list. Use [List RFID tokens](/actions/peblar.list_rfid_tokens/) to see what is on it, and [Add RFID token](/actions/peblar.add_rfid_token/) to put something new there.
+
+{% include actions/try_it.md %}
+
+{% include actions/ui_header.md %}
+
+To authorize a charge session from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. In the **Then do** section, select **Add action**.
+4. From the search box, search for and select **Peblar: Authorize charge session**.
+5. Under **Peblar EV charger**, select the Peblar charger to present the token to.
+6. Enter either the **UID** of the token, or its **Description**. Fill in one of the two, not both.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Peblar EV charger:
+  description: The Peblar EV charger to present the token to.
+  required: true
+UID:
+  description: The unique identifier of the RFID token to present.
+  required: false
+Description:
+  description: The label of the RFID token to present, instead of its UID.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `peblar.authorize_charge_session`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: peblar.authorize_charge_session
+  data:
+    config_entry_id: "01234567890abcdef01234567890abcd"
+    uid: "04A1B2C3D4E5F6"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry_id:
+  description: >
+    The ID of the Peblar charger config entry to present the token to.
+  required: true
+  type: string
+uid:
+  description: >
+    The unique identifier (UID) of the RFID token to present. Provide this or `description`, not both.
+  required: false
+  type: string
+description:
+  description: >
+    The label of the RFID token to present, instead of its UID. Provide this or `uid`, not both.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- Only administrators can run this action.
+- The charger accepts the request and acts on it a moment later, so watch the charger's state to see the result rather than the action itself.
+- This action does not apply to every charger. A charger without an RFID reader has no standalone list to draw from, a charger managed over OCPP has its sessions authorized by that backoffice, and a charger set to charge without authorization has nothing to authorize.
+
+{% include actions/more_examples.md %}
+
+### Automation: authorize the charger when you arrive home
+
+When you get home and a cable is plugged in, present your token so charging can start.
+
+{% details "YAML example for authorizing on arrival" %}
+
+{% example %}
+automation: |
+  triggers:
+    - trigger: state
+      entity_id: person.jane
+      to: "home"
+  conditions:
+    - condition: state
+      entity_id: sensor.peblar_ev_charger_cp_state
+      state: "suspended"
+  actions:
+    - action: peblar.authorize_charge_session
+      data:
+        config_entry_id: "01234567890abcdef01234567890abcd"
+        description: "Jane's key fob"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/peblar.authorize_charge_session.markdown
+++ b/source/_actions/peblar.authorize_charge_session.markdown
@@ -68,7 +68,7 @@ config_entry_id:
   type: string
 uid:
   description: >
-    The unique identifier (UID) of the RFID token to present. Provide this or `description`, not both.
+    The unique identifier (UID) of the RFID token to present. Provide either this or `description`. You must provide one of the two.
   required: false
   type: string
 description:

--- a/source/_actions/peblar.authorize_charge_session.markdown
+++ b/source/_actions/peblar.authorize_charge_session.markdown
@@ -82,7 +82,10 @@ description:
 
 - Only administrators can run this action.
 - The charger accepts the request and acts on it a moment later, so watch the charger's state to see the result rather than the action itself.
-- This action does not apply to every charger. A charger without an RFID reader has no standalone list to draw from, a charger managed over OCPP has its sessions authorized by that backoffice, and a charger set to charge without authorization has nothing to authorize.
+- This action does not apply to every charger:
+  - Chargers without an RFID reader do not have a standalone authorization list.
+  - Chargers managed over OCPP have their sessions authorized by the OCPP back-end system.
+  - Chargers set to charge without authorization have nothing to authorize.
 
 {% include actions/more_examples.md %}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents `peblar.authorize_charge_session`, added in home-assistant/core#180678. It presents a token to the charger as if the card were held against the reader, so a session can be authorized without walking up to it.

Two things the page leads with, because neither is obvious from the action itself:

- **It toggles.** A session waiting for authorization gets it, and one already running is stopped. That is what holding a card against a reader does, and the API documents the call as simulating exactly that. Saying so up front beats letting someone discover it by pressing twice.
- **It does not apply to every charger.** A charger without an RFID reader has no list to draw from, a charger managed over OCPP has its sessions authorized by that backoffice, and a charger set to charge without authorization has nothing to authorize. The integration refuses each with its own message.

The page follows the other Peblar action pages: the `options_ui` block mirrors `strings.json` field for field, the charger field is labelled "Peblar EV charger", there is a `Good to know` noting this is administrator only, and it closes with the `stuck` and `related` includes.

`remark` and `textlint` pass.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#180678
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
