### PR TITLE
2026.9: Add backward-incompatible change for dropped browser support

### DIFF
--- a/source/_posts/2026-09-02-release-20269.markdown
+++ b/source/_posts/2026-09-02-release-20269.markdown
@@ -563,6 +563,22 @@ We do our best to avoid making changes to existing functionality that might unex
 
 We always make sure to document these changes to make the transition as easy as possible for you. This release has the following backward-incompatible changes:
 
+{% details "Browser support" %}
+
+Some older browsers can no longer run the Home Assistant interface:
+
+- Firefox older than version 94, released in November 2021, is no longer supported. Update Firefox to fix this. Both the current release and the current extended support release (ESR) are well past this version. If your operating system no longer receives Firefox updates, use Chrome instead.
+- iOS and iPadOS 11 and older are no longer supported. The iPad (4th generation), iPhone 5, and iPhone 5c cannot be updated past iOS 10.3, so they can no longer open Home Assistant. Installing a different browser does not help, because every browser on iOS uses the same engine as Safari. Devices that can be updated to iOS 12.5, such as the iPad Air (1st generation) and the iPad mini 2 and 3, keep working.
+
+Older devices that are still supported benefit from this change: the version of the interface served to them is roughly 20% smaller, so it loads faster.
+
+([@maartenla] - [#53691])
+
+[@maartenla]: https://github.com/maartenla
+[#53691]: https://github.com/home-assistant/frontend/pull/53691
+
+{% enddetails %}
+
 {% details "Flexit Nordic (BACnet)" %}
 
 The deprecated fireplace mode switch entity has been removed. If you have {% term automations %} or {% term scripts %} that use `switch.<device>_fireplace_mode`, use the `climate.set_preset_mode` action on the Flexit climate entity with `preset_mode: fireplace` instead.


### PR DESCRIPTION
## Proposed change

Adds a backward-incompatible change entry to the 2026.9 release notes for the browser support changes in home-assistant/frontend#53691.

That PR replaced the usage-based browserslist queries with pinned floors. Comparing the resolved target lists, two of them moved up, which drops support for real devices:

- Firefox: 69 → 94
- iOS Safari: 11.0 → 12.0

The legacy build also went from ES5 output (with Safari 10 workarounds) to ES2017, so devices that cannot be updated past iOS 10.3 — the iPad (4th generation), iPhone 5, and iPhone 5c — can no longer load the interface. Devices that reach iOS 12.5, such as the iPad Air (1st generation) and the iPad mini 2 and 3, keep working.

The other floors moved down (Chrome 70 → 59, Safari 13 → 12, Samsung Internet 10.1 → 9.2), so nothing else loses support.

The entry deliberately describes only what stopped working, rather than publishing the new minimum versions, so it does not read as a commitment to keep those floors in place.

## Type of change

- [x] Change to existing documentation (blog post release notes)

## Additional information

- Frontend PR: home-assistant/frontend#53691

## Checklist

- [x] I have followed the [Home Assistant documentation standards](https://developers.home-assistant.io/docs/documenting/standards).
- [x] Entry is placed alphabetically in the backward-incompatible changes section.
- [x] `textlint` reports no new problems for the modified file (the two existing errors are pre-existing and outside this change; `source/_posts` is excluded from the linter scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)