### PR TITLE
Document remote trigger behavior defaults

### DIFF
--- a/source/_triggers/remote.turned_off.markdown
+++ b/source/_triggers/remote.turned_off.markdown
@@ -32,6 +32,8 @@ Trigger when:
     - **Each** (default): fires every time any targeted remote turns off.
     - **First**: fires only when the first of a group turns off.
     - **All**: fires only after every targeted remote is off.
+  required: false
+  default: Each
 For at least:
   description: How long the remote must stay off before the trigger fires. Default is zero (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/remote.turned_off.markdown
+++ b/source/_triggers/remote.turned_off.markdown
@@ -33,7 +33,6 @@ Trigger when:
     - **First**: fires only when the first of a group turns off.
     - **All**: fires only after every targeted remote is off.
   required: false
-  default: Each
 For at least:
   description: How long the remote must stay off before the trigger fires. Default is zero (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/remote.turned_on.markdown
+++ b/source/_triggers/remote.turned_on.markdown
@@ -32,6 +32,8 @@ Trigger when:
     - **Each** (default): fires every time any targeted remote turns on.
     - **First**: fires only when the first of a group turns on.
     - **All**: fires only after every targeted remote is on.
+  required: false
+  default: Each
 For at least:
   description: How long the remote must stay on before the trigger fires. Default is zero (fires immediately).
 {% endoptions_ui %}

--- a/source/_triggers/remote.turned_on.markdown
+++ b/source/_triggers/remote.turned_on.markdown
@@ -33,7 +33,6 @@ Trigger when:
     - **First**: fires only when the first of a group turns on.
     - **All**: fires only after every targeted remote is on.
   required: false
-  default: Each
 For at least:
   description: How long the remote must stay on before the trigger fires. Default is zero (fires immediately).
 {% endoptions_ui %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Document the default behavior for remote triggers. The **Trigger when** option is now marked as optional in the UI documentation, and the YAML `behavior` option is marked as optional with its default value where present, because options with default values [should be marked as optional](https://developers.home-assistant.io/docs/documenting/create-page#about-configuration-variables).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 
- Related issue: https://github.com/home-assistant/home-assistant.io/issues/46958

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
