### PR TITLE
Say that Fronius per-string DC energy is device dependent

### DIFF
--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -134,16 +134,14 @@ Leave the data format setting (**float** or **int + SF**) as it is. The integrat
 
 These entities are added per inverter and updated every minute:
 
-- `MPPT <n> DC power` and `MPPT <n> DC energy` for each MPP tracker.
+- `MPPT <n> DC power` and `MPPT <n> energy` for each MPP tracker.
 - `MPPT <n> DC current` and `MPPT <n> DC voltage` for each MPP tracker. Disabled by default.
 - `PV energy total`: lifetime energy from the photovoltaic strings only. Whether this is a DC measurement depends on the device, see below.
 - `Battery charging energy total` and `Battery discharging energy total`: on hybrid inverters that expose their battery as dedicated MPP trackers, such as Gen24 with a battery.
 
-{% note %}
-`MPPT <n> DC power` is a DC measurement on every device tested, and matches `DC current` times `DC voltage`.
+`MPPT <n> DC power` is a DC measurement on every device tested, and matches `MPPT <n> DC current` times `MPPT <n> DC voltage`.
 
-`MPPT <n> DC energy` is not consistent between devices. A Gen24 reports the lifetime energy of each string, which is a DC value and therefore a few percent above `Total energy`, the AC counter. A SnapINverter reports the same value as `Total energy` instead, so `PV energy total` matches it exactly rather than adding anything. Comparing the two entities on your own system shows which the inverter provides.
-{% endnote %}
+`MPPT <n> energy` is not consistent between devices, which is why its name does not claim a side. A Gen24 reports the lifetime energy of each string, which is a DC value and therefore a few percent above `Total energy`, the AC counter. A SnapINverter reports the same value as `Total energy` instead, so `PV energy total` matches it exactly rather than adding anything. Comparing the two entities on your own system shows which the inverter provides.
 
 ### Controlling the inverter over Modbus
 

--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -136,8 +136,14 @@ These entities are added per inverter and updated every minute:
 
 - `MPPT <n> DC power` and `MPPT <n> DC energy` for each MPP tracker.
 - `MPPT <n> DC current` and `MPPT <n> DC voltage` for each MPP tracker. Disabled by default.
-- `PV energy total`: lifetime energy from the photovoltaic strings only, measured on the DC side.
+- `PV energy total`: lifetime energy from the photovoltaic strings only. Whether this is a DC measurement depends on the device, see below.
 - `Battery charging energy total` and `Battery discharging energy total`: on hybrid inverters that expose their battery as dedicated MPP trackers, such as Gen24 with a battery.
+
+{% note %}
+`MPPT <n> DC power` is a DC measurement on every device tested, and matches `DC current` times `DC voltage`.
+
+`MPPT <n> DC energy` is not consistent between devices. A Gen24 reports the lifetime energy of each string, which is a DC value and therefore a few percent above `Total energy`, the AC counter. A SnapINverter reports the same value as `Total energy` instead, so `PV energy total` matches it exactly rather than adding anything. Comparing the two entities on your own system shows which the inverter provides.
+{% endnote %}
 
 ### Controlling the inverter over Modbus
 
@@ -214,9 +220,9 @@ Recommended [energy dashboard](/docs/energy/) configuration:
 - For _"Devices"_ use the Ohmpilots `Energy consumed` entity.
 
 {% important %}
-The [Modbus TCP](#modbus-tcp) energy values are measured on the DC side, at the MPP trackers.
+For _"Solar production"_, prefer the inverter's `Energy total`. That is the AC energy you can use or sell.
 
-`PV energy total` is the energy the panels delivered, before inverter conversion losses, so it reads higher than the inverter's `Energy total`, which is the AC energy actually fed out. For _"Solar production"_, prefer the AC value. That is the energy you can use or sell.
+Where the device reports per-string energy, `PV energy total` is what the panels delivered before inverter conversion losses, so it reads a few percent higher. Where it does not, it is the same value as `Energy total` and adds nothing. Either way, the AC value is the one to use.
 
 `Battery charging energy total` and `Battery discharging energy total` are DC values measured at the battery. They are counters read from the device rather than values integrated over time, so they don't drift and are unaffected by Home Assistant restarts. For the same reason, they don't exactly match a Riemann sum of `SolarNet Power battery charge` and `SolarNet Power battery discharge`.
 {% endimportant %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Corrects a claim I made in #47610: that the Modbus energy values are measured on the DC side. That holds for a Gen24, but not for the older SnapINverter generation, and the page stated it as a general rule.

Measured on three devices:

| device | `MPPT n DC power` | `MPPT n DC energy` vs `Total energy` |
|---|---|---|
| Gen24 10.0 Plus | DC | sum is **5.7 % higher** — a real DC counter |
| Symo 5.0-3-M | DC | identical to within 4 Wh, the float32 step at 48 MWh |
| Galvo 1.5-1 | DC, `211 W` = `1.19 A × 178 V` against `187 W` AC | **identical** |

So the *power* is a genuine DC measurement everywhere, while the *energy* register is device dependent: a Gen24 counts per string, a SnapINverter reports the same number as the AC total. Fronius's own register map flags `DCWH` as not supported on some device classes, which fits — what a device puts there varies.

It also follows the rename in home-assistant/core#181016: the entity is `MPPT <n> energy` rather than `MPPT <n> DC energy`, because the name should not promise a side the value does not always have. Fronius names that register "Lifetime Energy" while naming current, voltage and power "DC", so this follows their own line.

The practical consequence is small but worth stating: on a SnapINverter, `PV energy total` is not an independent value, it equals `Total energy`. The energy dashboard advice is unchanged — use the AC `Energy total` for _"Solar production"_ — but the reasoning given for it was only correct for one device family.

## Type of change

<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/181016
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

