### PR TITLE
Document cover trigger behavior defaults

### DIFF
--- a/source/_triggers/cover.awning_closed.markdown
+++ b/source/_triggers/cover.awning_closed.markdown
@@ -30,7 +30,6 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple awnings are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted awning closes, **First** to fire only when the first targeted awning closes, or **All** to fire only after every targeted awning is closed. The default is **Each**.
   required: false
-  default: Each
 For at least:
   description: How long the awning must stay closed before the trigger fires. The default is `0` (fires immediately).
   required: false

--- a/source/_triggers/cover.awning_closed.markdown
+++ b/source/_triggers/cover.awning_closed.markdown
@@ -30,6 +30,7 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple awnings are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted awning closes, **First** to fire only when the first targeted awning closes, or **All** to fire only after every targeted awning is closed. The default is **Each**.
   required: false
+  default: Each
 For at least:
   description: How long the awning must stay closed before the trigger fires. The default is `0` (fires immediately).
   required: false
@@ -56,10 +57,10 @@ YAML sometimes provides additional options for more complex use cases that are n
 behavior:
   description: >
     When multiple awnings are targeted, controls when the trigger fires.
-    Accepts `any`, `first`, or `last`.
+    Accepts `each`, `first`, or `all`.
   required: false
   type: string
-  default: any
+  default: each
 for:
   description: >
     How long the awning must stay closed before the trigger fires.

--- a/source/_triggers/cover.awning_opened.markdown
+++ b/source/_triggers/cover.awning_opened.markdown
@@ -30,7 +30,6 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple awnings are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted awning opens, **First** to fire only when the first targeted awning opens, or **All** to fire only after every targeted awning is open. The default is **Each**.
   required: false
-  default: Each
 For at least:
   description: How long the awning must stay open before the trigger fires. The default is `0` (fires immediately).
   required: false

--- a/source/_triggers/cover.awning_opened.markdown
+++ b/source/_triggers/cover.awning_opened.markdown
@@ -30,6 +30,7 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple awnings are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted awning opens, **First** to fire only when the first targeted awning opens, or **All** to fire only after every targeted awning is open. The default is **Each**.
   required: false
+  default: Each
 For at least:
   description: How long the awning must stay open before the trigger fires. The default is `0` (fires immediately).
   required: false
@@ -56,10 +57,10 @@ YAML sometimes provides additional options for more complex use cases that are n
 behavior:
   description: >
     When multiple awnings are targeted, controls when the trigger fires.
-    Accepts `any`, `first`, or `last`.
+    Accepts `each`, `first`, or `all`.
   required: false
   type: string
-  default: any
+  default: each
 for:
   description: >
     How long the awning must stay open before the trigger fires.

--- a/source/_triggers/cover.blind_closed.markdown
+++ b/source/_triggers/cover.blind_closed.markdown
@@ -30,7 +30,6 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple blinds are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted blind closes, **First** to fire only when the first targeted blind closes, or **All** to fire only after every targeted blind is closed. The default is **Each**.
   required: false
-  default: Each
 For at least:
   description: How long the blind must stay closed before the trigger fires. The default is `0` (fires immediately).
   required: false

--- a/source/_triggers/cover.blind_closed.markdown
+++ b/source/_triggers/cover.blind_closed.markdown
@@ -30,6 +30,7 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple blinds are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted blind closes, **First** to fire only when the first targeted blind closes, or **All** to fire only after every targeted blind is closed. The default is **Each**.
   required: false
+  default: Each
 For at least:
   description: How long the blind must stay closed before the trigger fires. The default is `0` (fires immediately).
   required: false
@@ -56,10 +57,10 @@ YAML sometimes provides additional options for more complex use cases that are n
 behavior:
   description: >
     When multiple blinds are targeted, controls when the trigger fires.
-    Accepts `any`, `first`, or `last`.
+    Accepts `each`, `first`, or `all`.
   required: false
   type: string
-  default: any
+  default: each
 for:
   description: >
     How long the blind must stay closed before the trigger fires.

--- a/source/_triggers/cover.blind_opened.markdown
+++ b/source/_triggers/cover.blind_opened.markdown
@@ -30,7 +30,6 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple blinds are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted blind opens, **First** to fire only when the first targeted blind opens, or **All** to fire only after every targeted blind is open. The default is **Each**.
   required: false
-  default: Each
 For at least:
   description: How long the blind must stay open before the trigger fires. The default is `0` (fires immediately).
   required: false

