### PR TITLE
Document Flexit binary sensors and updated default baud rate

### DIFF
--- a/source/_integrations/flexit.markdown
+++ b/source/_integrations/flexit.markdown
@@ -2,11 +2,13 @@
 title: Flexit
 description: Instructions on how to integrate a Flexit air handling unit into Home Assistant.
 ha_category:
+  - Binary sensor
   - Climate
 ha_release: 0.47
 ha_iot_class: Local Polling
 ha_domain: flexit
 ha_platforms:
+  - binary_sensor
   - climate
 ha_integration_type: device
 ha_quality_scale: legacy
@@ -32,7 +34,7 @@ When you set up the integration, you're asked to choose between a serial or a ne
 Serial device:
   description: "The serial device your Flexit CI66 Modbus adapter is connected to. Only shown for a serial connection."
 Baud rate:
-  description: "The baud rate of the serial connection. Defaults to `57600`. Only shown for a serial connection."
+  description: "The baud rate of the serial connection. Defaults to `9600`. Only shown for a serial connection."
 Host:
   description: "The hostname or IP address of your Flexit CI66 Modbus bridge. Only shown for a network connection."
 Port:
@@ -60,6 +62,13 @@ A repair issue in {% my integrations title="**Settings** > **Devices & services*
 ### Climate
 
 The integration adds a climate entity for the Flexit unit. You can set a target temperature and choose a fan mode (**Off**, **Low**, **Medium**, or **High**). The current activity, such as heating, cooling, or idle, is shown as the entity's HVAC action.
+
+### Binary sensors
+
+The following binary sensors are categorized as diagnostic entities:
+
+- **Filter alarm**: Indicates whether the unit needs a filter replacement.
+- **Electric heater enabled**: Indicates whether the electric heater is enabled.
 
 ## Data updates
 


### PR DESCRIPTION
## Proposed change

Documents the Flexit binary sensor follow-up in home-assistant/core#180952: adds the **Filter alarm** and **Electric heater enabled** diagnostic binary sensors, and updates the default serial baud rate to `9600`.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/180952
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards