### PR TITLE
Document the iCloud to-do list platform

### DIFF
--- a/source/_integrations/icloud.markdown
+++ b/source/_integrations/icloud.markdown
@@ -15,7 +15,7 @@ ha_codeowners:
 ha_domain: icloud
 ha_platforms:
   - device_tracker
-  - media_source  
+  - media_source
   - sensor
   - todo
 ha_integration_type: hub
@@ -63,12 +63,12 @@ The iCloud integration will add a battery sensor for each iCloud devices availab
 
 ### To-do list
 
-The iCloud integration adds a to-do list entity for each of your Apple Reminders lists. You can add, edit, complete, and delete reminders, including their due date and notes, and the changes sync back to your Apple devices.
+The iCloud integration adds a to-do list entity for each of your Apple Reminders lists. You can add, edit, complete, and delete reminders, including their due date and notes. Changes sync back to your Apple devices.
 
-Reminder groups, which hold other lists rather than reminders, are not shown as to-do lists. Because Home Assistant to-do lists are flat, a reminder's subtasks are listed directly after the reminder they belong to.
+Reminder groups hold other lists rather than reminders, so they do not appear as to-do lists. Home Assistant to-do lists are flat, so a reminder's subtasks are listed directly after the reminder they belong to.
 
 {% note %}
-If you have [Advanced Data Protection](https://support.apple.com/en-us/102651) turned on, your reminders are end-to-end encrypted and Apple only returns readable content to a session that your device has approved. Approve the request on one of your Apple devices when prompted; until then, reminder titles cannot be read.
+If you have [Advanced Data Protection](https://support.apple.com/en-us/102651) turned on, your reminders are end-to-end encrypted. Apple only returns readable content to a session that one of your devices has approved, so Home Assistant cannot display your reminder titles until you approve the request when prompted on an Apple device.
 {% endnote %}
 
 {% include integrations/actions.md %}

--- a/source/_integrations/icloud.markdown
+++ b/source/_integrations/icloud.markdown
@@ -5,6 +5,7 @@ ha_category:
   - Media source
   - Presence detection
   - Sensor
+  - To-do list
 ha_iot_class: Cloud Polling
 ha_release: '0.10'
 ha_config_flow: true
@@ -16,6 +17,7 @@ ha_platforms:
   - device_tracker
   - media_source  
   - sensor
+  - todo
 ha_integration_type: hub
 ---
 
@@ -25,6 +27,7 @@ There is currently support for the following platforms within Home Assistant:
 
 - [Device tracker](#device-tracker)
 - [Sensor](#sensor)
+- [To-do list](#to-do-list)
 
 It does require that your devices are registered with the [Find My](https://www.apple.com/icloud/find-my/) service.
 
@@ -57,6 +60,16 @@ The iCloud integration will track available devices on your iCloud account.
 ### Sensor
 
 The iCloud integration will add a battery sensor for each iCloud devices available on your iCloud account.
+
+### To-do list
+
+The iCloud integration adds a to-do list entity for each of your Apple Reminders lists. You can add, edit, complete, and delete reminders, including their due date and notes, and the changes sync back to your Apple devices.
+
+Reminder groups, which hold other lists rather than reminders, are not shown as to-do lists. Because Home Assistant to-do lists are flat, a reminder's subtasks are listed directly after the reminder they belong to.
+
+{% note %}
+If you have [Advanced Data Protection](https://support.apple.com/en-us/102651) turned on, your reminders are end-to-end encrypted and Apple only returns readable content to a session that your device has approved. Approve the request on one of your Apple devices when prompted; until then, reminder titles cannot be read.
+{% endnote %}
 
 {% include integrations/actions.md %}
 


### PR DESCRIPTION
## Proposed change

Documents the new `todo` platform for the Apple iCloud integration, which exposes Apple Reminders lists as to-do list entities.

Adds the platform to the category, platform and support lists, and a "To-do list" section covering what it does, the handling of reminder groups and subtasks, and the Advanced Data Protection caveat.

## Type of change

- [ ] Removal of a brand or integration
- [ ] Spelling, grammar or other readability improvements to existing documentation
- [ ] Adjusted missing or incorrect information in existing documentation
- [x] Added documentation for a new integration or feature
- [ ] Removed documentation for a removed integration or feature

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/180716

## Checklist

- [x] I have read the [Documentation Standards](https://developers.home-assistant.io/docs/documenting/standards).