### PR TITLE
Add the P200 to the tested Lyngdorf models

### DIFF
--- a/source/_integrations/lyngdorf.markdown
+++ b/source/_integrations/lyngdorf.markdown
@@ -50,7 +50,7 @@ Every model gets a main zone media player and the RoomPerfect position and voici
 The P100, P200, and P300 are made by Lyngdorf and marketed as [Steinway & Lyngdorf].
 
 {% note %}
-Only the MP-60, TDAI-1120, and TDAI-3400 have been tested against real hardware. The other models listed here are implemented from the protocol documentation and have not been verified by an owner, so if you have one, please report anything that does not work on [GitHub](https://github.com/home-assistant/core/issues).
+Only the MP-60, TDAI-1120, TDAI-3400, and P200 have been tested against real hardware. The other models listed here are implemented from the protocol documentation and have not been verified by an owner, so if you have one, please report anything that does not work on [GitHub](https://github.com/home-assistant/core/issues).
 {% endnote %}
 
 ## Prerequisites
@@ -147,7 +147,7 @@ The **Lyngdorf** integration uses local push to receive real-time updates from t
 
 ## Known limitations
 
-- Only the MP-60, TDAI-1120, and TDAI-3400 have been tested against real hardware. The other models are implemented from the protocol documentation and may not support all features.
+- Only the MP-60, TDAI-1120, TDAI-3400, and P200 have been tested against real hardware. The other models are implemented from the protocol documentation and may not support all features.
 - Only local network control is supported.
 - Pausing a source that is controlled by another app, such as AirPlay, ends the session rather than pausing it. The device cannot resume it; only the controlling app can start it again. This is how those protocols work, and is not specific to Home Assistant.
 - Now playing information, playback position, and transport controls require a model with a streaming module. The TDAI-2170 and the P-series do not have one.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

A P200 owner has run the integration against real hardware, so the model moves
into the tested list. The note appears twice on the page, under supported
devices and under known limitations, and both are updated.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
