### PR TITLE
Google Assistant: local fulfillment requires Testing URLs

### DIFF
--- a/source/_integrations/google_assistant.markdown
+++ b/source/_integrations/google_assistant.markdown
@@ -138,19 +138,69 @@ For secure remote access, use a reverse proxy such as the {% my supervisor_addon
    1. Download `app.js` from [here](https://github.com/NabuCasa/home-assistant-google-assistant-local-sdk/releases/latest)
    2. Select **Upload your JavaScript targeting Node** and upload the `app.js` from step 4.1.
    3. Select **Upload your JavaScript targeting Chrome (browser)** and upload the same `app.js` from step 4.1.
-5. Check the box **Support local queries**.
-6. Add device scan configuration:
+5. Set the **Testing URLs** to a copy of the app that is served by Home Assistant.
+
+   {% important %}
+   The files uploaded in step 4 are currently not delivered to your devices. The console stores them in a bucket that enforces public access prevention, so the device cannot fetch the app and silently falls back to cloud fulfillment. This is tracked in [this Google issue](https://issuetracker.google.com/issues/512514638) and in [NabuCasa/home-assistant-google-assistant-local-sdk#39](https://github.com/NabuCasa/home-assistant-google-assistant-local-sdk/issues/39). Until it is resolved, the **Testing URLs** are what actually delivers the app to your devices.
+   {% endimportant %}
+
+   1. Create a `local-home` folder inside the `www` folder next to your {% term "`configuration.yaml`" %}, creating `www` first if it does not exist.
+   2. Copy the `app.js` from step 4.1 into `www/local-home/`.
+   3. Create a file `www/local-home/index.html` with the following content:
+
+      ```html
+      <html>
+        <head>
+          <script src="https://www.gstatic.com/eureka/smarthome/smarthome_sdk.js"></script>
+          <script src="./app.js"></script>
+        </head>
+      </html>
+      ```
+
+   4. If you had to create the `www` folder in step 5.1, restart Home Assistant now. The `/local/` path is only served if the `www` folder already exists when Home Assistant starts.
+   5. Confirm both files are reachable by opening `http://<HOME_ASSISTANT_IP>:8123/local/local-home/index.html` and `http://<HOME_ASSISTANT_IP>:8123/local/local-home/app.js` in a browser.
+   6. Set **Testing URL for Chrome** to `http://<HOME_ASSISTANT_IP>:8123/local/local-home/index.html`.
+   7. Set **Testing URL for Node** to `http://<HOME_ASSISTANT_IP>:8123/local/local-home/app.js`.
+
+   The two fields must point to different files. Devices with a Chrome runtime, such as Nest Hubs and other displays, navigate to the URL as a web page and need the HTML file that loads the Local Home SDK before the app. Devices with a Node runtime load the JavaScript directly.
+6. Check the box **Support local queries**.
+7. Add device scan configuration:
    1. Select **+ Add scan configuration** if no configuration exists.
    2. For Discovery protocol select **mDNS**.
    3. Set **Enter mDNS service name** to `_home-assistant._tcp.local`
    4. Select **Add field**, then under **Select a field**, choose **Name**.
    5. Enter a new **Value** field set to `.*\._home-assistant\._tcp\.local`
-7. Scroll to bottom of page and **Save** your changes.
-8. Either wait for 30 minutes, or restart all your Google Assistant devices.
-9. Restart Home Assistant Core.
-10. With a Google Assistant device, try saying "OK Google, sync my devices." This can be helpful to avoid issues, especially if you are enabling local fulfillment sometime after adding cloud Google Assistant support.
+8. Scroll to bottom of page and **Save** your changes.
+9. Either wait for 30 minutes, or restart all your Google Assistant devices.
+10. Restart Home Assistant Core.
+11. With a Google Assistant device, try saying "OK Google, sync my devices." This can be helpful to avoid issues, especially if you are enabling local fulfillment sometime after adding cloud Google Assistant support.
 
 You can debug the setup by following [these instructions](https://developers.home.google.com/local-home/test#debugging_from_chrome).
+
+#### Verifying local fulfillment
+
+Devices fall back to cloud fulfillment silently, so a working setup and a broken one behave the same from your point of view. To confirm which one you have, enable debug logging:
+
+```yaml
+logger:
+  logs:
+    homeassistant.components.google_assistant: debug
+```
+
+Note that this is `google_assistant`. The `google_assistant_sdk` integration is unrelated and logs nothing for local fulfillment.
+
+Restart Home Assistant, then give a voice command to one of your Google Assistant devices. A command served locally logs two lines:
+
+```txt
+Received local message <requestId> from <device IP> (JS <version>)
+Processing message: ...
+```
+
+A command that went through the cloud logs only `Processing message`. If `Received local message` never appears, local fulfillment is not being used.
+
+Test with a regular device such as a light. Commands for [secure devices](#secure-devices) always go through the cloud by design and never produce a `Received local message` line.
+
+The device IP in that line tells you which device answered. Local fulfillment is established per device, so check each speaker and display separately. A device that has not picked up the configuration yet usually starts working after a power cycle followed by "OK Google, sync my devices".
 
 ### YAML configuration
 


### PR DESCRIPTION
## Proposed change

The **Enable local fulfillment** steps tell you to upload `app.js` to the two **Upload your JavaScript** slots, and never mention the **Testing URLs** section. Followed exactly, the device never fetches the app, and every command falls back to cloud fulfillment with nothing logged on either side.

Per [NabuCasa/home-assistant-google-assistant-local-sdk#39](https://github.com/NabuCasa/home-assistant-google-assistant-local-sdk/issues/39) and Google bug [512514638](https://issuetracker.google.com/issues/512514638), the console stores uploads in a bucket with public access prevention enforced, so devices can't read them.

I ran into this and reproduced it: with both upload slots populated per the current steps and nothing else changed, packet capture showed zero HTTP requests from the device to Home Assistant across several reboots. Adding a Testing URL made the device fetch the app on its next boot.

Changes:

- Adds a step for **Testing URLs**, serving the app from the `www` folder at `/local/`.
- Documents that the Node and Chrome fields need different files. Chrome-runtime devices such as Nest Hubs navigate to the URL as a document, so they need an HTML file that loads the Local Home SDK before `app.js`. Point the Chrome field at raw `app.js` and the device renders the JavaScript as text, with no app and no error.
- Adds a **Verifying local fulfillment** section, using the `Received local message` debug line to tell local from cloud. This is the gap raised in [issue 33547](https://github.com/home-assistant/home-assistant.io/issues/33547).

Tested on 2026.8.3 with a manual (non-Cloud) setup, against a Nest Hub (Chrome runtime) and a Home Mini (Node runtime).

This asks readers to create two files, which the documentation didn't before. The app is location-independent, so a hosted receiver page works just as well, and Google's own codelab uses a public Firebase URL for it. I served it from `www` to avoid a third-party dependency for code that talks to the user's instance. If Nabu Casa hosted a receiver alongside the SDK releases, the Chrome URL could be a fixed public URL and those substeps would collapse to one line. I can rework it that way if you'd prefer.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

Related context, not closed by this PR:

- [NabuCasa/home-assistant-google-assistant-local-sdk#39](https://github.com/NabuCasa/home-assistant-google-assistant-local-sdk/issues/39) - uploads not reaching devices
- [Google issue 512514638](https://issuetracker.google.com/issues/512514638) - the underlying bucket permission bug
- [home-assistant.io issue 33547](https://github.com/home-assistant/home-assistant.io/issues/33547) - asked for a way to confirm local fulfillment is actually being used

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
