### PR TITLE
Add idle state to lawn mower

### DIFF
--- a/source/_actions/lawn_mower.dock.markdown
+++ b/source/_actions/lawn_mower.dock.markdown
@@ -6,6 +6,7 @@ description: "Returns a lawn mower to its dock."
 related_actions:
   - lawn_mower.start_mowing
   - lawn_mower.pause
+  - lawn_mower.stop
 ---
 
 Use this action to send a robotic lawn mower back to its dock, for example to end a run early when it starts to rain.

--- a/source/_actions/lawn_mower.pause.markdown
+++ b/source/_actions/lawn_mower.pause.markdown
@@ -6,6 +6,7 @@ description: "Pauses a lawn mower's current task."
 related_actions:
   - lawn_mower.start_mowing
   - lawn_mower.dock
+  - lawn_mower.stop
 ---
 
 Use this action to pause a robotic lawn mower's current task, for example to stop it briefly while you cross the lawn and resume it afterwards.

--- a/source/_actions/lawn_mower.start_mowing.markdown
+++ b/source/_actions/lawn_mower.start_mowing.markdown
@@ -6,6 +6,7 @@ description: "Starts or resumes a lawn mower's mowing task."
 related_actions:
   - lawn_mower.pause
   - lawn_mower.dock
+  - lawn_mower.stop
 ---
 
 Use this action to start or resume mowing on a robotic lawn mower, for example to begin a scheduled run or pick up where a paused task left off.

