### PR TITLE
Document the Persang Infrared button platform

### DIFF
--- a/source/_integrations/persang_infrared.markdown
+++ b/source/_integrations/persang_infrared.markdown
@@ -2,6 +2,7 @@
 title: Persang Infrared
 description: Integration to control Persang speakers using an infrared transmitter.
 ha_category:
+  - Button
   - Infrared
   - Media player
 ha_release: '2026.10'
@@ -11,6 +12,7 @@ ha_codeowners:
 ha_domain: persang_infrared
 ha_config_flow: true
 ha_platforms:
+  - button
   - media_player
 ha_integration_type: device
 ha_quality_scale: bronze
@@ -47,6 +49,16 @@ The **Persang Infrared** integration provides the following entities.
   - **Description**: Represents the speaker and allows you to control it over IR.
   - **Supported features**: Turn on, turn off, volume up, volume down, mute, play, pause, next track, and previous track.
 
+### Buttons
+
+Button entities are provided for the remaining remote buttons, which the media player entity does not expose:
+
+- **Mode**: Cycles through the speaker's playback modes.
+- **Equalizer**: Cycles through the speaker's equalizer presets.
+- **Scan**: Starts scanning the current source.
+- **Repeat**: Cycles through the repeat modes.
+- **Number 0** to **Number 9**: Send the corresponding numeric key, which the speaker uses to select a track.
+
 ## Known limitations
 
 - The integration uses assumed state, meaning Home Assistant cannot read the actual state of the speaker (for example, whether it is on or off, or what the current volume is).
@@ -55,7 +67,7 @@ The **Persang Infrared** integration provides the following entities.
 - Volume control is step-based only; there is no way to set an absolute volume level.
 - Mute is not restored after a restart.
 - Source selection is not exposed, because the remote has no dedicated source buttons.
-- The remaining remote buttons, such as mode, equalizer, scan, repeat, and the numeric keys, are not exposed yet.
+- The mode, equalizer, and repeat buttons cycle through the available settings, so Home Assistant cannot select a specific one or tell which one is active.
 
 ## Removing the integration
 

--- a/source/_integrations/persang_infrared.markdown
+++ b/source/_integrations/persang_infrared.markdown
@@ -57,7 +57,7 @@ Button entities are provided for the remaining remote buttons, which the media p
 - **Equalizer**: Cycles through the speaker's equalizer presets.
 - **Scan**: Starts scanning the current source.
 - **Repeat**: Cycles through the repeat modes.
-- **Number 0** to **Number 9**: Send the corresponding numeric key, which the speaker uses to select a track.
+- **Number 0** to **Number 9**: Sends the corresponding numeric key, which the speaker uses to select a track.
 
 ## Known limitations
 


### PR DESCRIPTION
## Proposed change

Documents the button entities that the linked core pull request adds to the Persang Infrared integration: the mode, equalizer, scan, and repeat cycles, and the numeric keys, **Number 0** to **Number 9**. These are the remaining buttons on the Persang remote that the media player entity has no slot for, and the original integration documentation listed them as not exposed yet.

The change adds `Button` to the categories and `button` to the platforms in the front matter, adds a **Buttons** section under **Supported functionality**, and replaces the "not exposed yet" known limitation with one explaining that the mode, equalizer, and repeat buttons cycle through settings, so Home Assistant cannot select a specific one or tell which one is active.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/181161
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
