### PR TITLE
Correct the Lyngdorf network requirements, add per-model features and blueprints

### DIFF
--- a/source/_integrations/lyngdorf.markdown
+++ b/source/_integrations/lyngdorf.markdown
@@ -32,24 +32,22 @@ The **Lyngdorf** {% term integration %} allows you to control [Lyngdorf] and [St
 
 ## Supported devices
 
-Every model gets a main zone media player and the RoomPerfect position and
-voicing selects. The rest depends on what the model has:
+Every model gets a main zone media player and the RoomPerfect position and voicing selects. The rest depends on what the model has:
 
 | Model | Zone B | Now playing and transport | Remote | Lip sync | Bass and treble trims | Channel trims | Input sensors |
 | ----- | ------ | ------------------------- | ------ | -------- | --------------------- | ------------- | ------------- |
-| [MP-40](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-mp-40/) | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| [MP-50](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-mp-50/) | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| [MP-60](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-mp-60/) | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| [TDAI-1120](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-1120/) | — | Yes | — | — | Yes | — | — |
-| [TDAI-2170](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-2170/) | — | — | — | — | — | — | — |
-| [TDAI-2210](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-2210/) | — | Yes | — | — | Yes | — | — |
-| [TDAI-3400](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-3400/) | — | Yes | — | — | Yes | — | — |
-| [P100](https://steinwaylyngdorf.com/steinway-sons-p100/) | Yes | — | Yes | Yes | — | — | Yes |
-| [P200](https://steinwaylyngdorf.com/steinway-sons-p200/) | Yes | — | Yes | Yes | — | — | Yes |
-| [P300](https://steinwaylyngdorf.com/steinway-sons-p300/) | Yes | — | Yes | Yes | — | — | Yes |
+| [MP-40](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-mp-40/) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [MP-50](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-mp-50/) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [MP-60](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-mp-60/) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [TDAI-1120](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-1120/) | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| [TDAI-2170](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-2170/) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| [TDAI-2210](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-2210/) | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| [TDAI-3400](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-3400/) | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| [P100](https://steinwaylyngdorf.com/steinway-sons-p100/) | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ |
+| [P200](https://steinwaylyngdorf.com/steinway-sons-p200/) | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ |
+| [P300](https://steinwaylyngdorf.com/steinway-sons-p300/) | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ |
 
-The P100, P200, and P300 are made by Lyngdorf and marketed as
-[Steinway & Lyngdorf].
+The P100, P200, and P300 are made by Lyngdorf and marketed as [Steinway & Lyngdorf].
 
 {% note %}
 Only the MP-60, TDAI-1120, and TDAI-3400 have been tested against real hardware. The other models listed here are implemented from the protocol documentation and have not been verified by an owner, so if you have one, please report anything that does not work on [GitHub](https://github.com/home-assistant/core/issues).
@@ -57,17 +55,9 @@ Only the MP-60, TDAI-1120, and TDAI-3400 have been tested against real hardware.
 
 ## Prerequisites
 
-- Home Assistant must be able to reach the device on TCP port 84, which carries
-  the control protocol.
-- The device is identified by the serial number in its UPnP description. Home
-  Assistant locates the description with an SSDP request on UDP port 1900, then
-  fetches it over HTTP from the port the device advertises. The device assigns
-  that port itself and it is not fixed, so a firewall rule cannot rely on a
-  particular number. This applies when adding a device by IP address as well as
-  when one is discovered.
-- Automatic discovery additionally needs the device on the same subnet as Home
-  Assistant, because it relies on multicast SSDP. A device on another subnet can
-  still be added by IP address.
+- Home Assistant must be able to reach the device on TCP port 84, which carries the control protocol.
+- The device is identified by the serial number in its UPnP description. Home Assistant locates the description with an SSDP request on UDP port 1900, then fetches it over HTTP from the port the device advertises. The device assigns that port itself and it is not fixed, so a firewall rule cannot rely on a particular number. This applies when adding a device by IP address as well as when one is discovered.
+- Automatic discovery additionally needs the device on the same subnet as Home Assistant, because it relies on multicast SSDP. A device on another subnet can still be added by IP address.
 
 {% include integrations/config_flow.md %}
 
@@ -215,7 +205,7 @@ The Lyngdorf device does not show up as a discovered device in Home Assistant.
 
 To resolve this issue, try the following steps:
 
-1. Make sure your Lyngdorf device is powered on and on the same subnet as Home Assistant. Automatic discovery uses multicast SSDP, which does not cross subnets.
+1. Make sure your Lyngdorf device is powered on and connected to the same subnet as Home Assistant. Automatic discovery uses multicast SSDP, which does not cross subnets.
 2. Check that UPnP/SSDP is not blocked on your network.
 3. Add the device manually using its IP address. This works across subnets, but still needs UPnP to be reachable, because the device is identified from its UPnP description.
 

--- a/source/_integrations/lyngdorf.markdown
+++ b/source/_integrations/lyngdorf.markdown
@@ -123,62 +123,23 @@ Diagnostic sensors report what the device is receiving and playing:
 
 ## Examples
 
-Switch voicing and RoomPerfect position when playback starts on the main zone:
+### Use a different voicing while watching
 
-```yaml
-automation:
-  - alias: "Cinema mode"
-    triggers:
-      - trigger: state
-        entity_id: media_player.lyngdorf_main_zone
-        to: "playing"
-    actions:
-      - action: select.select_option
-        target:
-          entity_id: select.lyngdorf_voicing
-        data:
-          option: "Movie"
-      - action: select.select_option
-        target:
-          entity_id: select.lyngdorf_roomperfect_position
-        data:
-          option: "Focus 1"
-```
+A voicing chosen for music is rarely the one you want for a film. This blueprint switches the RoomPerfect voicing while a chosen source is selected and the processor is actually receiving video and audio, and switches back as soon as it is not.
 
-Correct lip sync for a source that needs it:
+{% my blueprint_import badge blueprint_url="https://www.home-assistant.io/blueprints/integrations/lyngdorf_cinema_mode.yaml" %}
 
-```yaml
-automation:
-  - alias: "Fix lip sync on the streaming box"
-    triggers:
-      - trigger: state
-        entity_id: media_player.lyngdorf_main_zone
-        attribute: source
-        to: "HDMI 2"
-    actions:
-      - action: number.set_value
-        target:
-          entity_id: number.lyngdorf_lip_sync
-        data:
-          value: 80
-```
+### Correct lip sync for one source
 
-Open the setup menu and step down to the second entry:
+A single source whose picture and sound drift apart needs a delay the other sources do not. This blueprint applies a lip sync delay while that source is selected, and returns to your normal delay when you switch away.
 
-```yaml
-script:
-  lyngdorf_open_setup:
-    sequence:
-      - action: remote.send_command
-        target:
-          entity_id: remote.lyngdorf
-        data:
-          command:
-            - menu
-            - down
-            - down
-            - enter
-```
+{% my blueprint_import badge blueprint_url="https://www.home-assistant.io/blueprints/integrations/lyngdorf_lip_sync_per_source.yaml" %}
+
+### Run a scene when surround audio starts
+
+The audio information sensor reports the incoming format, so it knows a surround soundtrack has started even when the source has not changed. This blueprint runs any action you choose when a surround format appears, and another when it goes back to stereo.
+
+{% my blueprint_import badge blueprint_url="https://www.home-assistant.io/blueprints/integrations/lyngdorf_surround_scene.yaml" %}
 
 ## Data updates
 

--- a/source/_integrations/lyngdorf.markdown
+++ b/source/_integrations/lyngdorf.markdown
@@ -32,28 +32,42 @@ The **Lyngdorf** {% term integration %} allows you to control [Lyngdorf] and [St
 
 ## Supported devices
 
-### Lyngdorf
+Every model gets a main zone media player and the RoomPerfect position and
+voicing selects. The rest depends on what the model has:
 
-- [MP-40](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-mp-40/)
-- MP-50
-- [MP-60](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-mp-60/)
-- [TDAI-1120](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-1120/)
-- TDAI-2170
-- [TDAI-3400](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-3400/)
+| Model | Zone B | Now playing and transport | Remote | Lip sync | Bass and treble trims | Channel trims | Input sensors |
+| ----- | ------ | ------------------------- | ------ | -------- | --------------------- | ------------- | ------------- |
+| [MP-40](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-mp-40/) | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| [MP-50](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-mp-50/) | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| [MP-60](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-mp-60/) | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| [TDAI-1120](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-1120/) | — | Yes | — | — | Yes | — | — |
+| [TDAI-2170](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-2170/) | — | — | — | — | — | — | — |
+| [TDAI-2210](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-2210/) | — | Yes | — | — | Yes | — | — |
+| [TDAI-3400](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-3400/) | — | Yes | — | — | Yes | — | — |
+| [P100](https://steinwaylyngdorf.com/steinway-sons-p100/) | Yes | — | Yes | Yes | — | — | Yes |
+| [P200](https://steinwaylyngdorf.com/steinway-sons-p200/) | Yes | — | Yes | Yes | — | — | Yes |
+| [P300](https://steinwaylyngdorf.com/steinway-sons-p300/) | Yes | — | Yes | Yes | — | — | Yes |
 
-### Steinway & Lyngdorf
-
-- P100
-- P200
-- P300
+The P100, P200, and P300 are made by Lyngdorf and marketed as
+[Steinway & Lyngdorf].
 
 {% note %}
-The MP-60 is the only model that has been tested in the wild so far. Other models should work but may not support all features. If you have a different model, please report any issues on [GitHub](https://github.com/home-assistant/core/issues).
+Only the MP-60, TDAI-1120, and TDAI-3400 have been tested against real hardware. The other models listed here are implemented from the protocol documentation and have not been verified by an owner, so if you have one, please report anything that does not work on [GitHub](https://github.com/home-assistant/core/issues).
 {% endnote %}
 
 ## Prerequisites
 
-- Your Lyngdorf device must be connected to the same network as Home Assistant.
+- Home Assistant must be able to reach the device on TCP port 84, which carries
+  the control protocol.
+- The device is identified by the serial number in its UPnP description. Home
+  Assistant locates the description with an SSDP request on UDP port 1900, then
+  fetches it over HTTP from the port the device advertises. The device assigns
+  that port itself and it is not fixed, so a firewall rule cannot rely on a
+  particular number. This applies when adding a device by IP address as well as
+  when one is discovered.
+- Automatic discovery additionally needs the device on the same subnet as Home
+  Assistant, because it relies on multicast SSDP. A device on another subnet can
+  still be added by IP address.
 
 {% include integrations/config_flow.md %}
 
@@ -182,7 +196,7 @@ The **Lyngdorf** integration uses local push to receive real-time updates from t
 
 ## Known limitations
 
-- Only the MP-60 has been tested. Other models may not support all features.
+- Only the MP-60, TDAI-1120, and TDAI-3400 have been tested against real hardware. The other models are implemented from the protocol documentation and may not support all features.
 - Only local network control is supported.
 - Pausing a source that is controlled by another app, such as AirPlay, ends the session rather than pausing it. The device cannot resume it; only the controlling app can start it again. This is how those protocols work, and is not specific to Home Assistant.
 - Now playing information, playback position, and transport controls require a model with a streaming module. The TDAI-2170 and the P-series do not have one.
@@ -201,9 +215,9 @@ The Lyngdorf device does not show up as a discovered device in Home Assistant.
 
 To resolve this issue, try the following steps:
 
-1. Make sure your Lyngdorf device is powered on and connected to the same network as Home Assistant.
+1. Make sure your Lyngdorf device is powered on and on the same subnet as Home Assistant. Automatic discovery uses multicast SSDP, which does not cross subnets.
 2. Check that UPnP/SSDP is not blocked on your network.
-3. Add the device manually using its IP address.
+3. Add the device manually using its IP address. This works across subnets, but still needs UPnP to be reachable, because the device is identified from its UPnP description.
 
 ### Connection issues
 

--- a/source/_integrations/lyngdorf.markdown
+++ b/source/_integrations/lyngdorf.markdown
@@ -22,7 +22,7 @@ ha_platforms:
   - select
   - sensor
 ha_integration_type: device
-ha_quality_scale: silver
+ha_quality_scale: platinum
 ---
 
 The **Lyngdorf** {% term integration %} allows you to control [Lyngdorf] and [Steinway & Lyngdorf] audio processors and amplifiers from Home Assistant. Lyngdorf Audio is known for its RoomPerfect room correction technology. This integration lets you control power, volume, source selection, sound modes, and audio processing parameters.

--- a/source/blueprints/integrations/lyngdorf_cinema_mode.yaml
+++ b/source/blueprints/integrations/lyngdorf_cinema_mode.yaml
@@ -1,0 +1,140 @@
+blueprint:
+  name: Lyngdorf cinema mode
+  description: >
+    Switch a Lyngdorf processor to a chosen RoomPerfect voicing while a chosen
+    source is selected, the processor is on, and it is actually receiving both
+    video and audio. Return to another voicing as soon as any of that stops
+    being true. Because it waits for a detected signal, the voicing follows what
+    is really on screen rather than merely which input is selected.
+  domain: automation
+  author: fishloa
+
+  input:
+    media_player_entity:
+      name: Media player
+      description: The Lyngdorf zone to watch.
+      selector:
+        entity:
+          filter:
+            - integration: lyngdorf
+              domain: media_player
+    source_name:
+      name: Source
+      description: >
+        The source used for watching, as named on the processor, for example
+        Sky.
+      selector:
+        text:
+    video_information_entity:
+      name: Video information
+      description: The video information sensor, used to detect a video signal.
+      selector:
+        entity:
+          filter:
+            - integration: lyngdorf
+              domain: sensor
+    audio_information_entity:
+      name: Audio information
+      description: The audio information sensor, used to detect an audio signal.
+      selector:
+        entity:
+          filter:
+            - integration: lyngdorf
+              domain: sensor
+    voicing_entity:
+      name: Voicing
+      description: The RoomPerfect voicing select.
+      selector:
+        entity:
+          filter:
+            - integration: lyngdorf
+              domain: select
+    voicing_active:
+      name: Voicing while watching
+      description: >
+        The voicing to select while that source is playing, for example
+        Action+Movie. It must be one of the options the voicing select offers.
+      selector:
+        text:
+    voicing_inactive:
+      name: Voicing otherwise
+      description: >
+        The voicing to return to the rest of the time, for example Neutral.
+      selector:
+        text:
+    no_video_values:
+      name: No video
+      description: >
+        What the video information sensor reports when nothing is arriving.
+        Matched if the sensor value contains any of these.
+      default:
+        - No video
+      selector:
+        text:
+          multiple: true
+    no_audio_values:
+      name: No audio
+      description: >
+        What the audio information sensor reports when nothing is arriving.
+        Matched if the sensor value contains any of these.
+      default:
+        - No Information
+      selector:
+        text:
+          multiple: true
+
+mode: single
+
+triggers:
+  - trigger: state
+    entity_id: !input media_player_entity
+  - trigger: state
+    entity_id: !input video_information_entity
+  - trigger: state
+    entity_id: !input audio_information_entity
+
+variables:
+  media_player_entity: !input media_player_entity
+  source_name: !input source_name
+  video_information_entity: !input video_information_entity
+  audio_information_entity: !input audio_information_entity
+  voicing_entity: !input voicing_entity
+  voicing_active: !input voicing_active
+  voicing_inactive: !input voicing_inactive
+  no_video_values: !input no_video_values
+  no_audio_values: !input no_audio_values
+  video_state: "{{ states(video_information_entity) }}"
+  audio_state: "{{ states(audio_information_entity) }}"
+  has_video: >
+    {{ video_state not in ['unknown', 'unavailable']
+       and no_video_values | select('in', video_state) | list | count == 0 }}
+  has_audio: >
+    {{ audio_state not in ['unknown', 'unavailable']
+       and no_audio_values | select('in', audio_state) | list | count == 0 }}
+  watching: >
+    {{ states(media_player_entity) not in ['off', 'unknown', 'unavailable']
+       and state_attr(media_player_entity, 'source') == source_name
+       and has_video and has_audio }}
+
+actions:
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: >
+              {{ watching and states(voicing_entity) != voicing_active }}
+        sequence:
+          - action: select.select_option
+            target:
+              entity_id: !input voicing_entity
+            data:
+              option: !input voicing_active
+      - conditions:
+          - condition: template
+            value_template: >
+              {{ not watching and states(voicing_entity) != voicing_inactive }}
+        sequence:
+          - action: select.select_option
+            target:
+              entity_id: !input voicing_entity
+            data:
+              option: !input voicing_inactive

--- a/source/blueprints/integrations/lyngdorf_lip_sync_per_source.yaml
+++ b/source/blueprints/integrations/lyngdorf_lip_sync_per_source.yaml
@@ -1,0 +1,81 @@
+blueprint:
+  name: Lyngdorf lip sync per source
+  description: >
+    Apply a lip sync delay when a Lyngdorf zone switches to a particular
+    source, and reset it when the zone switches away.
+  domain: automation
+  author: fishloa
+
+  input:
+    media_player_entity:
+      name: Media player
+      description: The Lyngdorf zone to watch.
+      selector:
+        entity:
+          filter:
+            - integration: lyngdorf
+              domain: media_player
+    source_name:
+      name: Source
+      description: >
+        The source that needs the delay, as named on the processor, for example
+        Sky.
+      selector:
+        text:
+    lip_sync_entity:
+      name: Lip sync
+      description: The lip sync number entity.
+      selector:
+        entity:
+          filter:
+            - integration: lyngdorf
+              domain: number
+    delay_ms:
+      name: Delay
+      description: The delay to apply while that source is selected.
+      default: 80
+      selector:
+        number:
+          min: 0
+          max: 500
+          unit_of_measurement: ms
+    reset_ms:
+      name: Delay when switched away
+      description: The delay to return to for other sources.
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 500
+          unit_of_measurement: ms
+
+mode: single
+
+triggers:
+  - trigger: state
+    entity_id: !input media_player_entity
+    attribute: source
+    id: source_changed
+
+actions:
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: >
+              {{ state_attr(media_player_entity, 'source') == source_name }}
+        sequence:
+          - action: number.set_value
+            target:
+              entity_id: !input lip_sync_entity
+            data:
+              value: !input delay_ms
+    default:
+      - action: number.set_value
+        target:
+          entity_id: !input lip_sync_entity
+        data:
+          value: !input reset_ms
+
+variables:
+  media_player_entity: !input media_player_entity
+  source_name: !input source_name

--- a/source/blueprints/integrations/lyngdorf_surround_scene.yaml
+++ b/source/blueprints/integrations/lyngdorf_surround_scene.yaml
@@ -1,0 +1,66 @@
+blueprint:
+  name: Lyngdorf run a scene on surround audio
+  description: >
+    Run an action when a Lyngdorf processor reports a surround audio format,
+    and another when it goes back to stereo. The audio information sensor
+    reports the incoming format, so this reacts to what is actually playing
+    rather than to the selected source.
+  domain: automation
+  author: fishloa
+
+  input:
+    audio_information_entity:
+      name: Audio information
+      description: The audio information sensor.
+      selector:
+        entity:
+          filter:
+            - integration: lyngdorf
+              domain: sensor
+    surround_formats:
+      name: Surround formats
+      description: >
+        Formats that count as surround. Matched if the sensor value contains
+        any of these, so Atmos matches Dolby Atmos.
+      default:
+        - Atmos
+        - DTS
+        - Surround
+      selector:
+        text:
+          multiple: true
+    surround_action:
+      name: When surround starts
+      description: What to do when a surround format is detected.
+      selector:
+        action:
+    stereo_action:
+      name: When surround stops
+      description: What to do when the format is no longer surround.
+      default: []
+      selector:
+        action:
+
+mode: single
+
+triggers:
+  - trigger: state
+    entity_id: !input audio_information_entity
+
+variables:
+  formats: !input surround_formats
+  current: "{{ trigger.to_state.state | default('', true) }}"
+  previous: "{{ trigger.from_state.state | default('', true) }}"
+  is_surround: "{{ formats | select('in', current) | list | count > 0 }}"
+  was_surround: "{{ formats | select('in', previous) | list | count > 0 }}"
+
+actions:
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: "{{ is_surround and not was_surround }}"
+        sequence: !input surround_action
+      - conditions:
+          - condition: template
+            value_template: "{{ was_surround and not is_surround }}"
+        sequence: !input stereo_action


### PR DESCRIPTION
## Proposed change

The same-network requirement was wrong. The serial lookup is a unicast SSDP
M-SEARCH to the device rather than multicast, so a device on another subnet
works fine when added by IP address — the old wording told those users they were
unsupported. Only automatic discovery needs the same subnet.

The prerequisites now name the ports that are fixed, TCP 84 for the control
protocol and UDP 1900 for the SSDP request, and explain that the UPnP
description is served from a port the device assigns itself, so a firewall rule
cannot rely on a particular number. Measured against an MP-60, which serves it
from a high device-assigned port. This also matters in troubleshooting, where
"add the device manually using its IP address" is offered as the fix for a
discovery problem and only works if UPnP is reachable — that step now says so.

The two brand lists under supported devices are replaced by one table of which
entities each model gets. The models differ more than the old list suggested:
the P-series has Zone B, a remote and lip sync but no streaming or trims, while
the TDAI-series has streaming and tone trims but none of the rest, and the
TDAI-2170 gets only a main zone media player and the two RoomPerfect selects.
Every value comes from the library's own per-model capability table.

Also adds TDAI-2210, which the library has always supported but the page never
listed, links every model, and replaces the claim that only the MP-60 has been
tested — the TDAI-1120 and TDAI-3400 both have owners running it, and two of the
library fixes came from them.

The inline examples are replaced by three blueprints under
`source/blueprints/integrations/`, linked with import badges:

- Switches voicing while watching a source
- Applies lip sync delay per source
- Runs actions when surround audio starts

The remote script example is dropped; `remote.send_command` is already covered
under supported functionality.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

Targeted at `next` rather than `current` because the sections being corrected
only exist there: the platform documentation for 2026.9 landed on `next` in
#47477, and the corrected paragraphs are part of it.

- Link to parent pull request in the codebase: https://github.com/home-assistant/home-assistant.io/pull/47477
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

