### PR TITLE
Add LG AC infrared buttons documentation

### DIFF
--- a/source/_integrations/lg_infrared.markdown
+++ b/source/_integrations/lg_infrared.markdown
@@ -147,7 +147,7 @@ Supported range: 16 °C to 30 °C in 1 °C steps.
 
 #### Buttons
 
-When an infrared emitter is configured, these button entities are created for the air conditioner. Each button sends a one-shot infrared command that has no separate on and off code.
+When an infrared emitter is configured, these button entities are created for the air conditioner. Each button sends a single infrared command. There is no separate command to turn the feature on and off again.
 
 - **Jet**: Runs the unit at maximum power for fast cooling or heating.
 - **Eco**: Reduces the unit's power draw. Some remotes label this button Diet.
@@ -181,7 +181,7 @@ If you also have an infrared receiver entity (from an IR blaster that can also l
 - Volume control for the TV is step-based only; there is no way to set an absolute volume level.
 - For the air conditioner, the dry mode temperature is fixed at 24 °C by the LG air conditioner infrared protocol and cannot be changed. Fan only mode has no target temperature at all. Changing the target temperature in either mode is remembered for the next time you switch to cool or heat, but nothing is sent to the unit.
 - Changing the fan speed while the air conditioner is off is also remembered rather than sent. It is applied with the next command that turns the unit on.
-- The air conditioner button entities send one-shot commands and have no state. The unit does not report whether a feature is currently on or off, so features like **Jet** or **Eco** cannot be shown as active.
+- The air conditioner button entities each send a single command and have no state. The unit does not report whether a feature is currently on or off, so features like **Jet** or **Eco** cannot be shown as active.
 - The air conditioner switch entities also use assumed state. Each sends a discrete infrared code, but Home Assistant cannot confirm that the unit received it, so the shown state reflects the last command sent.
 
 ## Removing the integration

--- a/source/_integrations/lg_infrared.markdown
+++ b/source/_integrations/lg_infrared.markdown
@@ -149,18 +149,18 @@ Supported range: 16 °C to 30 °C in 1 °C steps.
 
 When an infrared emitter is configured, these button entities are created for the air conditioner. Each button sends a single infrared command. There is no separate command to turn the feature on and off again.
 
-- **Jet**: Runs the unit at maximum power for fast cooling or heating.
-- **Eco**: Reduces the unit's power draw. Some remotes label this button Diet.
-- **Viraat**: Runs an extra boost mode, separate from **Jet**. Only LG India models offer it, so this button is disabled by default. Enable it if your remote has a Viraat button.
+- **Jet mode**: Runs the unit at maximum power for fast cooling or heating.
+- **Eco mode**: Reduces the unit's power draw. Some remotes label this button Diet.
+- **Viraat mode**: Runs an extra boost mode, separate from **Jet mode**. Only LG India models offer it, so this button is disabled by default. Enable it if your remote has a Viraat button.
 - **AI mode**: Turns on the automatic AI operating mode.
 
 To turn one of these modes off, select any other mode, such as **Cool**.
 
-- **Light**: Toggles the display light on the unit.
-- **Beep**: Toggles the confirmation sound the unit makes.
-- **Wi-Fi**: Turns on the unit's Wi-Fi pairing.
+- **Toggle light**: Switches the display light on the unit on or off.
+- **Toggle beep**: Switches the confirmation sound the unit makes on or off.
+- **Start Wi-Fi pairing**: Puts the unit into Wi-Fi pairing mode.
 - **Diagnose**: Triggers the unit's self-diagnosis routine.
-- **Vertical swing toggle**: Switches the vertical vanes between swing and off. This button is disabled by default because the climate entity's swing mode control offers the same feature with more positions. Enable it only if your model does not respond to that control.
+- **Toggle vertical swing**: Switches the vertical vanes between swing and off. This button is disabled by default because the climate entity's swing mode control offers the same feature with more positions. Enable it only if your model does not respond to that control.
 
 #### Switches
 
@@ -181,7 +181,7 @@ If you also have an infrared receiver entity (from an IR blaster that can also l
 - Volume control for the TV is step-based only; there is no way to set an absolute volume level.
 - For the air conditioner, the dry mode temperature is fixed at 24 °C by the LG air conditioner infrared protocol and cannot be changed. Fan only mode has no target temperature at all. Changing the target temperature in either mode is remembered for the next time you switch to cool or heat, but nothing is sent to the unit.
 - Changing the fan speed while the air conditioner is off is also remembered rather than sent. It is applied with the next command that turns the unit on.
-- The air conditioner button entities each send a single command and have no state. The unit does not report whether a feature is currently on or off, so features like **Jet** or **Eco** cannot be shown as active.
+- The air conditioner button entities each send a single command and have no state. The unit does not report whether a feature is currently on or off, so features like **Jet mode** or **Eco mode** cannot be shown as active.
 - The air conditioner switch entities also use assumed state. Each sends a discrete infrared code, but Home Assistant cannot confirm that the unit received it, so the shown state reflects the last command sent.
 
 ## Removing the integration

--- a/source/_integrations/lg_infrared.markdown
+++ b/source/_integrations/lg_infrared.markdown
@@ -156,8 +156,8 @@ When an infrared emitter is configured, these button entities are created for th
 
 To turn one of these modes off, select any other mode, such as **Cool**.
 
-- **Toggle light**: Switches the display light on the unit on or off.
-- **Toggle beep**: Switches the confirmation sound the unit makes on or off.
+- **Toggle light**: Turns the unit's display light on or off.
+- **Toggle beep**: Turns the unit's confirmation sound on or off.
 - **Start Wi-Fi pairing**: Puts the unit into Wi-Fi pairing mode.
 - **Diagnose**: Triggers the unit's self-diagnosis routine.
 - **Toggle vertical swing**: Switches the vertical vanes between swing and off. This button is disabled by default because the climate entity's swing mode control offers the same feature with more positions. Enable it only if your model does not respond to the swing mode control.

--- a/source/_integrations/lg_infrared.markdown
+++ b/source/_integrations/lg_infrared.markdown
@@ -145,6 +145,23 @@ Horizontal swing positions the airflow left or right:
 
 Supported range: 16 °C to 30 °C in 1 °C steps.
 
+#### Buttons
+
+When an infrared emitter is configured, these button entities are created for the air conditioner. Each button sends a one-shot infrared command that has no separate on and off code.
+
+- **Jet**: Runs the unit at maximum power for fast cooling or heating.
+- **Eco**: Reduces the unit's power draw. Some remotes label this button Diet.
+- **Viraat**: Runs an extra boost mode, separate from **Jet**. Only LG India models offer it, so this button is disabled by default. Enable it if your remote has a Viraat button.
+- **AI mode**: Turns on the automatic AI operating mode.
+
+To turn one of these modes off, select any other mode, such as **Cool**.
+
+- **Light**: Toggles the display light on the unit.
+- **Beep**: Toggles the confirmation sound the unit makes.
+- **Wi-Fi**: Turns on the unit's Wi-Fi pairing.
+- **Diagnose**: Triggers the unit's self-diagnosis routine.
+- **Vertical swing toggle**: Switches the vertical vanes between swing and off. This button is disabled by default because the climate entity's swing mode control offers the same feature with more positions. Enable it only if your model does not respond to that control.
+
 #### Switches
 
 When an infrared emitter is configured, these switch entities are created for the air conditioner. Each uses a separate infrared code to turn the feature on or off.
@@ -164,6 +181,7 @@ If you also have an infrared receiver entity (from an IR blaster that can also l
 - Volume control for the TV is step-based only; there is no way to set an absolute volume level.
 - For the air conditioner, the dry mode temperature is fixed at 24 °C by the LG air conditioner infrared protocol and cannot be changed. Fan only mode has no target temperature at all. Changing the target temperature in either mode is remembered for the next time you switch to cool or heat, but nothing is sent to the unit.
 - Changing the fan speed while the air conditioner is off is also remembered rather than sent. It is applied with the next command that turns the unit on.
+- The air conditioner button entities send one-shot commands and have no state. The unit does not report whether a feature is currently on or off, so features like **Jet** or **Eco** cannot be shown as active.
 - The air conditioner switch entities also use assumed state. Each sends a discrete infrared code, but Home Assistant cannot confirm that the unit received it, so the shown state reflects the last command sent.
 
 ## Removing the integration

--- a/source/_integrations/lg_infrared.markdown
+++ b/source/_integrations/lg_infrared.markdown
@@ -147,7 +147,7 @@ Supported range: 16 °C to 30 °C in 1 °C steps.
 
 #### Buttons
 
-When an infrared emitter is configured, these button entities are created for the air conditioner. Each button sends a single infrared command. There is no separate command to turn the feature on and off again.
+When an infrared emitter is configured, these button entities are created for the air conditioner. Each button sends a single infrared command. The protocol has no separate on and off codes for these features, so they are buttons rather than switches.
 
 - **Jet mode**: Runs the unit at maximum power for fast cooling or heating.
 - **Eco mode**: Reduces the unit's power draw. Some remotes label this button Diet.
@@ -160,7 +160,7 @@ To turn one of these modes off, select any other mode, such as **Cool**.
 - **Toggle beep**: Switches the confirmation sound the unit makes on or off.
 - **Start Wi-Fi pairing**: Puts the unit into Wi-Fi pairing mode.
 - **Diagnose**: Triggers the unit's self-diagnosis routine.
-- **Toggle vertical swing**: Switches the vertical vanes between swing and off. This button is disabled by default because the climate entity's swing mode control offers the same feature with more positions. Enable it only if your model does not respond to that control.
+- **Toggle vertical swing**: Switches the vertical vanes between swing and off. This button is disabled by default because the climate entity's swing mode control offers the same feature with more positions. Enable it only if your model does not respond to the swing mode control.
 
 #### Switches
 


### PR DESCRIPTION
## Proposed change
<!--
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the
    additional information section.
-->

Documents the LG air conditioner buttons: **Jet**, **Eco**, **Viraat**, **AI mode**, **Light**, **Beep**, **Wi-Fi**, **Diagnose** and the legacy vertical swing toggle, along with a known limitation covering their lack of state.

The core change was split into four pull requests at a reviewer's request, so this documentation PR was split to match and pairs with the one code PR above.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/180842
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
