### PR TITLE
Document access log reporting for ISEO Argo BLE

### DIFF
--- a/source/_actions/iseo_argo_ble.read_access_log.markdown
+++ b/source/_actions/iseo_argo_ble.read_access_log.markdown
@@ -1,0 +1,113 @@
+---
+title: "Read access log"
+action: iseo_argo_ble.read_access_log
+domain: iseo_argo_ble
+description: "Reads the entries your ISEO lock has recorded since the last read."
+since: "2026.10"
+---
+
+The **Read access log** action reads the entries your ISEO Argo lock has recorded since the last read, and reports the most recent one of each kind on the lock's **Access log** entity.
+
+Home Assistant normally reads the log by itself: when it notices the door has been opened, and after you unlock the door from Home Assistant. Because the door state is only checked every 30 seconds, a door that is opened and closed again within that time is not noticed, and its entries sit unread on the lock until the next read. This action is how you fetch them without waiting.
+
+It is also useful right after you set the lock up, to pull in whatever your lock recorded before Home Assistant knew about it.
+
+{% include actions/ui_header.md %}
+
+To read the access log from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **ISEO Argo BLE: Read access log**.
+6. Select what you want to control. Under **By target**, select the lock whose log you want to read.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Entity:
+  description: The ISEO lock, or locks, whose access log you want to read.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `iseo_argo_ble.read_access_log`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: iseo_argo_ble.read_access_log
+  target:
+    entity_id: lock.front_door
+{% endexample %}
+
+This reads whatever `lock.front_door` has recorded since the last read.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: >
+    The entity ID, or list of entity IDs, of the ISEO locks whose access log
+    you want to read.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- Reading the log clears it. Your lock hands over everything recorded since the last read and then never offers those entries again, so a read after a quiet spell can return a long history at once. Only the most recent entry of each kind is reported, so the backlog is not replayed as though it had just happened.
+- Reading connects to the lock over Bluetooth. Close the Argo app on all phones first, because the lock only accepts one connection at a time.
+- If the lock is out of Bluetooth range, the action reports an error and nothing is read. The entries stay on the lock and arrive with the next successful read.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: Catch up on the access log every morning
+
+Every morning, the night's entries are read so they show up in the logbook even if the door was opened and closed too quickly to be noticed.
+
+- **Trigger**: Time
+  - **At**: 07:00:00
+- **Action**: ISEO Argo BLE: Read access log
+  - **Target**: Front door (`lock.front_door`)
+
+{% example %}
+automation: |
+  alias: "Catch up on the front door access log"
+  triggers:
+    - trigger: time
+      at: "07:00:00"
+  actions:
+    - action: iseo_argo_ble.read_access_log
+      target:
+        entity_id: lock.front_door
+{% endexample %}
+
+### Automation: Check the log when you get home
+
+When you arrive home, the log is read so you can see whether anyone came to the door while you were out.
+
+- **Trigger**: State of a person changes to **Home**
+- **Action**: ISEO Argo BLE: Read access log
+  - **Target**: Front door (`lock.front_door`)
+
+{% example %}
+automation: |
+  alias: "Read the front door access log on arrival"
+  triggers:
+    - trigger: state
+      entity_id: person.me
+      to: home
+  actions:
+    - action: iseo_argo_ble.read_access_log
+      target:
+        entity_id: lock.front_door
+{% endexample %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/iseo_argo_ble.read_access_log.markdown
+++ b/source/_actions/iseo_argo_ble.read_access_log.markdown
@@ -60,7 +60,8 @@ entity_id:
 
 - Reading the log clears it. Your lock hands over everything recorded since the last read and then never offers those entries again, so a read after a quiet spell can return a long history at once. Only the most recent entry of each kind is reported, so the backlog is not replayed as though it had just happened.
 - Reading connects to the lock over Bluetooth. Close the Argo app on all phones first, because the lock only accepts one connection at a time.
-- If the lock is out of Bluetooth range, the action reports an error and nothing is read. The entries stay on the lock and arrive with the next successful read.
+- If Home Assistant has already noticed the lock is unreachable, its entity is unavailable and this action quietly does nothing, as actions do for any unavailable entity. If the lock only goes out of range once the read is under way, the action reports an error. Either way the entries stay on the lock and arrive with the next successful read.
+- A read that fails part way through still reports whatever it managed to read. The lock hands over each page only once, so those entries would otherwise be lost.
 
 {% include actions/try_it.md %}
 

--- a/source/_actions/iseo_argo_ble.read_access_log.markdown
+++ b/source/_actions/iseo_argo_ble.read_access_log.markdown
@@ -53,7 +53,7 @@ entity_id:
     The entity ID, or list of entity IDs, of the ISEO locks whose access log
     you want to read.
   required: true
-  type: string
+  type: string | list
 {% endoptions_yaml %}
 
 ## Good to know

--- a/source/_actions/iseo_argo_ble.read_access_log.markdown
+++ b/source/_actions/iseo_argo_ble.read_access_log.markdown
@@ -59,6 +59,7 @@ entity_id:
 ## Good to know
 
 - Reading the log clears it. Your lock hands over everything recorded since the last read and then never offers those entries again, so a read after a quiet spell can return a long history at once. Only the most recent entry of each kind is reported, so the backlog is not replayed as though it had just happened.
+- The **Access log** entity has to be enabled. Reading empties the log on the lock, so with the entity disabled there would be nothing left to report the entries to; the action refuses instead, and the automatic read after a door opening is skipped.
 - Reading connects to the lock over Bluetooth. Close the Argo app on all phones first, because the lock only accepts one connection at a time.
 - If Home Assistant has already noticed the lock is unreachable, its entity is unavailable and this action quietly does nothing, as actions do for any unavailable entity. If the lock only goes out of range once the read is under way, the action reports an error. Either way the entries stay on the lock and arrive with the next successful read.
 - A read that fails part way through still reports whatever it managed to read. The lock hands over each page only once, so those entries would otherwise be lost.

--- a/source/_actions/iseo_argo_ble.read_access_log.markdown
+++ b/source/_actions/iseo_argo_ble.read_access_log.markdown
@@ -53,7 +53,7 @@ entity_id:
     The entity ID, or list of entity IDs, of the ISEO locks whose access log
     you want to read.
   required: true
-  type: [string, list])
+  type: [string, list]
 {% endoptions_yaml %}
 
 ## Good to know

