### PR TITLE
Use config_ai My link in Anthropic documentation

### DIFF
--- a/source/_integrations/anthropic.markdown
+++ b/source/_integrations/anthropic.markdown
@@ -172,7 +172,7 @@ Set up and configure Claude as a conversation agent in an [Assist pipeline](/int
 
 ### Home Assistant interface
 
-You can set the Claude AI Task entity as the default AI Task entity. To do this, go to {% my config_ai_task title="**Settings** > **System** > **AI tasks**" %} and select the Claude AI Task entity. This makes the Claude AI Task entity the default for blueprints, and for the **Suggest with AI** button in various places in the interface.
+You can set the Claude AI Task entity as the default AI Task entity. To do this, go to {% my config_ai title="**Settings** > **System** > **AI tasks**" %} and select the Claude AI Task entity. This makes the Claude AI Task entity the default for blueprints, and for the **Suggest with AI** button in various places in the interface.
 
 ### Automation
 

--- a/source/_integrations/anthropic.markdown
+++ b/source/_integrations/anthropic.markdown
@@ -172,7 +172,7 @@ Set up and configure Claude as a conversation agent in an [Assist pipeline](/int
 
 ### Home Assistant interface
 
-You can set the Claude AI Task entity as the default AI Task entity. To do this, go to {% my config_ai title="**Settings** > **System** > **AI tasks**" %} and select the Claude AI Task entity. This makes the Claude AI Task entity the default for blueprints, and for the **Suggest with AI** button in various places in the interface.
+You can set the Claude AI Task entity as the default AI Task entity. To do this, go to {% my config_ai title="**Settings** > **System** > **AI**" %} and select the Claude AI Task entity. This makes the Claude AI Task entity the default for blueprints, and for the **Suggest with AI** button in various places in the interface.
 
 ### Automation
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The AI settings page moves from `/config/ai-tasks` to `/config/ai` in Home Assistant 2026.10, and a new `config_ai` My link replaces the deprecated `config_ai_task`. This updates the Anthropic documentation to use the new link.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/53933
- Link to parent pull request in the Brands repository: 
- Link to the My Home Assistant pull request adding the `config_ai` redirect: https://github.com/home-assistant/my.home-assistant.io/pull/756
- This PR fixes or closes issue: fixes #

The `config_ai` redirect needs to be live on My Home Assistant before this PR is merged, otherwise the link in the documentation will not resolve.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
