### PR TITLE
Document battery trigger behavior defaults

### DIFF
--- a/source/_triggers/battery.became_low.markdown
+++ b/source/_triggers/battery.became_low.markdown
@@ -37,6 +37,7 @@ Trigger when:
     - **First**: fires only when the first targeted sensor reports a low battery.
     - **All**: fires only after every targeted sensor reports a low battery.
   required: false
+  default: Each
 For at least:
   description: How long the sensor or sensors must remain reporting low battery before the trigger fires. The default is `0` hours, `00` minutes and `00` seconds (fires immediately).
   required: false

--- a/source/_triggers/battery.level_crossed.markdown
+++ b/source/_triggers/battery.level_crossed.markdown
@@ -52,6 +52,8 @@ Trigger when:
     - **All**: fires only after every targeted entity crosses the threshold.
 
     This corresponds to the `behavior` field in YAML. Default is **Each**.
+  required: false
+  default: Each
 For at least:
   description: How long the reading must remain past the threshold before the trigger fires. Useful to avoid triggering on brief fluctuations. For example, set it to `0:30:00` to fire only after the reading has stayed past the threshold for 30 minutes. Default is `0` (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/battery.no_longer_low.markdown
+++ b/source/_triggers/battery.no_longer_low.markdown
@@ -37,6 +37,7 @@ Trigger when:
     - **First**: fires only when the first targeted sensor stops reporting a low battery.
     - **All**: fires only after every targeted sensor stops reporting a low battery.
   required: false
+  default: Each
 For at least:
   description: How long the sensor or sensors must remain reporting a normal battery level before the trigger fires. The default is `0` hours, `00` minutes and `00` seconds (fires immediately).
   required: false

--- a/source/_triggers/battery.started_charging.markdown
+++ b/source/_triggers/battery.started_charging.markdown
@@ -34,6 +34,8 @@ Trigger when:
     - **Each** (default): fires every time any targeted device starts charging.
     - **First**: fires only on the first device that starts charging.
     - **All**: fires only after every targeted device starts charging.
+  required: false
+  default: Each
 For at least:
   description: How long the device must be actively charging before the trigger fires. Default is `0` (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/battery.stopped_charging.markdown
+++ b/source/_triggers/battery.stopped_charging.markdown
@@ -34,6 +34,8 @@ Trigger when:
     - **Each** (default): fires every time any targeted device stops charging.
     - **First**: fires only on the first device that stops charging.
     - **All**: fires only after every targeted device stops charging.
+  required: false
+  default: Each
 For at least:
   description: How long the device must remain not charging before the trigger fires. Default is `0` (fires immediately).
 {% endoptions_ui %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Document the default behavior for battery triggers. The **Trigger when** option is now marked as optional in the UI documentation, and the YAML `behavior` option is marked as optional with its default value where present, because options with default values [should be marked as optional](https://developers.home-assistant.io/docs/documenting/create-page#about-configuration-variables).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 
- Related issue: https://github.com/home-assistant/home-assistant.io/issues/46958

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
