### PR TITLE
Document temporary PIN support for Schlage add_code and get_codes

### DIFF
--- a/source/_actions/schlage.add_code.markdown
+++ b/source/_actions/schlage.add_code.markdown
@@ -28,7 +28,7 @@ To add a PIN code from an automation or a script:
 
 {% options_ui %}
 PIN name:
-  description: Name for PIN code. Must be case insensitively unique to the lock.
+  description: Name for PIN code. Must be unique ignoring capitalization to the lock.
 PIN code:
   description: The PIN code to add. Must be unique to the lock and be between 4 and 8 digits long.
 Notify when PIN is used:
@@ -82,7 +82,7 @@ action: |
 
 {% options_yaml %}
 name:
-  description: Name for PIN code. Must be case insensitively unique to the lock.
+  description: Name for PIN code. Must be unique ignoring capitalization to the lock.
   required: true
   type: string
 code:
@@ -97,11 +97,11 @@ notify_on_use:
 start_datetime:
   description: When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required.
   required: false
-  type: string
+  type: datetime
 end_datetime:
   description: When this PIN stops working. Required together with the start time; leaving both empty creates a permanent PIN.
   required: false
-  type: string
+  type: datetime
 {% endoptions_yaml %}
 
 {% include actions/targets.md domain="lock" %}

--- a/source/_actions/schlage.add_code.markdown
+++ b/source/_actions/schlage.add_code.markdown
@@ -28,7 +28,7 @@ To add a PIN code from an automation or a script:
 
 {% options_ui %}
 PIN name:
-  description: Name for PIN code. Must be unique ignoring capitalization to the lock.
+  description: The name of the PIN code. Must be unique to the lock, regardless of capitalization.
 PIN code:
   description: The PIN code to add. Must be unique to the lock and be between 4 and 8 digits long.
 Notify when PIN is used:
@@ -82,7 +82,7 @@ action: |
 
 {% options_yaml %}
 name:
-  description: Name for PIN code. Must be unique ignoring capitalization to the lock.
+  description: The name of the PIN code. Must be unique to the lock, regardless of capitalization.
   required: true
   type: string
 code:

--- a/source/_actions/schlage.add_code.markdown
+++ b/source/_actions/schlage.add_code.markdown
@@ -46,9 +46,9 @@ End time:
 
 When you add a PIN without a start or end time, it becomes a permanent PIN that works until you delete it. If you provide both a start time and an end time, the PIN becomes a temporary PIN that is only active during that window.
 
-You must provide both times together or leave both empty. If you provide only one, you get an error: _Start and end times are required together. Provide both to create a temporary PIN, or neither for a permanent one._
+You must provide both times together or leave both empty. If you provide only one, you get an error: `Start and end times are required together. Provide both to create a temporary PIN, or neither for a permanent one.`
 
-The start time must be before the end time. If the start time is the same as or after the end time, you get an error: _Start time must be before end time._
+The start time must be before the end time. If the start time is the same as or after the end time, you get an error: `Start time must be before end time.`
 
 {% include actions/yaml_header.md %}
 

--- a/source/_actions/schlage.add_code.markdown
+++ b/source/_actions/schlage.add_code.markdown
@@ -8,7 +8,7 @@ related_actions:
   - schlage.get_codes
 ---
 
-Use this action to add a new PIN code to a Schlage lock, for example to give a guest or family member their own code.
+Use this action to add a new PIN code to a Schlage lock, for example to give a guest or family member their own code. You can create a permanent PIN or a temporary PIN that is only active during a specific time window.
 
 {% include actions/ui_header.md %}
 
@@ -21,19 +21,34 @@ To add a PIN code from an automation or a script:
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Schlage lock.
 6. From the actions shown for that target, select **Schlage: Add PIN code**.
 7. Enter the **PIN name** and the **PIN code**.
-8. Select **Save**.
+8. To create a temporary PIN, enter a **Start time** and **End time**. Leave both empty for a permanent PIN.
+9. Select **Save**.
 
 ### Options in the UI
 
 {% options_ui %}
 PIN name:
-  description: A name for the PIN code. Must be unique to the lock, regardless of capitalization.
+  description: Name for PIN code. Must be case insensitively unique to the lock.
 PIN code:
