### PR TITLE
Add stop action to MQTT lawn mower

### DIFF
--- a/source/_integrations/lawn_mower.mqtt.markdown
+++ b/source/_integrations/lawn_mower.mqtt.markdown
@@ -27,7 +27,7 @@ Alternatively, you can set it up via [MQTT discovery](/integrations/mqtt/#mqtt-d
 
 {% configuration %}
 activity_state_topic:
-  description: The MQTT topic subscribed to receive an update of the activity. Valid activities are `mowing`, `paused`, `idle`, `docked`, `returning`, and `error`. Use `value_template` to extract the activity state from a custom payload. When payload `none` is received, the activity state will be reset to `unknown`.  
+  description: The MQTT topic subscribed to receive an update of the activity. Valid activities are `mowing`, `paused`, `idle`, `docked`, `returning`, and `error`. Use `value_template` to extract the activity state from a custom payload. When the payload `none` is received, the activity state will be reset to `unknown`.
   required: false
   type: string
 activity_value_template:

--- a/source/_integrations/lawn_mower.mqtt.markdown
+++ b/source/_integrations/lawn_mower.mqtt.markdown
@@ -217,7 +217,7 @@ start_mowing_command_template:
   required: false
   type: template
 start_mowing_command_topic:
-  description: The MQTT topic that publishes commands when the `lawn_mower.start_mowing` action is performed. The value `start_mowing` is published when the action used. Use a `start_mowing_command_template` to publish a custom format.
+  description: The MQTT topic that publishes commands when the `lawn_mower.start_mowing` action is performed. The value `start_mowing` is published when the action is used. Use a `start_mowing_command_template` to publish a custom format.
   required: false
   type: string
 stop_command_template:

--- a/source/_integrations/lawn_mower.mqtt.markdown
+++ b/source/_integrations/lawn_mower.mqtt.markdown
@@ -27,7 +27,7 @@ Alternatively, you can set it up via [MQTT discovery](/integrations/mqtt/#mqtt-d
 
 {% configuration %}
 activity_state_topic:
-  description: The MQTT topic subscribed to receive an update of the activity. Valid activities are `mowing`, `paused`, `docked`, and `error`. Use `value_template` to extract the activity state from a custom payload. When payload `none` is received, the activity state will be reset to `unknown`.  
+  description: The MQTT topic subscribed to receive an update of the activity. Valid activities are `mowing`, `paused`, `idle`, `docked`, `returning`, and `error`. Use `value_template` to extract the activity state from a custom payload. When payload `none` is received, the activity state will be reset to `unknown`.  
   required: false
   type: string
 activity_value_template:
@@ -212,12 +212,20 @@ qos:
   required: false
   type: integer
   default: 0
-start_mowing_template:
+start_mowing_command_template:
   description: Defines a [template](/docs/templating/where-to-use/#mqtt) to generate the payload to send to `start_mowing_command_topic`. The `value` parameter in the template will be set to `start_mowing`.
   required: false
   type: template
 start_mowing_command_topic:
   description: The MQTT topic that publishes commands when the `lawn_mower.start_mowing` action is performed. The value `start_mowing` is published when the action used. Use a `start_mowing_command_template` to publish a custom format.
+  required: false
+  type: string
+stop_command_template:
+  description: Defines a [template](/docs/templating/where-to-use/#mqtt) to generate the payload to send to `stop_command_topic`. The `value` parameter in the template will be set to `stop`.
+  required: false
+  type: template
+stop_command_topic:
+  description: The MQTT topic that publishes commands when the `lawn_mower.stop` action is performed. The value `stop` is published when the action is used. Use a `stop_command_template` to publish a custom format.
   required: false
   type: string
 retain:
@@ -257,4 +265,6 @@ mqtt:
       dock_command_template: '{"activity": "{{ value }}"}' 
       start_mowing_command_topic: "lawn_mower_plus/set"
       start_mowing_command_template: '{"activity": "{{ value }}"}' 
+      stop_command_topic: "lawn_mower_plus/set"
+      stop_command_template: '{"activity": "{{ value }}"}' 
 ```

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -948,6 +948,8 @@ support_url:
     'stat_tpl':            'state_template',
     'stat_val_tpl':        'state_value_template',
     'step':                'step',
+    'stop_cmd_t':          'stop_command_topic',
+    'stop_cmd_tpl':        'stop_command_template',
     'stype':               'subtype',
     'sug_dsp_prc':         'suggested_display_precision',
     'sup_clrm':            'supported_color_modes',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the new `stop_command_topic` and `stop_command_template` options of the MQTT lawn mower, added in home-assistant/core#181192, and adds the `idle` activity to the list of valid activities.

Also fixes two existing mistakes on the page: the `start_mowing_template` option is actually named `start_mowing_command_template`, and the `returning` activity was missing from the list of valid activities.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#181192
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
