### PR TITLE
Document climate trigger behavior defaults

### DIFF
--- a/source/_triggers/climate.hvac_mode_changed.markdown
+++ b/source/_triggers/climate.hvac_mode_changed.markdown
@@ -40,6 +40,8 @@ Trigger when:
     - **Each** (default): fires every time any targeted thermostat changes mode.
     - **First**: fires only on the first mode change.
     - **All**: fires only after every targeted thermostat changes mode.
+  required: false
+  default: Each
 For at least:
   description: How long the thermostat must remain in the new mode before the trigger fires. Useful to ignore brief mode changes. Default is `0` (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/climate.hvac_mode_changed.markdown
+++ b/source/_triggers/climate.hvac_mode_changed.markdown
@@ -41,7 +41,6 @@ Trigger when:
     - **First**: fires only on the first mode change.
     - **All**: fires only after every targeted thermostat changes mode.
   required: false
-  default: Each
 For at least:
   description: How long the thermostat must remain in the new mode before the trigger fires. Useful to ignore brief mode changes. Default is `0` (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/climate.started_cooling.markdown
+++ b/source/_triggers/climate.started_cooling.markdown
@@ -39,7 +39,6 @@ Trigger when:
     - **First**: fires only when the first of a group starts cooling.
     - **All**: fires only after every targeted thermostat is cooling.
   required: false
-  default: Each
 For at least:
   description: How long the thermostat must stay in the cooling state before the trigger fires. Default is zero (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/climate.started_cooling.markdown
+++ b/source/_triggers/climate.started_cooling.markdown
@@ -38,6 +38,8 @@ Trigger when:
     - **Each** (default): fires every time any targeted thermostat starts cooling.
     - **First**: fires only when the first of a group starts cooling.
     - **All**: fires only after every targeted thermostat is cooling.
+  required: false
+  default: Each
 For at least:
   description: How long the thermostat must stay in the cooling state before the trigger fires. Default is zero (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/climate.started_drying.markdown
+++ b/source/_triggers/climate.started_drying.markdown
@@ -36,6 +36,8 @@ Trigger when:
     - **Each** (default): fires every time any targeted thermostat starts drying.
     - **First**: fires only when the first of a group starts drying.
     - **All**: fires only after every targeted thermostat is drying.
+  required: false
+  default: Each
 For at least:
   description: How long the thermostat must stay in the drying state before the trigger fires. Default is zero (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/climate.started_drying.markdown
+++ b/source/_triggers/climate.started_drying.markdown
@@ -37,7 +37,6 @@ Trigger when:
     - **First**: fires only when the first of a group starts drying.
     - **All**: fires only after every targeted thermostat is drying.
   required: false
-  default: Each
 For at least:
   description: How long the thermostat must stay in the drying state before the trigger fires. Default is zero (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/climate.started_heating.markdown
+++ b/source/_triggers/climate.started_heating.markdown
@@ -36,6 +36,8 @@ Trigger when:
     - **Each** (default): fires every time any targeted thermostat starts heating.
     - **First**: fires only when the first of a group starts heating.
     - **All**: fires only after every targeted thermostat is heating.
+  required: false
+  default: Each
 For at least:
   description: How long the thermostat must stay in the heating state before the trigger fires. Default is zero (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/climate.started_heating.markdown
+++ b/source/_triggers/climate.started_heating.markdown
@@ -37,7 +37,6 @@ Trigger when:
     - **First**: fires only when the first of a group starts heating.
     - **All**: fires only after every targeted thermostat is heating.
   required: false
-  default: Each
 For at least:
   description: How long the thermostat must stay in the heating state before the trigger fires. Default is zero (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/climate.target_humidity_crossed_threshold.markdown
+++ b/source/_triggers/climate.target_humidity_crossed_threshold.markdown
@@ -53,7 +53,6 @@ Trigger when:
     - **First**: fires only on the first threshold crossing.
     - **All**: fires only after every targeted thermostat crosses the threshold.
   required: false
-  default: Each
 For at least:
   description: How long the thermostat setpoint must stay beyond the threshold before the trigger fires. Useful to avoid false triggers from brief adjustments. Default is `0` (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/climate.target_humidity_crossed_threshold.markdown
+++ b/source/_triggers/climate.target_humidity_crossed_threshold.markdown
@@ -52,6 +52,8 @@ Trigger when:
     - **Each** (default): fires every time any targeted thermostat crosses the threshold.
     - **First**: fires only on the first threshold crossing.
     - **All**: fires only after every targeted thermostat crosses the threshold.
+  required: false
+  default: Each
 For at least:
   description: How long the thermostat setpoint must stay beyond the threshold before the trigger fires. Useful to avoid false triggers from brief adjustments. Default is `0` (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/climate.target_temperature_crossed_threshold.markdown
+++ b/source/_triggers/climate.target_temperature_crossed_threshold.markdown
@@ -56,7 +56,6 @@ Trigger when:
     - **First**: fires only on the first threshold crossing.
     - **All**: fires only after every targeted thermostat crosses the threshold.
   required: false
-  default: Each
 For at least:
   description: How long the thermostat setpoint must stay beyond the threshold before the trigger fires. Useful to avoid false triggers from brief adjustments. Default is `0` (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/climate.target_temperature_crossed_threshold.markdown
+++ b/source/_triggers/climate.target_temperature_crossed_threshold.markdown
@@ -55,6 +55,8 @@ Trigger when:
     - **Each** (default): fires every time any targeted thermostat crosses the threshold.
     - **First**: fires only on the first threshold crossing.
     - **All**: fires only after every targeted thermostat crosses the threshold.
+  required: false
+  default: Each
 For at least:
   description: How long the thermostat setpoint must stay beyond the threshold before the trigger fires. Useful to avoid false triggers from brief adjustments. Default is `0` (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/climate.turned_off.markdown
+++ b/source/_triggers/climate.turned_off.markdown
@@ -36,7 +36,6 @@ Trigger when:
     - **First**: fires only when the first of a group turns off.
     - **All**: fires only after every targeted thermostat is off.
   required: false
-  default: Each
 For at least:
   description: How long the thermostat must stay off before the trigger fires. Default is `0` (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/climate.turned_off.markdown
+++ b/source/_triggers/climate.turned_off.markdown
@@ -35,6 +35,8 @@ Trigger when:
     - **Each** (default): fires every time any targeted thermostat turns off.
     - **First**: fires only when the first of a group turns off.
     - **All**: fires only after every targeted thermostat is off.
+  required: false
+  default: Each
 For at least:
   description: How long the thermostat must stay off before the trigger fires. Default is `0` (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/climate.turned_on.markdown
+++ b/source/_triggers/climate.turned_on.markdown
@@ -36,7 +36,6 @@ Trigger when:
     - **First**: fires only when the first of a group turns on.
     - **All**: fires only after every targeted thermostat is on.
   required: false
-  default: Each
 For at least:
   description: How long the thermostat must stay on before the trigger fires. Default is `0` (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/climate.turned_on.markdown
+++ b/source/_triggers/climate.turned_on.markdown
@@ -35,6 +35,8 @@ Trigger when:
     - **Each** (default): fires every time any targeted thermostat turns on.
     - **First**: fires only when the first of a group turns on.
     - **All**: fires only after every targeted thermostat is on.
+  required: false
+  default: Each
 For at least:
   description: How long the thermostat must stay on before the trigger fires. Default is `0` (fires immediately).
 {% endoptions_ui %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Document the default behavior for climate triggers. The **Trigger when** option is now marked as optional in the UI documentation, and the YAML `behavior` option is marked as optional with its default value where present, because options with default values [should be marked as optional](https://developers.home-assistant.io/docs/documenting/create-page#about-configuration-variables).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 
- Related issue: https://github.com/home-assistant/home-assistant.io/issues/46958

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