-  description: The PIN code to add. Must be unique to the lock and between 4 and 8 digits long.
+  description: The PIN code to add. Must be unique to the lock and be between 4 and 8 digits long.
 Notify when PIN is used:
-  description: Send the native Schlage notification when this PIN is used. On by default.
+  description: Whether the native Schlage notification should be sent when this PIN is used. On by default.
+  required: false
+Start time:
+  description: When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required.
+  required: false
+End time:
+  description: When this PIN stops working. Required together with the start time; leaving both empty creates a permanent PIN.
   required: false
 {% endoptions_ui %}
+
+### Temporary vs. permanent PINs
+
+When you add a PIN without a start or end time, it becomes a permanent PIN that works until you delete it. If you provide both a start time and an end time, the PIN becomes a temporary PIN that is only active during that window.
+
+You must provide both times together or leave both empty. If you provide only one, you get an error: _Start and end times are required together. Provide both to create a temporary PIN, or neither for a permanent one._
+
+The start time must be before the end time. If the start time is the same as or after the end time, you get an error: _Start time must be before end time._
 
 {% include actions/yaml_header.md %}
 
@@ -49,22 +64,44 @@ action: |
     code: "3333"
 {% endexample %}
 
+To add a temporary PIN in YAML:
+
+{% example %}
+action: |
+  action: schlage.add_code
+  target:
+    entity_id: lock.front_door
+  data:
+    name: Guest
+    code: "1234"
+    start_datetime: "2026-09-01T15:00:00"
+    end_datetime: "2026-09-01T16:00:00"
+{% endexample %}
+
 ### Options in YAML
 
 {% options_yaml %}
 name:
-  description: A name for the PIN code. Must be unique to the lock, regardless of capitalization.
+  description: Name for PIN code. Must be case insensitively unique to the lock.
   required: true
   type: string
 code:
-  description: The PIN code to add. Must be unique to the lock and between 4 and 8 digits long.
+  description: The PIN code to add. Must be unique to the lock and be between 4 and 8 digits long.
   required: true
   type: string
 notify_on_use:
-  description: Send the native Schlage notification when this PIN is used.
+  description: Whether the native Schlage notification should be sent when this PIN is used.
   required: false
   type: boolean
   default: true
+start_datetime:
+  description: When this PIN becomes active. Providing a start time makes the PIN temporary; both a start and an end time are required.
+  required: false
+  type: string
+end_datetime:
+  description: When this PIN stops working. Required together with the start time; leaving both empty creates a permanent PIN.
+  required: false
+  type: string
 {% endoptions_yaml %}
 
 {% include actions/targets.md domain="lock" %}