--- a/source/_actions/lawn_mower.stop.markdown
+++ b/source/_actions/lawn_mower.stop.markdown
@@ -1,0 +1,88 @@
+---
+title: "Stop lawn mower"
+action: lawn_mower.stop
+domain: lawn_mower
+description: "Stops a lawn mower's current task."
+related_actions:
+  - lawn_mower.pause
+  - lawn_mower.dock
+  - lawn_mower.start_mowing
+---
+
+Use this action to stop a robotic lawn mower and cancel its current task. The mower stays where it is and becomes idle: it does not return to the dock, and the next start begins a fresh run instead of resuming the old one.
+
+This differs from pausing, which keeps the task so it can be resumed, and from docking, which sends the mower home. Use it when you want the mower to stop right away, like when a child or a pet enters the lawn, or when you want to abandon a run and start over later.
+
+{% include actions/ui_header.md %}
+
+To stop a lawn mower from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the lawn mower you want to stop.
+6. From the actions shown for that target, select **Stop lawn mower**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `lawn_mower.stop`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: lawn_mower.stop
+  target:
+    entity_id: lawn_mower.backyard
+{% endexample %}
+
+This stops `lawn_mower.backyard` and cancels its current task.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with lawn mowers that support stopping.
+- After a stop, the mower reports the idle state. Use the [Lawn mower became idle](/triggers/lawn_mower.became_idle/) trigger to react to it, for example to bring the mower home after a while.
+- To send the mower back to its charging station instead, use the [Return lawn mower to dock](/actions/lawn_mower.dock/) action.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: stop the mower when motion is detected on the lawn
+
+Stop the mower as soon as someone or a pet is on the lawn, so it does not resume on its own once they leave.
+
+- **Trigger**: State: Lawn motion sensor turned on
+- **Action**: Stop lawn mower
+  - **Target**: Backyard mower
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Stop the mower when someone is on the lawn"
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.lawn_motion
+        to: "on"
+    actions:
+      - action: lawn_mower.stop
+        target:
+          entity_id: lawn_mower.backyard
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_conditions/lawn_mower.is_idle.markdown
+++ b/source/_conditions/lawn_mower.is_idle.markdown
@@ -1,0 +1,148 @@
+---
+title: "Lawn mower is idle"
+condition: lawn_mower.is_idle
+domain: lawn_mower
+description: "Tests if one or more lawn mowers are idle."
+---
+
+The **Lawn mower is idle** condition passes when one or more targeted mowers are stopped in the yard, neither docked nor paused.
+Use it when an automation should only continue while the mower has no task, like starting a fresh run, sending it back to the dock, or reminding you that it was left outside.
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Lawn mower is idle**.
+5. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the area where your mower is used. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All**.
+7. Under **For at least**, set how long the mower must stay idle before the condition passes. Leave it at zero to check the current state only.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Condition passes if:
+  description: When multiple lawn mowers are targeted, controls how results combine. Pick **Any** to pass if at least one targeted mower is idle, or **All** to pass only when every targeted mower is idle.
+For at least:
+  description: How long the mower must stay idle before the condition passes. Leave it at zero to check the current state only.
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `lawn_mower.is_idle`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: lawn_mower.is_idle
+  target:
+    entity_id: lawn_mower.backyard
+{% endexample %}
+
+This passes when `lawn_mower.backyard` is currently idle.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple lawn mowers are targeted, controls how results combine.
+    Accepts `all` or `any`.
+  required: false
+  type: string
+  default: any
+for:
+  description: >
+    How long the mower must stay idle before the condition passes. Accepts a
+    duration like `00:10:00` for 10 minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include conditions/targets.md %}
+
+{% include conditions/behavior.md %}
+
+## Good to know
+
+- Mowers in the `unavailable` or `unknown` state are ignored when Home Assistant evaluates the condition.
+- A paused mower does not pass this condition: it still has a task to resume. Use [Lawn mower is paused](/conditions/lawn_mower.is_paused/) for that case.
+- Not every mower reports an idle state. Check the states your integration supports.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: Start the evening run only if the mower is idle
+
+If the mower was stopped earlier and left in the yard, start a fresh run in the evening instead of leaving it there overnight.
+
+- **Trigger**: Time: 19:00
+- **Condition**: Lawn mower is idle
+  - **Target**: Backyard mower
+- **Action**: Start lawn mower
+  - **Target**: Backyard mower
+
+{% details "YAML example for starting an idle mower" %}
+
+{% example %}
+automation: |
+  alias: "Evening run if the mower is idle"
+  triggers:
+    - trigger: time
+      at: "19:00:00"
+  conditions:
+    - condition: lawn_mower.is_idle
+      target:
+        entity_id: lawn_mower.backyard
+  actions:
+    - action: lawn_mower.start_mowing
+      target:
+        entity_id: lawn_mower.backyard
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Remind yourself that the mower was left outside
+
+Check every hour and send a reminder while the mower stays idle in the yard.
+
+- **Trigger**: Time pattern: Every hour
+- **Condition**: Lawn mower is idle
+  - **Target**: Backyard mower
+  - **For at least**: 00:30:00
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for an idle-mower reminder" %}
+
+{% example %}
+automation: |
+  alias: "Remind me that the mower is outside"
+  triggers:
+    - trigger: time_pattern
+      hours: "/1"
+  conditions:
+    - condition: lawn_mower.is_idle
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        for: "00:30:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "The backyard mower is still standing in the yard."
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_integrations/lawn_mower.markdown
+++ b/source/_integrations/lawn_mower.markdown
@@ -12,7 +12,7 @@ ha_integration_type: entity
 ---
 
 The **Lawn mower** {% term integration %} lets you bring compatible robotic lawn mowers into Home Assistant.
-Use it to monitor whether your mower is mowing, paused, returning to dock, docked, or reporting an error, and build automations around those states.
+Use it to monitor whether your mower is mowing, paused, idle, returning to dock, docked, or reporting an error, and build automations around those states.
 
 {% include integrations/building_block_integration.md %}
 
@@ -23,6 +23,7 @@ A lawn mower entity can have the following states:
 - **Mowing**: The lawn mower is currently mowing.
 - **Docked**: The lawn mower is done mowing and is currently docked.
 - **Paused**: The lawn mower was active and is now paused.
+- **Idle**: The lawn mower is stopped, not docked, and does not have any errors.
 - **Returning**: The lawn mower is returning to the dock.
 - **Error**: The lawn mower encountered an error while active and needs assistance.
 - **Unavailable**: The entity is currently unavailable.

--- a/source/_integrations/lawn_mower.markdown
+++ b/source/_integrations/lawn_mower.markdown
@@ -23,7 +23,7 @@ A lawn mower entity can have the following states:
 - **Mowing**: The lawn mower is currently mowing.
 - **Docked**: The lawn mower is done mowing and is currently docked.
 - **Paused**: The lawn mower was active and is now paused.
