### PR TITLE
Document user management for ISEO Argo BLE

### DIFF
--- a/source/_actions/iseo_argo_ble.delete_credential.markdown
+++ b/source/_actions/iseo_argo_ble.delete_credential.markdown
@@ -1,0 +1,119 @@
+---
+title: "Delete credential"
+action: iseo_argo_ble.delete_credential
+domain: iseo_argo_ble
+description: "Removes a credential from your ISEO lock for good."
+since: "2026.10"
+related_actions:
+  - iseo_argo_ble.set_credential_enabled
+---
+
+The **Delete credential** action removes one of the credentials enrolled on your ISEO Argo lock — a card, a PIN, a phone, or a fingerprint — and frees the space it used.
+
+Use it when a credential is gone for good: a lost card you do not expect to find, a tenant who has moved out, or a phone that is no longer in the household.
+
+There is no undo. Home Assistant cannot enrol a credential, so whoever held it has to be enrolled again on the lock with your Master Card. If you only want to stop a credential working for a while, use [**Set credential enabled**](/actions/iseo_argo_ble.set_credential_enabled/) instead, which leaves it on the lock.
+
+Only Home Assistant administrators can run this action.
+
+{% include actions/ui_header.md %}
+
+To delete a credential from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **ISEO Argo BLE: Delete credential**.
+6. Select what you want to control. Under **By target**, select the credential you want to remove.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Entity:
+  description: The credential, or credentials, you want to remove from the lock.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `iseo_argo_ble.delete_credential`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: iseo_argo_ble.delete_credential
+  target:
+    entity_id: binary_sensor.front_door_alice_card
+{% endexample %}
+
+This removes Alice's card from the lock. The card no longer opens the door, and its sensor disappears from Home Assistant.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: >
+    The entity ID, or list of entity IDs, of the credentials you want to
+    remove from the lock.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- The credential's sensor is removed from Home Assistant once the lock confirms the deletion, because neither the credential nor the sensor comes back on its own.
+- The two identities Home Assistant enrolled for itself have no sensors, so this action cannot remove Home Assistant's own access to the lock.
+- Deleting connects to the lock over Bluetooth. Close the Argo app on all phones first, because the lock only accepts one connection at a time.
+- If the lock is out of Bluetooth range, the action reports an error and nothing is removed.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: Clear a guest's card when their stay ends
+
+At checkout time, the guest card is removed from the lock rather than left enrolled.
+
+- **Trigger**: Time
+  - **At**: 11:00:00
+- **Action**: ISEO Argo BLE: Delete credential
+  - **Target**: Guest card (`binary_sensor.front_door_guest_card`)
+
+{% example %}
+automation: |
+  alias: "Clear the guest card at checkout"
+  triggers:
+    - trigger: time
+      at: "11:00:00"
+  actions:
+    - action: iseo_argo_ble.delete_credential
+      target:
+        entity_id: binary_sensor.front_door_guest_card
+{% endexample %}
+
+### Automation: Remove a card reported lost for a week
+
+A card that has been suspended for a week is unlikely to turn up, so it is removed to free the space.
+
+- **Trigger**: State of **Alice's card** is **Off** for 7 days
+- **Action**: ISEO Argo BLE: Delete credential
+  - **Target**: Alice's card (`binary_sensor.front_door_alice_card`)
+
+{% example %}
+automation: |
+  alias: "Remove the long-suspended card"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.front_door_alice_card
+      to: "off"
+      for: "168:00:00"
+  actions:
+    - action: iseo_argo_ble.delete_credential
+      target:
+        entity_id: binary_sensor.front_door_alice_card
+{% endexample %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/iseo_argo_ble.delete_credential.markdown
+++ b/source/_actions/iseo_argo_ble.delete_credential.markdown
@@ -12,7 +12,7 @@ The **Delete credential** action removes one of the credentials enrolled on your
 
 Use it when a credential is gone for good: a lost card you do not expect to find, a tenant who has moved out, or a phone that is no longer in the household.
 
-There is no undo. Home Assistant cannot enrol a credential, so whoever held it has to be enrolled again on the lock with your Master Card. If you only want to stop a credential working for a while, use [**Set credential enabled**](/actions/iseo_argo_ble.set_credential_enabled/) instead, which leaves it on the lock.
+There is no undo. Home Assistant cannot enroll a credential, so whoever held it has to be enrolled again on the lock with your Master Card. If you only want to stop a credential working for a while, use [**Set credential enabled**](/actions/iseo_argo_ble.set_credential_enabled/) instead, which leaves it on the lock.
 
 Only Home Assistant administrators can run this action.
 
@@ -27,14 +27,6 @@ To delete a credential from an automation or a script:
 5. From the search box, search for and select **ISEO Argo BLE: Delete credential**.
 6. Select what you want to control. Under **By target**, select the credential you want to remove.
 7. Select **Save**.
-
-### Options in the UI
-
-{% options_ui %}
-Entity:
-  description: The credential, or credentials, you want to remove from the lock.
-  required: true
-{% endoptions_ui %}
 
 {% include actions/yaml_header.md %}
 

--- a/source/_actions/iseo_argo_ble.delete_credential.markdown
+++ b/source/_actions/iseo_argo_ble.delete_credential.markdown
@@ -56,6 +56,7 @@ entity_id:
 
 - The credential's sensor is removed from Home Assistant once the lock confirms the deletion, because neither the credential nor the sensor comes back on its own.
 - The two identities Home Assistant enrolled for itself have no sensors, so this action cannot remove Home Assistant's own access to the lock.
+- A gateway enrolled by something else — another home automation system, for instance — does get a sensor, but cannot be deleted from here. The lock only erases a gateway while a Master Card is being scanned on it, which Home Assistant cannot ask for, so the action reports an error. Remove it in the Argo app instead. Suspending it from [**Set credential enabled**](/actions/iseo_argo_ble.set_credential_enabled/) does work.
 - Deleting connects to the lock over Bluetooth. Close the Argo app on all phones first, because the lock only accepts one connection at a time.
 - If the lock is out of Bluetooth range, the action reports an error and nothing is removed.
 

--- a/source/_actions/iseo_argo_ble.set_credential_enabled.markdown
+++ b/source/_actions/iseo_argo_ble.set_credential_enabled.markdown
@@ -75,6 +75,8 @@ enabled:
 - Changing a credential connects to the lock over Bluetooth. Close the Argo app on all phones first, because the lock only accepts one connection at a time.
 - If the lock is out of Bluetooth range, the action reports an error and nothing changes on the lock.
 - Suspending a credential does not remove it. To remove one for good, use the [**Delete credential**](/actions/iseo_argo_ble.delete_credential/) action instead.
+- A credential that is only valid for a period — an invitation, or a guest card with an end date — keeps that period when you restore it. Home Assistant remembers the window it read from the lock and puts it back.
+- A credential that was already suspended before Home Assistant first read the lock cannot be restored from here, because its original period is no longer on the lock to read. Restore it in the Argo app, which set it that way.
 
 {% include actions/try_it.md %}
 

--- a/source/_actions/iseo_argo_ble.set_credential_enabled.markdown
+++ b/source/_actions/iseo_argo_ble.set_credential_enabled.markdown
@@ -1,0 +1,138 @@
+---
+title: "Set credential enabled"
+action: iseo_argo_ble.set_credential_enabled
+domain: iseo_argo_ble
+description: "Lets a credential enrolled on your ISEO lock open the door, or stops it doing so."
+since: "2026.10"
+---
+
+The **Set credential enabled** action suspends or restores one of the credentials enrolled on your ISEO Argo lock: a card, a PIN, a phone, or a fingerprint. A suspended credential stays on the lock, it just stops opening the door, so you can hand it back later without enrolling it again.
+
+This is useful when someone loses their card, when a guest's stay ends, or when you want a cleaner's fob to work only on certain days.
+
+Only Home Assistant administrators can run this action, because it changes who can get into your home. Everyone else can still see each credential's state on its sensor.
+
+{% include actions/ui_header.md %}
+
+To suspend or restore a credential from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **ISEO Argo BLE: Set credential enabled**.
+6. Select what you want to control. Under **By target**, select the credential you want to change.
+7. Turn **Enabled** on to let the credential open the lock, or off to suspend it.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Entity:
+  description: The credential, or credentials, you want to change.
+  required: true
+Enabled:
+  description: Whether the credential may open the lock. Turn it off to suspend the credential, and on to restore it.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `iseo_argo_ble.set_credential_enabled`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: iseo_argo_ble.set_credential_enabled
+  target:
+    entity_id: binary_sensor.front_door_alice_card
+  data:
+    enabled: false
+{% endexample %}
+
+This suspends Alice's card. Her card stays enrolled on the lock, but it no longer opens the door.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: >
+    The entity ID, or list of entity IDs, of the credentials you want to
+    change.
+  required: true
+  type: string
+enabled:
+  description: >
+    Whether the credential may open the lock. Set it to false to suspend the
+    credential, and true to restore it.
+  required: true
+  type: boolean
+{% endoptions_yaml %}
+
+## Good to know
+
+- Changing a credential connects to the lock over Bluetooth. Close the Argo app on all phones first, because the lock only accepts one connection at a time.
+- If the lock is out of Bluetooth range, the action reports an error and nothing changes on the lock.
+- Suspending a credential does not remove it. To delete a credential for good, use the official Argo app.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: Suspend a lost card straight away
+
+When you mark a card as lost with a toggle helper you created yourself, the card stops opening the door.
+
+- **Trigger**: State of the **Card lost** toggle changes to **On**
+- **Action**: ISEO Argo BLE: Set credential enabled
+  - **Target**: Alice's card (`binary_sensor.front_door_alice_card`)
+  - **Enabled**: off
+
+{% example %}
+automation: |
+  alias: "Suspend the lost card"
+  triggers:
+    - trigger: state
+      entity_id: input_boolean.card_lost
+      to: "on"
+  actions:
+    - action: iseo_argo_ble.set_credential_enabled
+      target:
+        entity_id: binary_sensor.front_door_alice_card
+      data:
+        enabled: false
+{% endexample %}
+
+The **Card lost** toggle is an `input_boolean` {% term helper %} you have to create yourself, under **Settings** > **Devices & services** > **Helpers**.
+
+### Automation: Let the cleaner in only on Tuesday mornings
+
+The cleaner's fob works during the cleaning slot and is suspended again afterwards.
+
+- **Trigger**: Time
+  - **At**: 09:00:00
+- **Condition**: Day of the week is Tuesday
+- **Action**: ISEO Argo BLE: Set credential enabled
+  - **Target**: Cleaner fob (`binary_sensor.front_door_cleaner_card`)
+  - **Enabled**: on
+
+{% example %}
+automation: |
+  alias: "Enable the cleaner fob on Tuesday morning"
+  triggers:
+    - trigger: time
+      at: "09:00:00"
+  conditions:
+    - condition: time
+      weekday:
+        - tue
+  actions:
+    - action: iseo_argo_ble.set_credential_enabled
+      target:
+        entity_id: binary_sensor.front_door_cleaner_card
+      data:
+        enabled: true
+{% endexample %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/iseo_argo_ble.set_credential_enabled.markdown
+++ b/source/_actions/iseo_argo_ble.set_credential_enabled.markdown
@@ -4,6 +4,8 @@ action: iseo_argo_ble.set_credential_enabled
 domain: iseo_argo_ble
 description: "Lets a credential enrolled on your ISEO lock open the door, or stops it doing so."
 since: "2026.10"
+related_actions:
+  - iseo_argo_ble.delete_credential
 ---
 
 The **Set credential enabled** action suspends or restores one of the credentials enrolled on your ISEO Argo lock: a card, a PIN, a phone, or a fingerprint. A suspended credential stays on the lock, it just stops opening the door, so you can hand it back later without enrolling it again.
@@ -72,7 +74,7 @@ enabled:
 
 - Changing a credential connects to the lock over Bluetooth. Close the Argo app on all phones first, because the lock only accepts one connection at a time.
 - If the lock is out of Bluetooth range, the action reports an error and nothing changes on the lock.
-- Suspending a credential does not remove it. To delete a credential for good, use the official Argo app.
+- Suspending a credential does not remove it. To remove one for good, use the [**Delete credential**](/actions/iseo_argo_ble.delete_credential/) action instead.
 
 {% include actions/try_it.md %}
 

--- a/source/_actions/iseo_argo_ble.set_credential_enabled.markdown
+++ b/source/_actions/iseo_argo_ble.set_credential_enabled.markdown
@@ -30,9 +30,6 @@ To suspend or restore a credential from an automation or a script:
 ### Options in the UI
 
 {% options_ui %}
-Entity:
-  description: The credential, or credentials, you want to change.
-  required: true
 Enabled:
   description: Whether the credential may open the lock. Turn it off to suspend the credential, and on to restore it.
   required: true

--- a/source/_actions/iseo_argo_ble.set_credential_enabled.markdown
+++ b/source/_actions/iseo_argo_ble.set_credential_enabled.markdown
@@ -31,7 +31,7 @@ To suspend or restore a credential from an automation or a script:
 
 {% options_ui %}
 Enabled:
-  description: Whether the credential may open the lock. Turn it off to suspend the credential, and on to restore it.
+  description: Whether the credential is allowed to open the lock. Turn it off to suspend the credential, and on to restore it along with any validity period it had.
   required: true
 {% endoptions_ui %}
 
@@ -61,8 +61,9 @@ entity_id:
   type: string
 enabled:
   description: >
-    Whether the credential may open the lock. Set it to false to suspend the
-    credential, and true to restore it.
+    Whether the credential is allowed to open the lock. Set it to false to
+    suspend the credential, and true to restore it along with any validity
+    period it had.
   required: true
   type: boolean
 {% endoptions_yaml %}
@@ -72,7 +73,7 @@ enabled:
 - Changing a credential connects to the lock over Bluetooth. Close the Argo app on all phones first, because the lock only accepts one connection at a time.
 - If the lock is out of Bluetooth range, the action reports an error and nothing changes on the lock.
 - Suspending a credential does not remove it. To remove one for good, use the [**Delete credential**](/actions/iseo_argo_ble.delete_credential/) action instead.
-- A credential that is only valid for a period — an invitation, or a guest card with an end date — keeps that period when you restore it. Home Assistant remembers the window it read from the lock and puts it back.
+- A credential that is only valid for a period — an invitation, or a guest card with an end date — keeps that period when you restore it. Home Assistant remembers the window it read from the lock and puts it back. Restoring it does not extend that period, so a credential whose period has already passed still will not open the door.
 - A credential that was already suspended before Home Assistant first read the lock cannot be restored from here, because its original period is no longer on the lock to read. Restore it in the Argo app, which set it that way.
 
 {% include actions/try_it.md %}

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -10,8 +10,8 @@ ha_codeowners:
   - '@FezVrasta'
 ha_domain: iseo_argo_ble
 ha_platforms:
+  - binary_sensor
   - lock
-  - switch
 ha_bluetooth: true
 ha_integration_type: device
 ha_quality_scale: bronze
@@ -49,13 +49,53 @@ Enable user management:
 ## Supported functionality
 
 - **Lock**: Controls the lock (unlock only). Reflects the current locked/unlocked state.
-- **Switches**: One switch per credential enrolled on the lock, such as a card, a PIN, or a phone. Turning a switch off suspends that credential: it stays on the lock but no longer opens the door. Turning it back on restores it. These switches are only created if you enabled user management during setup.
+- **Credential sensors**: One sensor per credential enrolled on the lock, such as a card, a PIN, or a phone. Each shows whether that credential may currently open the door. These sensors are only created if you enabled user management during setup.
 
-The credential type is part of each switch's name, because one person often holds several and the lock allows them to share a name. The two identities Home Assistant registered for itself do not get switches, so you cannot lock yourself out of your own lock.
+The credential type is part of each sensor's name, because one person often holds several and the lock allows them to share a name. The two identities Home Assistant registered for itself do not get sensors, so you cannot lock yourself out of your own lock.
+
+The sensors are read-only. To suspend or restore a credential, use the [**Set credential enabled**](/actions/iseo_argo_ble.set_credential_enabled/) action, which only Home Assistant administrators can run.
+
+{% include integrations/actions.md %}
+
+## ISEO Argo BLE automation examples
+
+Credentials do not have to be managed by hand. Home Assistant can suspend and restore them for you.
+
+{% include docs/paste_yaml_tip.md %}
+
+### Automation: Suspend a lost card straight away
+
+When you mark a card as lost with a toggle helper you created yourself, the card stops opening the door.
+
+- **Trigger**: State of the **Card lost** toggle changes to **On**
+- **Action**: ISEO Argo BLE: Set credential enabled
+  - **Target**: Alice's card (`binary_sensor.front_door_alice_card`)
+  - **Enabled**: off
+
+{% details "YAML example for suspending a lost card" %}
+
+{% example %}
+automation: |
+  alias: "Suspend the lost card"
+  triggers:
+    - trigger: state
+      entity_id: input_boolean.card_lost
+      to: "on"
+  actions:
+    - action: iseo_argo_ble.set_credential_enabled
+      target:
+        entity_id: binary_sensor.front_door_alice_card
+      data:
+        enabled: false
+{% endexample %}
+
+{% enddetails %}
+
+The **Card lost** toggle is an `input_boolean` {% term helper %} you have to create yourself, under **Settings** > **Devices & services** > **Helpers**.
 
 ## Data updates
 
-Home Assistant reads the list of enrolled credentials once, while it sets the lock up. It is not read again on a timer, because repeatedly running administrator commands over Bluetooth eventually stops recent ISEO firmware from responding at all. After you turn a switch on or off, Home Assistant applies that change to the list it already holds rather than reading it again.
+Home Assistant reads the list of enrolled credentials once, while it sets the lock up. It is not read again on a timer, because repeatedly running administrator commands over Bluetooth eventually stops recent ISEO firmware from responding at all. After you suspend or restore a credential, Home Assistant applies that change to the list it already holds rather than reading it again.
 
 To pick up credentials that were added or removed in the Argo app, reload the integration: go to {% my integrations title="**Settings** > **Devices & services**" %}, select the lock, and select **Reload** from the three-dot menu.
 

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -53,7 +53,7 @@ Enable user management:
 
 The credential type is part of each sensor's name, because one person often holds several and the lock allows them to share a name. The two identities Home Assistant registered for itself do not get sensors, so you cannot lock yourself out of your own lock.
 
-The sensors are read-only. To suspend or restore a credential, use the [**Set credential enabled**](/actions/iseo_argo_ble.set_credential_enabled/) action, which only Home Assistant administrators can run.
+The sensors are read-only. To suspend or restore a credential, use the [**Set credential enabled**](/actions/iseo_argo_ble.set_credential_enabled/) action, and to remove one for good, use [**Delete credential**](/actions/iseo_argo_ble.delete_credential/). Both are limited to Home Assistant administrators.
 
 {% include integrations/actions.md %}
 
@@ -103,6 +103,7 @@ To pick up credentials that were added or removed in the Argo app, reload the in
 
 - The lock only supports _one active Bluetooth connection_ at a time. Close the Argo app on all phones before unlocking or during setup.
 - The ISEO X1R is a momentary actuator: it re-latches automatically after every unlock. The `lock` action is therefore not supported.
+- Home Assistant can suspend and remove credentials, but it cannot enrol new ones. Adding a credential needs your Master Card and the Argo app.
 - User management can only be turned on while you set the lock up, because the administrator identity has to be registered during the Master Card scan. If you set your lock up without it, delete the integration and add it again.
 - Credentials added or removed in the Argo app appear after you reload the integration, not straight away. Asking Home Assistant to update a credential sensor does nothing on purpose, because re-reading the list is the operation that upsets the lock's firmware.
 

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -11,6 +11,7 @@ ha_codeowners:
 ha_domain: iseo_argo_ble
 ha_platforms:
   - lock
+  - switch
 ha_bluetooth: true
 ha_integration_type: device
 ha_quality_scale: bronze
@@ -36,17 +37,34 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 1. As soon as you add the integration to Home Assistant, Home Assistant scans for nearby ISEO locks and presents them in a list.
 2. In Home Assistant, go to {% my integrations title="**Settings** > **Devices & services**" %}.
 3. From the list, select the lock you want to set up.
-4. Select **Submit** and within 30 seconds, scan the Master Card on the lock to authorize Home Assistant. 
+4. Decide whether to leave **Enable user management** turned on.
+5. Select **Submit** and within 30 seconds, scan the Master Card on the lock to authorize Home Assistant.
    - **Result**: The lock's LED will blink green when the card is successfully read.
+
+{% configuration_basic %}
+Enable user management:
+  description: "Register a second, administrator identity for Home Assistant, so it can list the people enrolled on your lock and turn each of them on or off. Both identities have to be registered during the same Master Card scan, so this can only be turned on while you set the lock up. Defaults to on."
+{% endconfiguration_basic %}
 
 ## Supported functionality
 
 - **Lock**: Controls the lock (unlock only). Reflects the current locked/unlocked state.
+- **Switches**: One switch per credential enrolled on the lock, such as a card, a PIN, or a phone. Turning a switch off suspends that credential: it stays on the lock but no longer opens the door. Turning it back on restores it. These switches are only created if you enabled user management during setup.
+
+The credential type is part of each switch's name, because one person often holds several and the lock allows them to share a name. The two identities Home Assistant registered for itself do not get switches, so you cannot lock yourself out of your own lock.
+
+## Data updates
+
+Home Assistant reads the list of enrolled credentials once, while it sets the lock up. It is not read again on a timer, because repeatedly running administrator commands over Bluetooth eventually stops recent ISEO firmware from responding at all. After you turn a switch on or off, Home Assistant applies that change to the list it already holds rather than reading it again.
+
+To pick up credentials that were added or removed in the Argo app, reload the integration: go to {% my integrations title="**Settings** > **Devices & services**" %}, select the lock, and select **Reload** from the three-dot menu.
 
 ## Known limitations
 
 - The lock only supports _one active Bluetooth connection_ at a time. Close the Argo app on all phones before unlocking or during setup.
 - The ISEO X1R is a momentary actuator: it re-latches automatically after every unlock. The `lock` action is therefore not supported.
+- User management can only be turned on while you set the lock up, because the administrator identity has to be registered during the Master Card scan. If you set your lock up without it, delete the integration and add it again.
+- Credentials added or removed in the Argo app appear after you reload the integration, not straight away.
 
 ## Removing the integration
 

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -104,7 +104,7 @@ To pick up credentials that were added or removed in the Argo app, reload the in
 - The lock only supports _one active Bluetooth connection_ at a time. Close the Argo app on all phones before unlocking or during setup.
 - The ISEO X1R is a momentary actuator: it re-latches automatically after every unlock. The `lock` action is therefore not supported.
 - User management can only be turned on while you set the lock up, because the administrator identity has to be registered during the Master Card scan. If you set your lock up without it, delete the integration and add it again.
-- Credentials added or removed in the Argo app appear after you reload the integration, not straight away.
+- Credentials added or removed in the Argo app appear after you reload the integration, not straight away. Asking Home Assistant to update a credential sensor does nothing on purpose, because re-reading the list is the operation that upsets the lock's firmware.
 
 ## Removing the integration
 

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -43,7 +43,7 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 
 {% configuration_basic %}
 Enable user management:
-  description: "Register a second, administrator identity for Home Assistant, so it can list the people enrolled on your lock and turn each of them on or off. Both identities have to be registered during the same Master Card scan, so this can only be turned on while you set the lock up. Defaults to on."
+  description: "Register a second, administrator identity for Home Assistant, so it can list the people enrolled on your lock and turn each of them on or off. Both identities have to be registered during a Master Card scan. If you turn it off here, you can add it later with **Reconfigure**, which asks for the card again. Defaults to on."
 {% endconfiguration_basic %}
 
 ## Supported functionality

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -49,7 +49,7 @@ Enable user management:
 ## Supported functionality
 
 - **Lock**: Controls the lock (unlock only). Reflects the current locked/unlocked state.
-- **Credential sensors**: One sensor per credential enrolled on the lock, such as a card, a PIN, or a phone. Each shows whether that credential may currently open the door. These sensors are only created if you enabled user management during setup.
+- **Credential sensors**: One sensor per credential enrolled on the lock, such as a card, a PIN, or a phone. Each shows whether that credential may currently open the door. These sensors are only created if user management is enabled.
 
 The credential type is part of each sensor's name, because one person often holds several and the lock allows them to share a name. The two identities Home Assistant registered for itself do not get sensors, so you cannot lock yourself out of your own lock.
 
@@ -99,12 +99,16 @@ Home Assistant reads the list of enrolled credentials once, while it sets the lo
 
 To pick up credentials that were added or removed in the Argo app, reload the integration: go to {% my integrations title="**Settings** > **Devices & services**" %}, select the lock, and select **Reload** from the three-dot menu.
 
+### Enabling user management later
+
+If you set the lock up without user management, you do not have to remove the integration to add it. Go to {% my integrations title="**Settings** > **Devices & services**" %}, select the lock, and choose **Reconfigure** from the three-dot menu. You need your Master Card again: the administrator identity can only be registered during a Master Card scan.
+
 ## Known limitations
 
 - The lock only supports _one active Bluetooth connection_ at a time. Close the Argo app on all phones before unlocking or during setup.
 - The ISEO X1R is a momentary actuator: it re-latches automatically after every unlock. The `lock` action is therefore not supported.
 - Home Assistant can suspend and remove credentials, but it cannot enrol new ones. Adding a credential needs your Master Card and the Argo app.
-- User management can only be turned on while you set the lock up, because the administrator identity has to be registered during the Master Card scan. If you set your lock up without it, delete the integration and add it again.
+- Turning user management on always needs your Master Card, because the administrator identity has to be registered during a Master Card scan. If you set your lock up without it, you can add it later with **Reconfigure** rather than removing the integration.
 - Credentials added or removed in the Argo app appear after you reload the integration, not straight away. Asking Home Assistant to update a credential sensor does nothing on purpose, because re-reading the list is the operation that upsets the lock's firmware.
 
 ## Removing the integration

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -49,11 +49,11 @@ Enable user management:
 ## Supported functionality
 
 - **Lock**: Controls the lock (unlock only). Reflects the current locked/unlocked state.
-- **Credential sensors**: One sensor per credential enrolled on the lock, such as a card, a PIN, or a phone. Each shows whether that credential may currently open the door. These sensors are only created if user management is enabled.
+- **Credential binary sensors**: One binary sensor per credential enrolled on the lock, such as a card, a PIN, or a phone. Each shows whether that credential may currently open the door. These binary sensors are only created if user management is enabled.
 
-The credential type is part of each sensor's name, because one person often holds several and the lock allows them to share a name. The two identities Home Assistant registered for itself do not get sensors, so you cannot lock yourself out of your own lock.
+The credential type is part of each binary sensor's name, because one person often holds several and the lock allows them to share a name. The two identities Home Assistant registered for itself do not get binary sensors, so you cannot lock yourself out of your own lock.
 
-The sensors are read-only. To suspend or restore a credential, use the [**Set credential enabled**](/actions/iseo_argo_ble.set_credential_enabled/) action, and to remove one for good, use [**Delete credential**](/actions/iseo_argo_ble.delete_credential/). Both are limited to Home Assistant administrators.
+The binary sensors are read-only. To suspend or restore a credential, use the [**Set credential enabled**](/actions/iseo_argo_ble.set_credential_enabled/) action, and to remove one for good, use [**Delete credential**](/actions/iseo_argo_ble.delete_credential/). Both are limited to Home Assistant administrators.
 
 {% include integrations/actions.md %}
 
@@ -107,7 +107,7 @@ If you set the lock up without user management, you do not have to remove the in
 
 - The lock only supports _one active Bluetooth connection_ at a time. Close the Argo app on all phones before unlocking or during setup.
 - The ISEO X1R is a momentary actuator: it re-latches automatically after every unlock. The `lock` action is therefore not supported.
-- Home Assistant can suspend and remove credentials, but it cannot enrol new ones. Adding a credential needs your Master Card and the Argo app.
+- Home Assistant can suspend and remove credentials, but it cannot enroll new ones. Adding a credential needs your Master Card and the Argo app.
 - Turning user management on always needs your Master Card, because the administrator identity has to be registered during a Master Card scan. If you set your lock up without it, you can add it later with **Reconfigure** rather than removing the integration.
 - Credentials added or removed in the Argo app appear after you reload the integration, not straight away. Asking Home Assistant to update a credential sensor does nothing on purpose, because re-reading the list is the operation that upsets the lock's firmware.
 

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -49,9 +49,11 @@ Enable user management:
 ## Supported functionality
 
 - **Lock**: Controls the lock (unlock only). Reflects the current locked/unlocked state.
-- **Credential binary sensors**: One binary sensor per credential enrolled on the lock, such as a card, a PIN, or a phone. Each shows whether that credential may currently open the door. These binary sensors are only created if user management is enabled.
+- **Credential binary sensors**: One binary sensor per credential enrolled on the lock, such as a card, a PIN, or a phone. Each shows whether that credential is suspended: **on** means nobody has suspended it, **off** means someone has. These binary sensors are only created if user management is enabled.
 
 The credential type is part of each binary sensor's name, because one person often holds several and the lock allows them to share a name. The two identities Home Assistant registered for itself do not get binary sensors, so you cannot lock yourself out of your own lock.
+
+A credential can also carry a validity period of its own — an invitation, or a guest card that runs to the end of the month. The lock keeps that separately from the suspension, so a credential whose period has passed still shows as **on**: it is not suspended, it has simply run out. Only the suspension is reported here.
 
 The binary sensors are read-only. To suspend or restore a credential, use the [**Set credential enabled**](/actions/iseo_argo_ble.set_credential_enabled/) action, and to remove one for good, use [**Delete credential**](/actions/iseo_argo_ble.delete_credential/). Both are limited to Home Assistant administrators.
 


### PR DESCRIPTION
## Proposed change

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents user management for the ISEO Argo BLE lock, added in home-assistant/core#181104.

Covers:

- the **Enable user management** option in the setup flow, and why it can only be chosen there — the administrator identity has to be registered during the same Master Card scan as the gateway identity;
- the binary sensors it creates, one per credential enrolled on the lock, and what suspending one actually does (the credential stays on the lock, it just stops opening the door);
- a **Data updates** section explaining that the credential list is read once at setup and never on a timer, because repeatedly running administrator commands over Bluetooth eventually stops recent ISEO firmware responding altogether;
- how to pick up credentials added or removed in the Argo app, by reloading the integration;
- the matching known limitations.

Also adds `binary_sensor` to `ha_platforms`. The credential entities are read-only binary sensors, not switches: suspending goes through the admin-only `set_credential_enabled` action, because `switch.turn_off` needs only entity-control permission and any non-admin could otherwise suspend someone else's card.

## Type of change

<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#181104
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

