### PR TITLE
Document Besen charging current control

### DIFF
--- a/source/_integrations/besen.markdown
+++ b/source/_integrations/besen.markdown
@@ -11,6 +11,7 @@ ha_codeowners:
 ha_domain: besen
 ha_bluetooth: true
 ha_platforms:
+  - number
   - sensor
   - switch
 ha_config_flow: true
@@ -32,18 +33,18 @@ Other Besen chargers using the same `ACP#` Bluetooth protocol may also work.
 ## Prerequisites
 
 - A Besen charger advertising as `ACP#...`.
-- The charger's Bluetooth address and 6-digit PIN.
+- The charger's 6-digit PIN.
 - A Bluetooth adapter or ESPHome Bluetooth proxy that supports active GATT connections.
 
 ESPHome Bluetooth proxies need active connections enabled. Each connected charger uses one active GATT connection slot on the selected proxy.
 
 {% include integrations/config_flow.md %}
 
-Home Assistant can discover chargers that advertise as `ACP#...`. If discovery does not find your charger, add the integration manually and enter the charger's Bluetooth address.
+Home Assistant can discover chargers that advertise as `ACP#...`. If your charger is not discovered automatically, add the integration manually and select it from the list of Besen chargers currently visible over Bluetooth. If no charger is found, follow the [discovery troubleshooting steps](#the-charger-is-not-discovered).
 
 {% configuration_basic %}
-Bluetooth address:
-  description: "The BLE address of the charger. Discovery fills this automatically when Home Assistant sees an ACP# advertisement."
+Device:
+  description: "The discovered Besen charger to set up."
 PIN:
   description: "The charger's 6-digit Bluetooth PIN. Many units default to 123456."
 {% endconfiguration_basic %}
@@ -55,6 +56,10 @@ PIN:
 The {% term integration %} provides a **Charge** switch to start or stop charging.
 
 The switch state follows the charging state reported by the charger.
+
+### Number
+
+The **Charging current** number sets the maximum current the charger can use. The available range starts at 6 A and ends at the maximum reported by the charger. Home Assistant uses 32 A if the charger does not report a maximum.
 
 ### Sensors
 
@@ -79,6 +84,7 @@ The integration does not provide custom actions. Use the standard entity actions
 
 - `switch.turn_on` starts charging.
 - `switch.turn_off` stops charging.
+- `number.set_value` sets the charging current.
 
 ## Examples
 
@@ -120,7 +126,7 @@ This is a local push integration. There is no cloud dependency.
 
 The integration does not support:
 
-- Changing charger settings such as charge current, language, temperature unit, LCD brightness, or device name.
+- Changing charger settings such as language, temperature unit, LCD brightness, or device name.
 - Reporting additional telemetry such as charging status text, charger error details, or Bluetooth signal strength as entities.
 - Wi-Fi provisioning.
 - Password reset.

--- a/source/_integrations/besen.markdown
+++ b/source/_integrations/besen.markdown
@@ -59,7 +59,7 @@ The switch state follows the charging state reported by the charger.
 
 ### Number
 
-The **Charging current** number sets the maximum current the charger can use. The available range starts at 6 A and ends at the maximum reported by the charger. Home Assistant uses 32 A if the charger does not report a maximum.
+The **Charging current** number sets the maximum current the charger can use. The available range starts at 6&nbsp;A and ends at the maximum reported by the charger. Home Assistant uses 32&nbsp;A if the charger does not report a maximum.
 
 ### Sensors
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

I documented the new Besen charging current number entity, including its range and standard action. I also corrected the setup instructions to match the config flow, which selects a charger currently discovered over Bluetooth instead of accepting a manually entered Bluetooth address.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/180617
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
