### PR TITLE
Add Elgato power-on number entities

### DIFF
--- a/source/_integrations/elgato.markdown
+++ b/source/_integrations/elgato.markdown
@@ -14,6 +14,7 @@ ha_platforms:
   - button
   - diagnostics
   - light
+  - number
   - sensor
   - switch
 ha_integration_type: device
@@ -73,6 +74,16 @@ The integration creates a light entity for each Elgato Light device. You can con
 
 - **Restart**
   - **Description**: Restarts the Elgato Light device.
+  - **Entity category**: Configuration
+
+### Numbers
+
+- **Power-on brightness**
+  - **Description**: The brightness the light uses when it powers on, as a percentage. Only applied when **Power-on behavior** is set to **Use defaults**.
+  - **Entity category**: Configuration
+
+- **Power-on color temperature**
+  - **Description**: The color temperature the light uses when it powers on. Only applied when **Power-on behavior** is set to **Use defaults**. Not available on devices configured to power on to a color instead of a color temperature.
   - **Entity category**: Configuration
 
 ### Sensors
@@ -136,6 +147,7 @@ The integration polls the Elgato Light device every 10 seconds over the local ne
 - The integration communicates with the Elgato Light device over the local network. If the device is not reachable, its entities become unavailable.
 - Color control is only available on devices that support it, such as the Light Strip. Color temperature and brightness are available on all supported models.
 - The battery level sensor and studio mode switch are only available on the Key Light Mini, as other models do not have a built-in battery.
+- The power-on settings are stored on the device itself, so they also apply when the light is switched on at the wall rather than through Home Assistant.
 
 ## Troubleshooting
 

--- a/source/_integrations/elgato.markdown
+++ b/source/_integrations/elgato.markdown
@@ -83,7 +83,7 @@ The integration creates a light entity for each Elgato Light device. You can con
   - **Entity category**: Configuration
 
 - **Power-on color temperature**
-  - **Description**: The color temperature the light uses when it powers on. Only applied when **Power-on behavior** is set to **Use defaults**. Not available on devices configured to power on to a color instead of a color temperature.
+  - **Description**: The color temperature the light uses when it powers on. Only applied when **Power-on behavior** is set to **Use defaults**. Shows as unknown on a light configured to power on to a color instead of a color temperature.
   - **Entity category**: Configuration
 
 ### Sensors


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the two power-on number entities added in home-assistant/core#180720: power-on brightness and power-on color temperature.

Also adds `number` to `ha_platforms`, and a note that these settings live on the device itself, so they apply when the light is switched on at the wall too, not only through Home Assistant.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#180720
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
