### PR TITLE
Teslemetry: document metadata gating of polling-only vehicle entities

### DIFF
--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -335,15 +335,17 @@ Teslemetry delivers data by streaming or polling, depending on the product. The 
 
 ### Vehicle data
 
-Most vehicles stream their data to Home Assistant in real time over Server-Sent Events (SSE), with no per-update cost. The integration sets up and manages this streaming configuration for you.
+Most vehicles stream their data to Home Assistant in real time. Streaming has no per-update cost, and the integration sets it up and manages it for you.
 
-Pre-2021 Model S and Model X vehicles cannot stream. For these vehicles, Teslemetry automatically refreshes their data on its own servers at no cost to you. A non-streaming vehicle is refreshed roughly every 15 minutes, and a vehicle that Tesla marks as discounted is refreshed much more often, roughly every 90 seconds. Both are free.
+Some entities can only get their data by polling. These show as **Polling** in the tables above. Home Assistant creates them only for vehicles where polling costs little or nothing.
 
-Credits are only spent on an on-demand fresh full-vehicle-data fetch, which costs 2 credits, or 0.1 credit for a discounted vehicle.
+A vehicle that streams and is not discounted gets no polling-only entities. Its data comes entirely from the live stream. Home Assistant never polls it, so fetching its data never spends credits. You still see its **Streaming** and **Both** entities.
 
-On a streaming vehicle, **Polling** entities read from Teslemetry's cached vehicle data instead of the live stream. Their values are not streamed and do not refresh on their own, which is why many of them are disabled by default. Enabling one is not a switch for Teslemetry's free automatic polling, and Home Assistant never bypasses the cache or forces a refresh on its own.
+A vehicle that does not stream gets polling-only entities. Teslemetry refreshes it on its own servers at no cost, roughly every 15 minutes, or roughly every 90 seconds if Tesla marks it as discounted. Home Assistant reads that data for free.
 
-If your vehicle is unpaired and streams through the safety screen, an enabled polling entity reads the cached vehicle data every 60 seconds while the vehicle is online. Most of those reads are free cache hits. Each time the cached data passes 20 minutes old, the next read becomes a charged fresh fetch at that cost, so it recurs for as long as the vehicle stays online. Streaming updates do not reset this 20-minute window.
+A vehicle that streams and is marked as discounted also gets polling-only entities. Each refresh for a discounted vehicle costs only 0.1 credit.
+
+When you update, a vehicle that streams and is not discounted no longer gets polling-only entities. If you had enabled one, Home Assistant removes it and it disappears. This is expected, and it stops that vehicle from being polled.
 
 The integration does not wake a sleeping vehicle to fetch data. Updates pause until the vehicle wakes up on its own or you interact with it.
 

--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -335,17 +335,9 @@ Teslemetry delivers data by streaming or polling, depending on the product. The 
 
 ### Vehicle data
 
-Most vehicles stream their data to Home Assistant in real time. Streaming has no per-update cost, and the integration sets it up and manages it for you.
+Most vehicles stream their data to Home Assistant in real time. Streaming has no per-update cost, and the integration sets it up and manages it for you. These vehicles do not get entities parked as **Polling** in the tables above, as that would incur and ongoing command credit cost.
 
-Some entities can only get their data by {% term polling %}. These show as **Polling** in the tables above. Home Assistant creates them only for vehicles where polling costs little or nothing.
-
-A vehicle that streams and is not discounted gets no polling-only entities. Its data comes entirely from the live stream. Home Assistant never polls it, so fetching its data never spends credits. You still see its **Streaming** and **Both** entities.
-
-A vehicle that does not stream gets polling-only entities. Teslemetry refreshes it on its own servers at no cost, roughly every 15 minutes, or roughly every 90 seconds if Tesla marks it as discounted. Home Assistant reads that data for free.
-
-A vehicle that streams and is marked as discounted also gets polling-only entities. Each refresh for a discounted vehicle costs only 0.1 credit.
-
-When you update, a vehicle that streams and is not discounted no longer gets polling-only entities. If you had enabled one, Home Assistant removes it and it disappears. This is expected, and it stops that vehicle from being polled.
+Legacy vehicles that do not supporting streaming gets all entities except those marked as **Streaming** in the tables above. Teslemetry handles the polling of this data in the cloud as part of your subscription, roughly every 15 minutes, or roughly every 90 seconds if the vehicle qualifies for a polling discount from Tesla.
 
 The integration does not wake a sleeping vehicle to fetch data. Updates pause until the vehicle wakes up on its own or you interact with it.
 

