### PR TITLE
Document pannable option for Sankey energy dashboard cards

### DIFF
--- a/source/_dashboards/energy.markdown
+++ b/source/_dashboards/energy.markdown
@@ -608,6 +608,11 @@ max_devices:
   description: Maximum number of devices shown under your home and under each upstream device. Devices beyond the limit are combined into a single **Other** node, smallest first, so their totals are still included. On the devices energy graph, `max_devices` hides the extra devices instead. The limit applies per upstream device, not per floor or area.
   type: integer
   default: 20
+pannable:
+  required: false
+  description: Whether the graph can be panned by dragging. When set to `false`, a drag gesture starting on the card falls through to the page instead.
+  type: boolean
+  default: true
 {% endconfiguration %}
 
 ### Examples
@@ -671,6 +676,11 @@ max_devices:
   description: Maximum number of devices shown under your home and under each upstream device. Devices beyond the limit are combined into a single **Other** node, smallest first, so their totals are still included. On the devices energy graph, `max_devices` hides the extra devices instead. The limit applies per upstream device, not per floor or area.
   type: integer
   default: 20
+pannable:
+  required: false
+  description: Whether the graph can be panned by dragging. When set to `false`, a drag gesture starting on the card falls through to the page instead.
+  type: boolean
+  default: true
 {% endconfiguration %}
 
 ### Examples

--- a/source/_dashboards/energy.markdown
+++ b/source/_dashboards/energy.markdown
@@ -610,7 +610,7 @@ max_devices:
   default: 20
 pannable:
   required: false
-  description: Whether the graph can be panned by dragging. When set to `false`, a drag gesture starting on the card falls through to the page instead.
+  description: Whether the graph can be panned by dragging. When set to `false`, dragging on the card scrolls the page instead.
   type: boolean
   default: true
 {% endconfiguration %}


### PR DESCRIPTION
## Proposed change

Documents the new `pannable` config option for the Sankey energy graph
and power Sankey graph cards. When set to `false`, drag-to-pan/zoom is
disabled on the chart, so a drag gesture starting on the card falls
through to the page for normal scrolling instead. Matches the style of
the existing `group_by_area`/`group_by_floor` entries.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/frontend#53926
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