--- a/source/_actions/schlage.get_codes.markdown
+++ b/source/_actions/schlage.get_codes.markdown
@@ -109,7 +109,7 @@ The `schedule` field describes when a PIN is active. It is `null` for permanent 
 }
 ```
 
-**Recurring multi** — two time windows, also set through the Schlage app:
+**Multi-recurring** — two time windows, also set through the Schlage app:
 
 ```json
 {

--- a/source/_actions/schlage.get_codes.markdown
+++ b/source/_actions/schlage.get_codes.markdown
@@ -55,7 +55,6 @@ The action returns the result for each targeted lock, keyed by entity ID. For ea
 - **name**: The name of the PIN code.
 - **code**: The PIN value.
 - **access_code_id**: A unique access code identifier.
-- **notify_on_use**: Whether the native Schlage notification is sent when this PIN is used.
 - **schedule**: The schedule for this PIN, or `null` for permanent PINs.
 
 ```yaml
@@ -64,13 +63,11 @@ lock.front_door:
     name: Example Person
     code: "3333"
     access_code_id: "93ab517c-0000-0000-0000-000000000000"
-    notify_on_use: true
     schedule: null
   82958b77-0000-0000-0000-000000000000:
     name: Guest
     code: "1234"
     access_code_id: "82958b77-0000-0000-0000-000000000000"
-    notify_on_use: true
     schedule:
       type: temporary
       start_datetime: "2026-09-01T15:00:00+00:00"
@@ -116,7 +113,7 @@ The `schedule` field describes when a PIN is active. It is `null` for permanent 
 
 ```json
 {
-  "type": "recurring_multi",
+  "type": "multi_recurring",
   "windows": [
     {
       "days_of_week": {
@@ -152,7 +149,7 @@ The `schedule` field describes when a PIN is active. It is `null` for permanent 
 }
 ```
 
-Recurring and recurring_multi schedules are configured through the Schlage app and cannot be set through Home Assistant service actions.
+Recurring and multi_recurring schedules are configured through the Schlage app and cannot be set through Home Assistant service actions.
 
 {% include actions/try_it.md %}
 

--- a/source/_actions/schlage.get_codes.markdown
+++ b/source/_actions/schlage.get_codes.markdown
@@ -50,17 +50,109 @@ This action has no additional YAML options beyond the target.
 
 ## Response data
 
-The action returns the result for each targeted lock, keyed by entity ID. For each lock, it returns a mapping of the stored codes, keyed by a unique code identifier. Each code has a `name` and the `code` itself.
+The action returns the result for each targeted lock, keyed by entity ID. For each lock, it returns a mapping of the stored codes, keyed by a unique code identifier. Each code has the following fields:
+
+- **name**: The name of the PIN code.
+- **code**: The PIN value.
+- **access_code_id**: A unique access code identifier.
+- **notify_on_use**: Whether the native Schlage notification is sent when this PIN is used.
+- **schedule**: The schedule for this PIN, or `null` for permanent PINs.
 
 ```yaml
 lock.front_door:
   93ab517c-0000-0000-0000-000000000000:
     name: Example Person
     code: "3333"
+    access_code_id: "93ab517c-0000-0000-0000-000000000000"
+    notify_on_use: true
+    schedule: null
   82958b77-0000-0000-0000-000000000000:
-    name: Example person 2
-    code: "2222"
+    name: Guest
+    code: "1234"
+    access_code_id: "82958b77-0000-0000-0000-000000000000"
+    notify_on_use: true
+    schedule:
+      type: temporary
+      start_datetime: "2026-09-01T15:00:00+00:00"
+      end_datetime: "2026-09-01T16:00:00+00:00"
 ```
+
+### Schedule formats
+
+The `schedule` field describes when a PIN is active. It is `null` for permanent PINs, or one of the following shapes:
+
+**Temporary** — set via the `start_datetime` and `end_datetime` fields:
+
+```json
+{
+  "type": "temporary",
+  "start_datetime": "2026-09-01T15:00:00+00:00",
+  "end_datetime": "2026-09-01T16:00:00+00:00"
+}
+```
+
+**Recurring** — a single recurring schedule set through the Schlage app:
+
+```json
+{
+  "type": "recurring",
+  "days_of_week": {
+    "sun": false,
+    "mon": true,
+    "tue": true,
+    "wed": true,
+    "thu": true,
+    "fri": true,
+    "sat": false
+  },
+  "start_hour": 8,
+  "start_minute": 0,
+  "end_hour": 17,
+  "end_minute": 0
+}
+```
+
+**Recurring multi** — two time windows, also set through the Schlage app:
+
+```json
+{
+  "type": "recurring_multi",
+  "windows": [
+    {
+      "days_of_week": {
+        "sun": false,
+        "mon": true,
+        "tue": true,
+        "wed": true,
+        "thu": true,
+        "fri": true,
+        "sat": false
+      },
+      "start_hour": 8,
+      "start_minute": 0,
+      "end_hour": 12,
+      "end_minute": 0
+    },
+    {
+      "days_of_week": {
+        "sun": false,
+        "mon": true,
+        "tue": true,
+        "wed": true,
+        "thu": true,
+        "fri": true,
+        "sat": false
+      },
+      "start_hour": 13,
+      "start_minute": 0,
+      "end_hour": 17,
+      "end_minute": 0
+    }
+  ]
+}
+```
+
+Recurring and recurring_multi schedules are configured through the Schlage app and cannot be set through Home Assistant service actions.
 
 {% include actions/try_it.md %}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the temporary PIN support added to the Schlage integration in home-assistant/core#180909 (draft): `schlage.add_code` gains optional `start_datetime` and `end_datetime` fields for time-window PINs, and `schlage.get_codes` now returns each PIN's `access_code_id` and serialized `schedule` (temporary, recurring, or multi-recurring shapes, or null for permanent PINs).

Changes are limited to the two existing per-action pages (`schlage.add_code` and `schlage.get_codes`). The integration page is unchanged.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#180909
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - [x] I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].