--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -335,9 +335,9 @@ Teslemetry delivers data by streaming or polling, depending on the product. The 
 
 ### Vehicle data
 
-Most vehicles stream their data to Home Assistant in real time. Streaming has no per-update cost, and the integration sets it up and manages it for you. These vehicles do not get entities parked as **Polling** in the tables above, as that would incur and ongoing command credit cost.
+Most vehicles stream their data to Home Assistant in real time. Streaming has no per-update cost, and the integration sets it up and manages it for you. These vehicles do not get entities parked as **Polling** in the tables above, as that would incur an ongoing command credit cost.
 
-Legacy vehicles that do not supporting streaming gets all entities except those marked as **Streaming** in the tables above. Teslemetry handles the polling of this data in the cloud as part of your subscription, roughly every 15 minutes, or roughly every 90 seconds if the vehicle qualifies for a polling discount from Tesla.
+Legacy vehicles (certain pre-2021 Model S & Model X vehicles) that do not supporting streaming gets all entities except those marked as **Streaming** in the tables above. Teslemetry handles the polling of this data in the cloud as part of your subscription, roughly every 15 minutes, or roughly every 90 seconds if the vehicle qualifies for a polling discount from Tesla.
 
 The integration does not wake a sleeping vehicle to fetch data. Updates pause until the vehicle wakes up on its own or you interact with it.
 

--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -337,7 +337,7 @@ Teslemetry delivers data by streaming or polling, depending on the product. The 
 
 Most vehicles stream their data to Home Assistant in real time. Streaming has no per-update cost, and the integration sets it up and manages it for you.
 
-Some entities can only get their data by polling. These show as **Polling** in the tables above. Home Assistant creates them only for vehicles where polling costs little or nothing.
+Some entities can only get their data by {% term polling %}. These show as **Polling** in the tables above. Home Assistant creates them only for vehicles where polling costs little or nothing.
 
 A vehicle that streams and is not discounted gets no polling-only entities. Its data comes entirely from the live stream. Home Assistant never polls it, so fetching its data never spends credits. You still see its **Streaming** and **Both** entities.
 

--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -337,7 +337,7 @@ Teslemetry delivers data by streaming or polling, depending on the product. The 
 
 Most vehicles stream their data to Home Assistant in real time. Streaming has no per-update cost, and the integration sets it up and manages it for you. These vehicles do not get entities parked as **Polling** in the tables above, as that would incur an ongoing command credit cost.
 
-Legacy vehicles (certain pre-2021 Model S & Model X vehicles) that do not supporting streaming gets all entities except those marked as **Streaming** in the tables above. Teslemetry handles the polling of this data in the cloud as part of your subscription, roughly every 15 minutes, or roughly every 90 seconds if the vehicle qualifies for a polling discount from Tesla.
+Legacy vehicles (certain pre-2021 Model S & Model X vehicles) that do not support streaming get all entities except those marked as **Streaming** in the tables above. Teslemetry handles the polling of this data in the cloud as part of your subscription, roughly every 15 minutes, or roughly every 90 seconds if the vehicle qualifies for a polling discount from Tesla.
 
 The integration does not wake a sleeping vehicle to fetch data. Updates pause until the vehicle wakes up on its own or you interact with it.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The vehicle data section no longer matched the integration, and it contradicted itself about whether Home Assistant polls a streaming vehicle.

This rewrites the section to match the metadata-based gating in the linked core PR. Home Assistant now creates polling-only vehicle entities only for a vehicle that does not stream, or that Tesla marks as discounted. A streaming, non-discounted vehicle gets none, so there is nothing to enable that starts charged polling. The section now explains, per kind of vehicle, what you will and will not see and what it costs, and notes that a polling-only entity a vehicle no longer qualifies for is removed on upgrade.

It targets `next` because it documents behaviour in an upcoming release, paired with the core PR below.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#181351
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
