### PR TITLE
Document vacuum trigger behavior defaults

### DIFF
--- a/source/_triggers/vacuum.errored.markdown
+++ b/source/_triggers/vacuum.errored.markdown
@@ -31,7 +31,8 @@ To use this trigger in an automation:
 {% options_ui %}
 Trigger when:
   description: When more than one vacuum is targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted vacuum reports an error, **First** to fire only on the first error event, or **All** to fire only after all targeted vacuums have reported an error.
-  required: true
+  required: false
+  default: Each
 For at least:
   description: The time the vacuum must remain in the error state before the trigger fires.
   required: false
@@ -62,7 +63,7 @@ YAML sometimes provides additional options for more complex use cases that are n
 behavior:
   description: >
     When multiple vacuums are targeted, controls when the trigger fires. Accepts `each`, `first`, or `all`.
-  required: true
+  required: false
   type: string
   default: each
 for:

--- a/source/_triggers/vacuum.errored.markdown
+++ b/source/_triggers/vacuum.errored.markdown
@@ -32,7 +32,6 @@ To use this trigger in an automation:
 Trigger when:
   description: When more than one vacuum is targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted vacuum reports an error, **First** to fire only on the first error event, or **All** to fire only after all targeted vacuums have reported an error.
   required: false
-  default: Each
 For at least:
   description: The time the vacuum must remain in the error state before the trigger fires.
   required: false

--- a/source/_triggers/vacuum.paused_cleaning.markdown
+++ b/source/_triggers/vacuum.paused_cleaning.markdown
@@ -32,7 +32,6 @@ To use this trigger in an automation:
 Trigger when:
   description: When monitoring more than one vacuum, controls when the trigger fires. Pick **Each** to fire every time any targeted vacuum pauses, **First** to fire only on the first pause event, or **All** to fire only after all targeted vacuums have paused.
   required: false
-  default: Each
 For at least:
   description: The time the vacuum must remain paused before the trigger fires.
   required: false

--- a/source/_triggers/vacuum.paused_cleaning.markdown
+++ b/source/_triggers/vacuum.paused_cleaning.markdown
@@ -31,7 +31,8 @@ To use this trigger in an automation:
 {% options_ui %}
 Trigger when:
   description: When monitoring more than one vacuum, controls when the trigger fires. Pick **Each** to fire every time any targeted vacuum pauses, **First** to fire only on the first pause event, or **All** to fire only after all targeted vacuums have paused.
-  required: true
+  required: false
+  default: Each
 For at least:
   description: The time the vacuum must remain paused before the trigger fires.
   required: false
@@ -60,7 +61,7 @@ YAML sometimes provides additional options for more complex use cases that are n
 behavior:
   description: >
     When multiple vacuums are targeted, controls when the trigger fires. Accepts `each`, `first`, or `all`.
-  required: true
+  required: false
   type: string
   default: each
 for:

--- a/source/_triggers/vacuum.returned_to_dock.markdown
+++ b/source/_triggers/vacuum.returned_to_dock.markdown
@@ -32,7 +32,6 @@ To use this trigger in an automation:
 Trigger when:
   description: When monitoring more than one vacuum, controls when the trigger fires. Pick **Each** to fire every time any targeted vacuum returns to dock, **First** to fire only on the first dock event, or **All** to fire only after all targeted vacuums have returned to dock.
   required: false
-  default: Each
 For at least:
   description: The time the vacuum must remain docked before the trigger fires.
   required: false

--- a/source/_triggers/vacuum.returned_to_dock.markdown
+++ b/source/_triggers/vacuum.returned_to_dock.markdown
@@ -31,7 +31,8 @@ To use this trigger in an automation:
 {% options_ui %}
 Trigger when:
   description: When monitoring more than one vacuum, controls when the trigger fires. Pick **Each** to fire every time any targeted vacuum returns to dock, **First** to fire only on the first dock event, or **All** to fire only after all targeted vacuums have returned to dock.
