### PR TITLE
Add documentation for optional speed parameter of velux cover actions

### DIFF
--- a/source/_integrations/velux.markdown
+++ b/source/_integrations/velux.markdown
@@ -107,7 +107,7 @@ All Velux cover entities support:
 - Stop
 - Set position
 
-The `open`, `close` and `set_position` actions support an optional `speed` parameter. Valid values are `silent`, `default` and `fast`.
+The **Open cover**, **Close cover**, and **Set cover position** actions support an optional `speed` option. Available values are listed in the `supported_speeds` attribute of the cover entity (`silent`, `fast`, and `default`).
 
 Blinds additionally support:
 

--- a/source/_integrations/velux.markdown
+++ b/source/_integrations/velux.markdown
@@ -107,6 +107,8 @@ All Velux cover entities support:
 - Stop
 - Set position
 
+The `open`, `close` and `set_position` actions support an optional `speed` parameter. Valid values are `silent`, `default` and `fast`.
+
 Blinds additionally support:
 
 - Open tilt


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
A speed parameter was added to velux cover actions in https://github.com/home-assistant/core/pull/180036, this adds their proper documentation. Note that the core PR was already merged and included in 2026.9.0, so `current` should be the correct target branch even though the bot thinks otherwise. 

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
