### PR TITLE
Document Imou Go to collection point select

### DIFF
--- a/source/_integrations/imou.markdown
+++ b/source/_integrations/imou.markdown
@@ -109,9 +109,9 @@ When the cloud API reports that the toggle is supported for a device, the integr
 
 ### Selects
 
-When the cloud API reports that the option is supported for a device, the integration exposes select entities.
+When the cloud API reports that the option is supported for a device, the integration exposes the following select entities:
 
-Device settings (configuration category):
+Device settings (**Configuration** category):
 
 - **Night vision mode**: Choose the night vision mode on supported cameras.
 - **Volume**: Choose mute, low, medium, or high volume on supported devices.

--- a/source/_integrations/imou.markdown
+++ b/source/_integrations/imou.markdown
@@ -109,10 +109,16 @@ When the cloud API reports that the toggle is supported for a device, the integr
 
 ### Selects
 
-When the cloud API reports that the option is supported for a device, the integration exposes the following select entities (device settings, configuration category):
+When the cloud API reports that the option is supported for a device, the integration exposes select entities.
+
+Device settings (configuration category):
 
 - **Night vision mode**: Choose the night vision mode on supported cameras.
 - **Volume**: Choose mute, low, medium, or high volume on supported devices.
+
+On supported PTZ cameras with saved presets:
+
+- **Go to collection point**: Choose a preset to move the camera to that position. After the move, the select returns to its prompt option so you can pick another preset.
 
 ### Binary sensors
 


### PR DESCRIPTION
## Summary

Documents the **Go to collection point** select entity added in home-assistant/core#181251.

- Split configuration selects (night vision mode, volume) from the PTZ preset action select.
- Explain that choosing a preset moves the camera and the select returns to its prompt option afterward.

## Related core PR

- https://github.com/home-assistant/core/pull/181251

## Test plan

- [x] Previewed the updated Selects section in `source/_integrations/imou.markdown`.