### PR TITLE
Document the Roomba signal strength sensor

### DIFF
--- a/source/_integrations/roomba.markdown
+++ b/source/_integrations/roomba.markdown
@@ -53,6 +53,7 @@ Sensors:
 - **Scrubs**: Total number of times the robot has executed a "scrub"
 - **Total cleaning time**: How many hours the robot has spent cleaning in total
 - **Total cleaned area**: The total area in m² the robot has cleaned
+- **Signal strength**: The Wi-Fi signal strength the robot reports, in dBm. Disabled by default
 
 ### Retrieving your credentials
 

--- a/source/_integrations/roomba.markdown
+++ b/source/_integrations/roomba.markdown
@@ -53,7 +53,7 @@ Sensors:
 - **Scrubs**: Total number of times the robot has executed a "scrub"
 - **Total cleaning time**: How many hours the robot has spent cleaning in total
 - **Total cleaned area**: The total area in m² the robot has cleaned
-- **Signal strength**: The Wi-Fi signal strength the robot reports, in dBm. Disabled by default
+- **Signal strength**: The Wi-Fi signal strength the robot reports, in dBm. Disabled by default.
 
 ### Retrieving your credentials
 


### PR DESCRIPTION
## Proposed change

Documents the Wi-Fi signal strength sensor added to the Roomba integration in home-assistant/core#181215.

The Roomba reports its Wi-Fi signal in the `signal` object of its state and the integration did not surface it. This page has an explicit list of the entities the integration creates, so the new one belongs in it.

One line, matching the existing style of the list.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch)
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch)
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch)
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch)
- [ ] Removed stale or deprecated documentation

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#181215
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] I have followed the [documentation standards](https://developers.home-assistant.io/docs/documenting/standards)
- [x] I have verified that the documentation renders correctly