--- a/source/_triggers/cover.blind_opened.markdown
+++ b/source/_triggers/cover.blind_opened.markdown
@@ -30,6 +30,7 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple blinds are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted blind opens, **First** to fire only when the first targeted blind opens, or **All** to fire only after every targeted blind is open. The default is **Each**.
   required: false
+  default: Each
 For at least:
   description: How long the blind must stay open before the trigger fires. The default is `0` (fires immediately).
   required: false
@@ -56,10 +57,10 @@ YAML sometimes provides additional options for more complex use cases that are n
 behavior:
   description: >
     When multiple blinds are targeted, controls when the trigger fires.
-    Accepts `any`, `first`, or `last`.
+    Accepts `each`, `first`, or `all`.
   required: false
   type: string
-  default: any
+  default: each
 for:
   description: >
     How long the blind must stay open before the trigger fires.

--- a/source/_triggers/cover.curtain_closed.markdown
+++ b/source/_triggers/cover.curtain_closed.markdown
@@ -30,7 +30,6 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple curtains are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted curtain closes, **First** to fire only when the first targeted curtain closes, or **All** to fire only after every targeted curtain is closed. The default is **Each**.
   required: false
-  default: Each
 For at least:
   description: How long the curtain must stay closed before the trigger fires. The default is `0` (fires immediately).
   required: false

--- a/source/_triggers/cover.curtain_closed.markdown
+++ b/source/_triggers/cover.curtain_closed.markdown
@@ -30,6 +30,7 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple curtains are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted curtain closes, **First** to fire only when the first targeted curtain closes, or **All** to fire only after every targeted curtain is closed. The default is **Each**.
   required: false
+  default: Each
 For at least:
   description: How long the curtain must stay closed before the trigger fires. The default is `0` (fires immediately).
   required: false
@@ -56,10 +57,10 @@ YAML sometimes provides additional options for more complex use cases that are n
 behavior:
   description: >
     When multiple curtains are targeted, controls when the trigger fires.
-    Accepts `any`, `first`, or `last`.
+    Accepts `each`, `first`, or `all`.
   required: false
   type: string
-  default: any
+  default: each
 for:
   description: >
     How long the curtain must stay closed before the trigger fires.

--- a/source/_triggers/cover.curtain_opened.markdown
+++ b/source/_triggers/cover.curtain_opened.markdown
@@ -30,7 +30,6 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple curtains are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted curtain opens, **First** to fire only when the first targeted curtain opens, or **All** to fire only after every targeted curtain is open. The default is **Each**.
   required: false
-  default: Each
 For at least:
   description: How long the curtain must stay open before the trigger fires. The default is `0` (fires immediately).
   required: false

--- a/source/_triggers/cover.curtain_opened.markdown
+++ b/source/_triggers/cover.curtain_opened.markdown
@@ -30,6 +30,7 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple curtains are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted curtain opens, **First** to fire only when the first targeted curtain opens, or **All** to fire only after every targeted curtain is open. The default is **Each**.
   required: false
+  default: Each
 For at least:
   description: How long the curtain must stay open before the trigger fires. The default is `0` (fires immediately).
   required: false
@@ -56,10 +57,10 @@ YAML sometimes provides additional options for more complex use cases that are n
 behavior:
   description: >
     When multiple curtains are targeted, controls when the trigger fires.
-    Accepts `any`, `first`, or `last`.
+    Accepts `each`, `first`, or `all`.
   required: false
   type: string
-  default: any
+  default: each
 for:
   description: >
     How long the curtain must stay open before the trigger fires.

--- a/source/_triggers/cover.shade_closed.markdown
+++ b/source/_triggers/cover.shade_closed.markdown
@@ -30,6 +30,7 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple shades are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted shade closes, **First** to fire only when the first targeted shade closes, or **All** to fire only after every targeted shade is closed. The default is **Each**.
   required: false
+  default: Each
 For at least:
   description: How long the shade must stay closed before the trigger fires. The default is `0` (fires immediately).
   required: false
@@ -56,10 +57,10 @@ YAML sometimes provides additional options for more complex use cases that are n
 behavior:
   description: >
     When multiple shades are targeted, controls when the trigger fires.
-    Accepts `any`, `first`, or `last`.
+    Accepts `each`, `first`, or `all`.
   required: false
   type: string
-  default: any
+  default: each
 for:
   description: >
     How long the shade must stay closed before the trigger fires.

--- a/source/_triggers/cover.shade_closed.markdown
+++ b/source/_triggers/cover.shade_closed.markdown
@@ -30,7 +30,6 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple shades are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted shade closes, **First** to fire only when the first targeted shade closes, or **All** to fire only after every targeted shade is closed. The default is **Each**.
   required: false
