### PR TITLE
Document CoolMasterNet demand sensor and HVAC action

### DIFF
--- a/source/_integrations/coolmaster.markdown
+++ b/source/_integrations/coolmaster.markdown
@@ -20,3 +20,16 @@ ha_integration_type: hub
 The **CoolMasterNet** {% term integration %} lets you control HVAC through [CoolMasterNet](https://coolautomation.com/products/coolmasternet/).
 
 {% include integrations/config_flow.md %}
+
+## Supported functionality
+
+### Climate
+
+The current activity of each unit is shown as the climate entity's HVAC action. A unit that is calling for heating or cooling shows **heating**, **cooling**, or **drying** to match its mode, a unit in fan only mode shows **fan**, a unit that is on but has already reached its target temperature shows **idle**, and a unit that is switched off shows **off**.
+
+The action is unknown when the bridge uses a status format that does not report demand. It is also unknown for a unit in automatic mode whose current temperature matches its target temperature, because the bridge does not report which way such a unit is working.
+
+### Binary sensors
+
+- **Demand**
+  - **Description**: Indicates whether the unit is calling for heating or cooling. A unit that is on but has already reached its target temperature is off. This is unknown when the bridge uses a status format that does not report demand.


### PR DESCRIPTION
> **Status: on hold with home-assistant/core#181291.** Testing on my own bridge (Mitsubishi Electric M-NET line) shows the demand flag this documents is never set on that line type, so the parent PR stays a draft until CoolAutomation confirms where Demand State is supported.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Documents the two things home-assistant/core#181291 adds to the CoolMasterNet integration:

- The **Demand** binary sensor. The bridge reports a per-unit demand flag, which is true while an indoor unit is actually calling for heating or cooling rather than merely switched on. I run six units behind a CoolMasterNet and this is the only runtime signal the hardware offers, so it is worth spelling out that a unit which has reached its target temperature reads as off.
- The climate entity's HVAC action, which is derived from that same flag.

Both cases where the action is unknown are documented, because they will otherwise look like a fault: bridges that answer with the older status format do not report demand at all, and a unit in the bridge's automatic mode whose current temperature equals its target gives nothing to infer a direction from.

I have kept this to what that core PR delivers. The integration's other entities (clean filter, error code, reset filter) are already shipped and undocumented, and adding them here would be a change to existing documentation and so belongs on the `current` branch in its own PR. I am happy to open that separately if you would like it.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#181291
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

No front matter change is needed: `ha_platforms` already lists `binary_sensor`, because the integration already ships a binary sensor.

Disclosure: I used Claude Code as an editor while drafting this page. I have read and understood it, the content is mine, and I checked it against the behaviour of the code in the parent pull request. `textlint` and `remark` both pass on the edited page.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