--- a/source/_actions/iseo_argo_ble.read_access_log.markdown
+++ b/source/_actions/iseo_argo_ble.read_access_log.markdown
@@ -53,7 +53,7 @@ entity_id:
     The entity ID, or list of entity IDs, of the ISEO locks whose access log
     you want to read.
   required: true
-  type: string | list
+  type: [string, list])
 {% endoptions_yaml %}
 
 ## Good to know

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -48,7 +48,7 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
   - **Access denied**: A credential was turned away, for example a wrong PIN or password, an expired or out-of-schedule credential, or a fingerprint that did not match.
   - **Fault**: The lock reported a problem, such as a full memory, a failing backup battery, or a hardware fault.
 
-Each event carries the lock's own description of what happened, the event code behind it, the time the lock recorded, and the name the lock stored for whoever triggered it, when it stored one.
+Each event carries the lock's own description of what happened, the event code behind it, the time the lock recorded, the name the lock stored for whoever triggered it (`opened_by`, when it stored one), and the identifier of the credential involved (`credential_id`).
 
 {% include integrations/actions.md %}
 
@@ -86,8 +86,8 @@ automation: |
         entity_id: notify.my_device
       data:
         message: >
-          {{ state_attr('event.front_door_access_log', 'opened_by') }}
-          just came in.
+          {{ state_attr('event.front_door_access_log', 'opened_by')
+             or 'Someone' }} just came in.
 {% endexample %}
 
 {% enddetails %}

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -10,6 +10,7 @@ ha_codeowners:
   - '@FezVrasta'
 ha_domain: iseo_argo_ble
 ha_platforms:
+  - event
   - lock
 ha_bluetooth: true
 ha_integration_type: device
@@ -42,11 +43,103 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 ## Supported functionality
 
 - **Lock**: Controls the lock (unlock only). Reflects the current locked/unlocked state.