-- **Idle**: The lawn mower is stopped, not docked, and does not have any errors.
+- **Idle**: The lawn mower is stopped, not docked, not paused, and does not have any errors.
 - **Returning**: The lawn mower is returning to the dock.
 - **Error**: The lawn mower encountered an error while active and needs assistance.
 - **Unavailable**: The entity is currently unavailable.

--- a/source/_triggers/lawn_mower.became_idle.markdown
+++ b/source/_triggers/lawn_mower.became_idle.markdown
@@ -1,0 +1,140 @@
+---
+title: "Lawn mower became idle"
+trigger: lawn_mower.became_idle
+domain: lawn_mower
+description: "Triggers when one or more lawn mowers become idle."
+---
+
+The **Lawn mower became idle** trigger fires when a mower stops and stays in the yard, neither docked nor paused.
+This is the state a mower enters after the stop action cancels its task, or when it is switched on away from the dock without a job. Use it when you want to react to a mower left standing, like sending a reminder or bringing it back to the dock after a while.
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Lawn mower became idle**.
+5. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the area where your mower is used. You can also select a floor, a device, a specific entity, or a label.
+6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
+7. Under **For at least**, set how long the mower must stay idle before the trigger fires. Leave it at zero to fire immediately.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Trigger when:
+  description: When multiple lawn mowers are targeted, controls when the trigger fires. Pick **Each** to fire every time any targeted mower becomes idle, **First** to fire only when the first targeted mower becomes idle, or **All** to fire only after every targeted mower is idle.
+For at least:
+  description: How long the mower must stay idle before the trigger fires. Leave it at zero to fire immediately.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `lawn_mower.became_idle`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: lawn_mower.became_idle
+  target:
+    entity_id: lawn_mower.backyard
+{% endexample %}
+
+This fires when `lawn_mower.backyard` changes to the idle state.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+behavior:
+  description: >
+    When multiple lawn mowers are targeted, controls when the trigger fires.
+    Accepts `each`, `first`, or `all`.
+  required: false
+  type: string
+  default: each
+for:
+  description: >
+    How long the mower must stay idle before the trigger fires. Accepts a
+    duration like `00:10:00` for 10 minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+{% include triggers/targets.md %}
+
+{% include triggers/behavior.md %}
+
+## Good to know
+
+- The trigger only fires when a mower changes into the idle state from a known state. If a mower comes back from `unavailable` or `unknown`, that recovery does not fire this trigger.
+- A paused mower is not idle: it still has a task to resume. Use the [Lawn mower paused mowing](/triggers/lawn_mower.paused_mowing/) trigger for interrupted runs.
+- Not every mower reports an idle state. Check the states your integration supports.
+
+{% include triggers/try_it.md %}
+
+{% include triggers/more_examples.md %}
+
+### Automation: Send the mower back to the dock when it has been idle for a while
+
+After a stop, the mower stays where it is. This automation brings it home if nobody has started a new run within 30 minutes.
+
+- **Trigger**: Lawn mower became idle
+  - **Target**: Backyard mower
+  - **For at least**: 00:30:00
+- **Action**: Return lawn mower to dock
+  - **Target**: Backyard mower
+
+{% details "YAML example for docking an idle mower" %}
+
+{% example %}
+automation: |
+  alias: "Dock the mower when it stays idle"
+  triggers:
+    - trigger: lawn_mower.became_idle
+      target:
+        entity_id: lawn_mower.backyard
+      options:
+        for: "00:30:00"
+  actions:
+    - action: lawn_mower.dock
+      target:
+        entity_id: lawn_mower.backyard
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Notify when the mower stops in the yard
+
+If the mower stops during a run, send a message so you can check whether something is in its way.
+
+- **Trigger**: Lawn mower became idle
+  - **Target**: Backyard mower
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+
+{% details "YAML example for an idle-mower notification" %}
+
+{% example %}
+automation: |
+  alias: "Notify when the mower stops"
+  triggers:
+    - trigger: lawn_mower.became_idle
+      target:
+        entity_id: lawn_mower.backyard
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "The backyard mower stopped and is waiting in the yard."
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents what home-assistant/core#181188 adds to the lawn mower entity: the **Idle** state on the integration page, the `lawn_mower.stop` action page, and the `lawn_mower.became_idle` trigger and `lawn_mower.is_idle` condition pages. The integration page lists them through the existing includes.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#181188
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

