### PR TITLE
Document the Fronius Modbus setpoint fallback

### DIFF
--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -175,6 +175,14 @@ Depending on the inverter's firmware, an `AC power limit` below `10 %` may force
 
 On a hybrid inverter, the `AC power limit` does not restrict **charging** the battery. Charging is not AC output. Surplus photovoltaic power goes into the battery instead of being wasted, which makes the limit useful for peak shaving. **Discharging** does count against it, because that power leaves the inverter on AC.
 
+#### Falling back to the inverter's own settings
+
+A setpoint stays on the inverter until it is changed, including while Home Assistant is shut down or unreachable. To have the inverter recover on its own instead, turn on **Revert the AC power limit if Home Assistant stops**: go to **Settings** > **Devices & services**, select the Fronius integration, and choose **Configure**.
+
+The inverter then drops the `AC power limit` an hour after it last received it, and hands control back to its own priority list. Home Assistant sends the limit again every 15 minutes, so the hour only ever runs out once Home Assistant has really stopped - a restart or a short outage has plenty of room. An inverter held at `30 %` runs unrestricted an hour after the Home Assistant host dies.
+
+This applies to the `AC power limit` only. Fronius documents no timeout for the battery setpoints, so those keep their value and switch state whatever happens to Home Assistant.
+
 #### The battery limits are power, not a charge level
 
 `Battery charge power limit` limits charging _power_. It is not a "charge to 80 %" setting. The inverter exposes no maximum state of charge over Modbus at all; only the minimum reserve.

--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -177,7 +177,7 @@ On a hybrid inverter, the `AC power limit` does not restrict **charging** the ba
 
 #### Falling back to the inverter's own settings
 
-A setpoint stays on the inverter until it is changed, including while Home Assistant is shut down or unreachable. To have the inverter recover on its own instead, turn on **Revert the AC power limit if Home Assistant stops**: go to **Settings** > **Devices & services**, select the Fronius integration, and choose **Configure**.
+A setpoint stays on the inverter until it is changed, including while Home Assistant is shut down or unreachable. Removing the integration leaves it behind as well, with nothing left to take it back. To have the inverter recover on its own instead, turn on **Revert the AC power limit if Home Assistant stops**: go to **Settings** > **Devices & services**, select the Fronius integration, and choose **Configure**.
 
 The inverter then drops the `AC power limit` an hour after it last received it, and hands control back to its own priority list. Home Assistant sends the limit again every 15 minutes, so the hour only ever runs out once Home Assistant has really stopped - a restart or a short outage has plenty of room. An inverter held at `30 %` runs unrestricted an hour after the Home Assistant host dies.
 

--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -66,6 +66,10 @@ Modbus port:
     description: "The port of the device's Modbus TCP interface. Only used when Modbus is enabled on the device, see [Modbus TCP](#modbus-tcp). The default is `502`."
     required: false
     type: integer
+Revert the AC power limit if Home Assistant stops:
+    description: "Whether the inverter should give up a power limit set by Home Assistant when it stops hearing it, see [Falling back to the inverter's own settings](#falling-back-to-the-inverters-own-settings). Off by default."
+    required: false
+    type: boolean
 {% endconfiguration_basic %}
 
 ## Monitored data
@@ -177,7 +181,7 @@ On a hybrid inverter, the `AC power limit` does not restrict **charging** the ba
 
 #### Falling back to the inverter's own settings
 
-A setpoint stays on the inverter until it is changed, including while Home Assistant is shut down or unreachable. Removing the integration leaves it behind as well, with nothing left to take it back. To have the inverter recover on its own instead, turn on **Revert the AC power limit if Home Assistant stops**: go to **Settings** > **Devices & services**, select the Fronius integration, and choose **Configure**.
+A setpoint stays on the inverter until it is changed, including while Home Assistant is shut down or unreachable. Removing the integration leaves it behind as well, with nothing left to take it back. To have the inverter recover on its own instead, turn on **Revert the AC power limit if Home Assistant stops**. It is offered when the integration is set up, and can be changed later: go to **Settings** > **Devices & services** > **Fronius**, select the three dots menu {% icon "mdi:dots-vertical" %} next to the entry, and choose **Reconfigure**.
 
 The inverter then drops the `AC power limit` an hour after it last received it, and hands control back to its own priority list. Home Assistant sends the limit again every 15 minutes, so the hour only ever runs out once Home Assistant has really stopped - a restart or a short outage has plenty of room. An inverter held at `30 %` runs unrestricted an hour after the Home Assistant host dies.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Documents the new Fronius option **Revert the AC power limit if Home Assistant stops**.

Setpoints written over Modbus stay on the inverter until they are changed - including while Home Assistant is shut down or unreachable. The option lets the inverter recover on its own: it drops the `AC power limit` an hour after it last received it, while Home Assistant sends the limit again every 15 minutes so the hour only runs out once Home Assistant has really stopped.

It also covers the case the option matters most for: removing the integration leaves the last limit in force with nothing left to take it back.

The new subsection also says what the option does *not* cover: Fronius documents no timeout for the battery setpoints, so those keep their value whatever happens to Home Assistant.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/181388
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