+- **Access log**: An event entity reporting what your lock recorded in its own access log. It reports three kinds of event:
+  - **Opened**: The door was opened, whether from Home Assistant, the Argo app, a card, a PIN, a fingerprint, a mechanical key, the internal handle, or a remote button.
+  - **Access denied**: A credential was turned away, for example a wrong PIN or password, an expired or out-of-schedule credential, or a fingerprint that did not match.
+  - **Fault**: The lock reported a problem, such as a full memory, a failing backup battery, or a hardware fault.
+
+Each event carries the lock's own description of what happened, the event code behind it, the time the lock recorded, and the name the lock stored for whoever triggered it, when it stored one.
+
+{% include integrations/actions.md %}
+
+## ISEO Argo BLE automation examples
+
+The access log tells you not just that your door opened, but who opened it, so you can act on the difference.
+
+{% include docs/paste_yaml_tip.md %}
+
+### Automation: Announce who came home
+
+When the front door is opened, the name the lock recorded is announced on a speaker.
+
+- **Trigger**: State of the **Access log** entity changes
+- **Condition**: The event type is `opened`
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for announcing who came home" %}
+
+{% example %}
+automation: |
+  alias: "Announce who came home"
+  triggers:
+    - trigger: state
+      entity_id: event.front_door_access_log
+  conditions:
+    - condition: state
+      entity_id: event.front_door_access_log
+      attribute: event_type
+      state: opened
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: >
+          {{ state_attr('event.front_door_access_log', 'opened_by') }}
+          just came in.
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Warn about repeated failed attempts
+
+When someone is turned away at the door, you get a notification with the lock's own explanation.
+
+- **Trigger**: State of the **Access log** entity changes
+- **Condition**: The event type is `access_denied`
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for warning about failed attempts" %}
+
+{% example %}
+automation: |
+  alias: "Warn about failed attempts at the front door"
+  triggers:
+    - trigger: state
+      entity_id: event.front_door_access_log
+  conditions:
+    - condition: state
+      entity_id: event.front_door_access_log
+      attribute: event_type
+      state: access_denied
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: >
+          Front door: {{ state_attr('event.front_door_access_log',
+          'description') }}.
+{% endexample %}
+
+{% enddetails %}
+
+## Data updates
+
+Home Assistant {% term polling polls %} the lock for its door state every 30 seconds.
+
+It reads the access log only when there is likely to be something in it: when that poll notices the door has been opened, and after you unlock the door from Home Assistant. You can also read it yourself at any time with the [**Read access log**](/actions/iseo_argo_ble.read_access_log/) action.
+
+Reading the log clears it. Your lock hands over everything recorded since the last read and then never offers those entries again, so a read after a quiet spell can return a long history at once. Home Assistant reports the most recent entry of each kind from every read, rather than replaying the whole backlog as though it had just happened.
 
 ## Known limitations
 
 - The lock only supports _one active Bluetooth connection_ at a time. Close the Argo app on all phones before unlocking or during setup.
 - The ISEO X1R is a momentary actuator: it re-latches automatically after every unlock. The `lock` action is therefore not supported.
+- Because the door state is checked every 30 seconds, a door that is opened and closed again within that time is not noticed, and its access log entries are not read until the next time the log is read. Nothing is lost: those entries are still waiting on the lock, and they arrive with the next read. Use the **Read access log** action if you want them straight away.
+- Only the most recent entry of each kind is reported per read, so several openings in quick succession appear as one.
 
 ## Removing the integration
 

--- a/source/_integrations/iseo_argo_ble.markdown
+++ b/source/_integrations/iseo_argo_ble.markdown
@@ -43,7 +43,7 @@ All communication is direct Bluetooth, with no cloud dependency or bridge hardwa
 ## Supported functionality
 
 - **Lock**: Controls the lock (unlock only). Reflects the current locked/unlocked state.
-- **Access log**: An event entity reporting what your lock recorded in its own access log. It reports three kinds of event:
+- **Access log**: An event entity reporting what your lock recorded in its own access log. It reports three kinds of events:
   - **Opened**: The door was opened, whether from Home Assistant, the Argo app, a card, a PIN, a fingerprint, a mechanical key, the internal handle, or a remote button.
   - **Access denied**: A credential was turned away, for example a wrong PIN or password, an expired or out-of-schedule credential, or a fingerprint that did not match.
   - **Fault**: The lock reported a problem, such as a full memory, a failing backup battery, or a hardware fault.
@@ -58,20 +58,20 @@ The access log tells you not just that your door opened, but who opened it, so y
 
 {% include docs/paste_yaml_tip.md %}
 
-### Automation: Announce who came home
+### Automation: Notify who came home
 
-When the front door is opened, the name the lock recorded is announced on a speaker.
+When the front door is opened, the name the lock recorded is sent as a notification.
 
 - **Trigger**: State of the **Access log** entity changes
 - **Condition**: The event type is `opened`
 - **Action**: Send a notification message
   - **Target**: My Device (`notify.my_device`)
 
-{% details "YAML example for announcing who came home" %}
+{% details "YAML example for notifying who came home" %}
 
 {% example %}
 automation: |
-  alias: "Announce who came home"
+  alias: "Notify who came home"
   triggers:
     - trigger: state
       entity_id: event.front_door_access_log


### PR DESCRIPTION
## Proposed change

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents access log reporting for the ISEO Argo BLE lock, added in home-assistant/core#181105.

Covers:

- the **Access log** event entity and the three kinds of event it reports (opened, access denied, fault), plus what each event carries;
- a split page for the new **Read access log** action, under `source/_actions/`, with UI and YAML options and two automation examples;
- an **ISEO Argo BLE automation examples** section with two examples on the integration page;
- a **Data updates** section explaining when the log is read, and why reading it clears it — the lock hands over everything since the last read and never offers those entries again, so only the newest entry of each kind is reported rather than replaying the backlog;
- the known limitation that a door opened and closed within the 30 second poll window is not noticed, that nothing is lost, and that the action is how you fetch those entries straight away.

Also adds `event` to `ha_platforms`.

Verified locally: `remark`, `textlint`, and a full `jekyll build` all pass, and both rendered pages were checked for heading structure and unrendered Liquid.

## Type of change

<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#181105
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