-  default: Each
 For at least:
   description: How long the shade must stay closed before the trigger fires. The default is `0` (fires immediately).
   required: false

--- a/source/_triggers/cover.shade_opened.markdown
+++ b/source/_triggers/cover.shade_opened.markdown
@@ -30,7 +30,6 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple shades are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted shade opens, **First** to fire only when the first targeted shade opens, or **All** to fire only after every targeted shade is open. The default is **Each**.
   required: false
-  default: Each
 For at least:
   description: How long the shade must stay open before the trigger fires. The default is `0` (fires immediately).
   required: false

--- a/source/_triggers/cover.shade_opened.markdown
+++ b/source/_triggers/cover.shade_opened.markdown
@@ -30,6 +30,7 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple shades are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted shade opens, **First** to fire only when the first targeted shade opens, or **All** to fire only after every targeted shade is open. The default is **Each**.
   required: false
+  default: Each
 For at least:
   description: How long the shade must stay open before the trigger fires. The default is `0` (fires immediately).
   required: false
@@ -56,10 +57,10 @@ YAML sometimes provides additional options for more complex use cases that are n
 behavior:
   description: >
     When multiple shades are targeted, controls when the trigger fires.
-    Accepts `any`, `first`, or `last`.
+    Accepts `each`, `first`, or `all`.
   required: false
   type: string
-  default: any
+  default: each
 for:
   description: >
     How long the shade must stay open before the trigger fires.

--- a/source/_triggers/cover.shutter_closed.markdown
+++ b/source/_triggers/cover.shutter_closed.markdown
@@ -30,6 +30,7 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple shutters are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted shutter closes, **First** to fire only when the first targeted shutter closes, or **All** to fire only after every targeted shutter is closed. The default is **Each**.
   required: false
+  default: Each
 For at least:
   description: How long the shutter must stay closed before the trigger fires. The default is `0` (fires immediately).
   required: false
@@ -56,10 +57,10 @@ YAML sometimes provides additional options for more complex use cases that are n
 behavior:
   description: >
     When multiple shutters are targeted, controls when the trigger fires.
-    Accepts `any`, `first`, or `last`.
+    Accepts `each`, `first`, or `all`.
   required: false
   type: string
-  default: any
+  default: each
 for:
   description: >
     How long the shutter must stay closed before the trigger fires.

--- a/source/_triggers/cover.shutter_closed.markdown
+++ b/source/_triggers/cover.shutter_closed.markdown
@@ -30,7 +30,6 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple shutters are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted shutter closes, **First** to fire only when the first targeted shutter closes, or **All** to fire only after every targeted shutter is closed. The default is **Each**.
   required: false
-  default: Each
 For at least:
   description: How long the shutter must stay closed before the trigger fires. The default is `0` (fires immediately).
   required: false

--- a/source/_triggers/cover.shutter_opened.markdown
+++ b/source/_triggers/cover.shutter_opened.markdown
@@ -30,6 +30,7 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple shutters are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted shutter opens, **First** to fire only when the first targeted shutter opens, or **All** to fire only after every targeted shutter is open. The default is **Each**.
   required: false
+  default: Each
 For at least:
   description: How long the shutter must stay open before the trigger fires. The default is `0` (fires immediately).
   required: false
@@ -56,10 +57,10 @@ YAML sometimes provides additional options for more complex use cases that are n
 behavior:
   description: >
     When multiple shutters are targeted, controls when the trigger fires.
-    Accepts `any`, `first`, or `last`.
+    Accepts `each`, `first`, or `all`.
   required: false
   type: string
-  default: any
+  default: each
 for:
   description: >
     How long the shutter must stay open before the trigger fires.

--- a/source/_triggers/cover.shutter_opened.markdown
+++ b/source/_triggers/cover.shutter_opened.markdown
@@ -30,7 +30,6 @@ To use this trigger in an automation:
 Trigger when:
   description: When multiple shutters are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted shutter opens, **First** to fire only when the first targeted shutter opens, or **All** to fire only after every targeted shutter is open. The default is **Each**.
   required: false
-  default: Each
 For at least:
   description: How long the shutter must stay open before the trigger fires. The default is `0` (fires immediately).
   required: false


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Document the default behavior for cover triggers. The **Trigger when** option is now marked as optional in the UI documentation, and the YAML `behavior` option is marked as optional with its default value where present, because options with default values [should be marked as optional](https://developers.home-assistant.io/docs/documenting/create-page#about-configuration-variables).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 
- Related issue: https://github.com/home-assistant/home-assistant.io/issues/46958

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
