### PR TITLE
Teslemetry: document keep accessory power buttons

### DIFF
--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -54,7 +54,8 @@ The [virtual key](https://teslemetry.com/docs/topics/virtualkey) is Teslemetry's
 ## Entities
 
 These are the entities available in the Teslemetry integration. Not all entities are enabled by default, and not all values are always available.
-Entities in the device tracker platform specifically require the `Vehicle location` scope, and will appear unavailable otherwise. 
+Entities in the device tracker platform specifically require the `Vehicle location` scope, and will appear unavailable otherwise.
+The **Enable keep accessory power** and **Disable keep accessory power** buttons are only created for vehicles on firmware 2025.38 or newer.
 
 ### Vehicles
 
@@ -121,6 +122,8 @@ Entities in the device tracker platform specifically require the `Vehicle locati
 |Binary sensor|User present|Yes|Polling|
 |Binary sensor|Wi-Fi|Yes|Streaming|
 |Binary sensor|Wiper heat|No|Streaming|
+|Button|Disable keep accessory power|Yes|—|
+|Button|Enable keep accessory power|Yes|—|
 |Button|Flash lights|Yes|—|
 |Button|HomeLink|Yes|—|
 |Button|Honk horn|Yes|—|

--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -54,7 +54,7 @@ The [virtual key](https://teslemetry.com/docs/topics/virtualkey) is Teslemetry's
 ## Entities
 
 These are the entities available in the Teslemetry integration. Not all entities are enabled by default, and not all values are always available.
-Entities in the device tracker platform specifically require the `Vehicle location` scope, and will appear unavailable otherwise.
+Entities in the device tracker platform specifically require the `Vehicle location` scope, and will appear unavailable otherwise. 
 The **Enable keep accessory power** and **Disable keep accessory power** buttons are only created for vehicles on firmware 2025.38 or newer.
 
 ### Vehicles


### PR DESCRIPTION
## Proposed change

Documents the two new vehicle buttons added to the Teslemetry integration in [home-assistant/core#179222](https://github.com/home-assistant/core/pull/179222): **Enable keep accessory power** and **Disable keep accessory power**.

These buttons are only created for vehicles on firmware 2025.38 or newer, so the page notes that requirement to explain why they may not appear for some vehicles.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#179222
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
