### PR TITLE
Add LG AC infrared switches documentation

### DIFF
--- a/source/_integrations/lg_infrared.markdown
+++ b/source/_integrations/lg_infrared.markdown
@@ -6,6 +6,7 @@ ha_category:
   - Event
   - Infrared
   - Media player
+  - Switch
 ha_release: 2026.4
 ha_iot_class: Assumed State
 ha_codeowners:

--- a/source/_integrations/lg_infrared.markdown
+++ b/source/_integrations/lg_infrared.markdown
@@ -17,6 +17,7 @@ ha_platforms:
   - climate
   - event
   - media_player
+  - switch
 ha_integration_type: device
 ha_quality_scale: silver
 ---
@@ -126,6 +127,13 @@ The climate entity offers the modes you selected during setup.
 
 Supported range: 16 °C to 30 °C in 1 °C steps.
 
+#### Switches
+
+When an infrared emitter is configured, these switch entities are created for the air conditioner. Each uses a separate infrared code to turn the feature on or off.
+
+- **Ion generator**: Turns the ionizer or plasma air-purifying feature on or off.
+- **Auto clean**: Turns the self-cleaning drying cycle on or off.
+
 #### Physical remote state tracking
 
 If you also have an infrared receiver entity (from an IR blaster that can also listen), you can optionally select it during setup. When selected, the integration decodes signals from the physical LG air conditioner remote and updates the climate entity to match, so the mode, fan speed, and target temperature stay in sync.
@@ -138,6 +146,7 @@ If you also have an infrared receiver entity (from an IR blaster that can also l
 - Volume control for the TV is step-based only; there is no way to set an absolute volume level.
 - For the air conditioner, the dry mode temperature is fixed at 24 °C by the LG air conditioner infrared protocol and cannot be changed. Fan only mode has no target temperature at all. Changing the target temperature in either mode is remembered for the next time you switch to cool or heat, but nothing is sent to the unit.
 - Changing the fan speed while the air conditioner is off is also remembered rather than sent. It is applied with the next command that turns the unit on.
+- The air conditioner switch entities also use assumed state. Each sends a discrete infrared code, but Home Assistant cannot confirm that the unit received it, so the shown state reflects the last command sent.
 
 ## Removing the integration
 


### PR DESCRIPTION
## Proposed change
<!--
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the
    additional information section.
-->

Documents the LG air conditioner **Ion generator** and **Auto clean** switches, adds `switch` to the platform list, and notes the assumed state they use.

The core change was split into four pull requests at a reviewer's request, so this documentation PR was split to match and pairs with the one code PR above.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/180843
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