-  required: true
+  required: false
+  default: Each
 For at least:
   description: The time the vacuum must remain docked before the trigger fires.
   required: false
@@ -62,7 +63,7 @@ YAML sometimes provides additional options for more complex use cases that are n
 behavior:
   description: >
     When multiple vacuums are targeted, controls when the trigger fires. Options: `each` (every time any targeted vacuum docks), `first` (only when the first returns), or `all` (only after all have docked).
-  required: true
+  required: false
   type: string
   default: each
 for:

--- a/source/_triggers/vacuum.started_cleaning.markdown
+++ b/source/_triggers/vacuum.started_cleaning.markdown
@@ -30,7 +30,8 @@ To use this trigger in an automation:
 {% options_ui %}
 Trigger when:
   description: If targeting multiple vacuums, determines when the trigger fires. Pick **Each** to fire every time any targeted vacuum starts cleaning, **First** to fire only on the first start event, or **All** to fire only after all targeted vacuums have started cleaning.
-  required: true
+  required: false
+  default: Each
 For at least:
   description: The time the vacuum must keep cleaning before the trigger fires.
   required: false
@@ -59,7 +60,7 @@ YAML sometimes provides additional options for more complex use cases that are n
 behavior:
   description: >
     When multiple vacuums are targeted, controls when the trigger fires. Accepts `each`, `first`, or `all`.
-  required: true
+  required: false
   type: string
   default: each
 for:

--- a/source/_triggers/vacuum.started_cleaning.markdown
+++ b/source/_triggers/vacuum.started_cleaning.markdown
@@ -31,7 +31,6 @@ To use this trigger in an automation:
 Trigger when:
   description: If targeting multiple vacuums, determines when the trigger fires. Pick **Each** to fire every time any targeted vacuum starts cleaning, **First** to fire only on the first start event, or **All** to fire only after all targeted vacuums have started cleaning.
   required: false
-  default: Each
 For at least:
   description: The time the vacuum must keep cleaning before the trigger fires.
   required: false

--- a/source/_triggers/vacuum.started_returning.markdown
+++ b/source/_triggers/vacuum.started_returning.markdown
@@ -30,7 +30,8 @@ To use this trigger in an automation:
 {% options_ui %}
 Trigger when:
   description: When monitoring more than one vacuum, controls when the trigger fires. Pick **Each** to fire every time any targeted vacuum starts returning, **First** to fire only on the first return event, or **All** to fire only after all targeted vacuums have started returning.
-  required: true
+  required: false
+  default: Each
 For at least:
   description: The time the vacuum must keep returning before the trigger fires.
   required: false
@@ -59,7 +60,7 @@ YAML sometimes provides additional options for more complex use cases that are n
 behavior:
   description: >
     When multiple vacuums are targeted, controls when the trigger fires. Accepts `each`, `first`, or `all`.
-  required: true
+  required: false
   type: string
   default: each
 for:

--- a/source/_triggers/vacuum.started_returning.markdown
+++ b/source/_triggers/vacuum.started_returning.markdown
@@ -31,7 +31,6 @@ To use this trigger in an automation:
 Trigger when:
   description: When monitoring more than one vacuum, controls when the trigger fires. Pick **Each** to fire every time any targeted vacuum starts returning, **First** to fire only on the first return event, or **All** to fire only after all targeted vacuums have started returning.
   required: false
-  default: Each
 For at least:
   description: The time the vacuum must keep returning before the trigger fires.
   required: false


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Document the default behavior for vacuum triggers. The **Trigger when** option is now marked as optional in the UI documentation, and the YAML `behavior` option is marked as optional with its default value where present, because options with default values [should be marked as optional](https://developers.home-assistant.io/docs/documenting/create-page#about-configuration-variables).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 
- Related issue: https://github.com/home-assistant/home-assistant.io/issues/46958

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
