### PR TITLE
Add Mitsubishi WF-RAC integration documentation

### DIFF
--- a/source/_integrations/mitsubishi_wf_rac.markdown
+++ b/source/_integrations/mitsubishi_wf_rac.markdown
@@ -48,7 +48,9 @@ Ignore duplicate IP address:
   description: "Off by default. Adds the airco even though another entry already uses that IP address, for re-adding a unit whose old entry went missing. The module accepts one connection at a time, so two entries polling it produce errors in the log."
 {% endconfiguration_basic %}
 
-Everything else is configured afterwards under **Configure**.
+## Configuration options
+
+Everything else is configured after setup, with the **Configure** button on the integration entry.
 
 {% configuration_basic %}
 Retry limit:
@@ -77,92 +79,107 @@ The integration creates one device per air conditioner with a climate entity tha
 
 The current temperature shown is the unit's own return-air reading, corrected by the indoor sensor offset.
 
+## Mitsubishi WF-RAC automation examples
+
+The unit measures at its own return air grille and knows nothing about the room it sits in. Most of what is worth automating here comes from pairing it with something that does.
+
+{% include docs/paste_yaml_tip.md %}
+
+### Automation: Pre-cool the bedroom before bedtime, but only in summer
+
+A separate room sensor is the better trigger, so the unit only starts when the room itself is warm rather than by the clock alone.
+
+- **Trigger**: Time: 21:30
+- **Condition**: Numeric state: bedroom temperature above 23 °C
+- **Action**: Climate: Set target temperature to 22 °C in cool mode
+
+{% details "YAML example for pre-cooling the bedroom" %}
+
+{% example %}
+automation: |
+  alias: "Pre-cool the bedroom"
+  triggers:
+    - trigger: time
+      at: "21:30:00"
+  conditions:
+    - condition: numeric_state
+      entity_id: sensor.bedroom_temperature
+      above: 23
+  actions:
+    - action: climate.set_temperature
+      target:
+        entity_id: climate.bedroom
+      data:
+        temperature: 22
+        hvac_mode: cool
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Turn the unit off when a window is opened
+
+The unit keeps running against an open window on its own. Give it a couple of minutes so a quick airing does not switch it off.
+
+- **Trigger**: State: bedroom window open for 2 minutes
+- **Action**: Climate: Turn off
+
+{% details "YAML example for switching off with the window open" %}
+
+{% example %}
+automation: |
+  alias: "Stop cooling with the window open"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.bedroom_window
+      to: "on"
+      for: "00:02:00"
+  actions:
+    - action: climate.turn_off
+      target:
+        entity_id: climate.bedroom
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Fall back to Home Leave instead of switching off
+
+On units that report it, Home Leave keeps the room within a wide band rather than letting it drift. It is offered as the `away` preset and needs the unit to be cooling or heating already, so the direction it should hold is unambiguous.
+
+- **Trigger**: State: person away from home for 30 minutes
+- **Condition**: The living room unit is not off
+- **Action**: Climate: Set preset mode to `away`
+
+{% details "YAML example for falling back to Home Leave" %}
+
+{% example %}
+automation: |
+  alias: "Home Leave while nobody is in"
+  triggers:
+    - trigger: state
+      entity_id: person.alex
+      to: "not_home"
+      for: "00:30:00"
+  conditions:
+    - condition: not
+      conditions:
+        - condition: state
+          entity_id: climate.living_room
+          state: "off"
+  actions:
+    - action: climate.set_preset_mode
+      target:
+        entity_id: climate.living_room
+      data:
+        preset_mode: away
+{% endexample %}
+
+{% enddetails %}
+
 ## Data updates
 
 The integration polls each module every 60 seconds over the local network. A command you send is applied immediately rather than waiting for the next poll.
 
 Commands issued together are coalesced into a single frame, because the module accepts one connection at a time and expects about a second between requests. A scene that sets the mode, the temperature and the fan speed at once therefore reaches the unit as one write rather than three. Actions issued one after another, each waiting for its own result, are sent separately.
-
-## Examples
-
-### Pre-cool the bedroom before bedtime, but only in summer
-
-The unit measures at the return air grille, so a separate room sensor is the better trigger. This waits for the room itself to be warm rather than switching on by the clock alone.
-
-{% raw %}
-
-```yaml
-automation:
-  - alias: "Pre-cool the bedroom"
-    triggers:
-      - trigger: time
-        at: "21:30:00"
-    conditions:
-      - condition: numeric_state
-        entity_id: sensor.bedroom_temperature
-        above: 23
-    actions:
-      - action: climate.set_temperature
-        target:
-          entity_id: climate.bedroom
-        data:
-          temperature: 22
-          hvac_mode: cool
-```
-
-{% endraw %}
-
-### Turn the unit off when a window is opened
-
-The unit keeps running against an open window on its own. Give it a couple of minutes so a quick airing does not switch it off.
-
-{% raw %}
-
-```yaml
-automation:
-  - alias: "Stop cooling with the window open"
-    triggers:
-      - trigger: state
-        entity_id: binary_sensor.bedroom_window
-        to: "on"
-        for: "00:02:00"
-    actions:
-      - action: climate.turn_off
-        target:
-          entity_id: climate.bedroom
-```
-
-{% endraw %}
-
-### Fall back to Home Leave instead of switching off
-
-On units that report it, Home Leave keeps the room within a wide band rather than letting it drift. It is offered as the `away` preset and needs the unit to be cooling or heating already, so the direction it should hold is unambiguous.
-
-{% raw %}
-
-```yaml
-automation:
-  - alias: "Home Leave while nobody is in"
-    triggers:
-      - trigger: state
-        entity_id: person.alex
-        to: "not_home"
-        for: "00:30:00"
-    conditions:
-      - condition: not
-        conditions:
-          - condition: state
-            entity_id: climate.living_room
-            state: "off"
-    actions:
-      - action: climate.set_preset_mode
-        target:
-          entity_id: climate.living_room
-        data:
-          preset_mode: away
-```
-
-{% endraw %}
 
 ## Known limitations
 

--- a/source/_integrations/mitsubishi_wf_rac.markdown
+++ b/source/_integrations/mitsubishi_wf_rac.markdown
@@ -29,7 +29,8 @@ The module is the requirement, not the indoor unit: a unit that works with the S
 ## Prerequisites
 
 - The module has to be on your network already. Set it up once with the manufacturer's app, or through the module's own access point; this integration does not perform that first-time setup.
-- Give the module a fixed address in your router. A changed address is not followed automatically and has to be corrected with **Reconfigure**.
+- Give the module a fixed address in your router. A changed address is picked up when the module announces itself again, but only then; if it does not, correct it with **Reconfigure**.
+- The module presents a self-signed certificate, and the connection does not verify it by default. To verify it instead, save the module's certificate as `ac_cert.pem` in your Home Assistant configuration directory; the integration picks it up on the next reload. Fetch it with `openssl s_client -connect <module IP>:51443 -showcerts </dev/null 2>/dev/null | openssl x509 -outform PEM > ac_cert.pem`. This is optional, and it only makes a difference on a network where you do not trust the path to the module.
 - The module accepts a limited number of registered controllers. If its account table is full, Home Assistant cannot register and the integration raises a repair issue saying so; free a slot in the app, or factory-reset the module.
 
 {% include integrations/config_flow.md %}

--- a/source/_integrations/mitsubishi_wf_rac.markdown
+++ b/source/_integrations/mitsubishi_wf_rac.markdown
@@ -1,0 +1,110 @@
+---
+title: Mitsubishi WF-RAC
+description: Instructions on how to integrate Mitsubishi Heavy Industries air conditioners with a WF-RAC module into Home Assistant.
+ha_category:
+  - Climate
+ha_release: 2026.10
+ha_iot_class: Local Polling
+ha_config_flow: true
+ha_codeowners:
+  - '@blues-sechseck'
+ha_domain: mitsubishi_wf_rac
+ha_platforms:
+  - climate
+  - diagnostics
+ha_zeroconf: true
+ha_integration_type: device
+---
+
+The **Mitsubishi WF-RAC** {% term integration %} controls Mitsubishi Heavy Industries air conditioners fitted with the WF-RAC wireless LAN module (sold as part number WF-RAC, and marketed with the Smart M-Air app).
+
+It talks to the module over your local network, using the same HTTP API the app uses. No account with the manufacturer is needed and the integration makes no outbound internet connection.
+
+## Supported devices
+
+Any indoor unit whose WF-RAC module answers on the local network. Confirmed on `SRK`-series wall-mounted units on single-split and multi-split systems, on all three firmware branches the module ships with. `FDT` cassettes and other indoor unit types use the same module and the same protocol.
+
+The module is the requirement, not the indoor unit: a unit that works with the Smart M-Air app on the same network works here.
+
+## Prerequisites
+
+- The module has to be on your network already. Set it up once with the manufacturer's app, or through the module's own access point; this integration does not perform that first-time setup.
+- Give the module a fixed address in your router. A changed address is not followed automatically and has to be corrected with **Reconfigure**.
+- The module accepts a limited number of registered controllers. If its account table is full, Home Assistant cannot register and the integration raises a repair issue saying so; free a slot in the app, or factory-reset the module.
+
+{% include integrations/config_flow.md %}
+
+Units on the same network are discovered automatically and appear as discovered devices. Confirm one and give it a name.
+
+{% configuration_basic %}
+Name:
+  description: "The name the airco gets in Home Assistant. It names the device and prefixes the entities belonging to it."
+Host:
+  description: "The local IP address of the airco's wireless module."
+Port:
+  description: "The port the module's local API listens on. This is 51443 on every firmware branch seen so far; discovery fills it in."
+Ignore duplicate IP address:
+  description: "Off by default. Adds the airco even though another entry already uses that IP address, for re-adding a unit whose old entry went missing. The module accepts one connection at a time, so two entries polling it produce errors in the log."
+{% endconfiguration_basic %}
+
+Everything else is configured afterwards under **Configure**.
+
+{% configuration_basic %}
+Retry limit:
+  description: "Consecutive failed polls before the airco is marked unavailable. The minimum of three is about three minutes at the 60-second poll interval, which is enough to ride through the module's hourly Wi-Fi reassociation. Raise it on a weak link."
+Target Temp. Offset:
+  description: "Calibrates the setpoint sent to the unit. Positive lowers what is sent while the card keeps showing your setting. Most units round a half degree up to the next whole one, so 0.5 often acts as 1."
+Target Temp. Offset (Cooling):
+  description: "Overrides the general target offset for cool and dry mode. Leave empty to use the general offset there too."
+Target Temp. Offset (Heating):
+  description: "Overrides the general target offset for heat mode. Leave empty to use the general offset for heat too."
+Indoor Temp. Sensor Offset:
+  description: "Added to the unit's own indoor reading before it is shown. Display only; it does not change what the unit does."
+Outdoor Temp. Sensor Offset:
+  description: "The same, for the outdoor temperature the unit reports."
+{% endconfiguration_basic %}
+
+## Supported functionality
+
+The integration creates one device per air conditioner with a climate entity that offers:
+
+- **Modes**: off, cool, heat, dry, fan only, and auto where the unit supports it.
+- **Target temperature**, within the range the unit itself reports for the mode it is in.
+- **Fan speed**, including the unit's quiet step.
+- **Vertical and horizontal swing**, including the unit's 3D auto mode where fitted.
+- **Away preset**, which switches the unit into its own Home Leave mode.
+
+The current temperature shown is the unit's own return-air reading, corrected by the indoor sensor offset.
+
+## Data updates
+
+The integration polls each module every 60 seconds over the local network. A command you send is applied immediately rather than waiting for the next poll.
+
+Commands issued close together are coalesced into a single frame, because the module accepts one connection at a time and expects about a second between requests. Changing the mode and the temperature in the same breath therefore reaches the unit as one write, not two.
+
+## Known limitations
+
+- **The unit briefly goes unavailable about once an hour.** The module reassociates with your Wi-Fi on its own; the default retry limit of three polls is chosen to ride through it. This is the module's behavior, not a network fault.
+- **Only one controller writes at a time.** The module grants a 60-second exclusive write lease to whoever wrote last. A command sent while somebody else holds it, typically the manufacturer's app, is refused and retried once when the lease lapses.
+- **The current temperature is measured at the return air grille**, above the unit and inside its own airflow, so it reads differently from a thermostat placed in the room. The target and sensor offsets exist to calibrate that difference.
+- **A limited number of controllers can be registered** on a module at once. Home Assistant occupies one slot.
+
+## Troubleshooting
+
+### The airco is not discovered
+
+Discovery uses mDNS, which does not cross subnets or VLANs by default. Add the unit manually with its IP address if Home Assistant and the airco are on different networks, or if multicast traffic is filtered between them.
+
+### Setup fails with "too many devices registered"
+
+The module's account table is full. Remove a controller in the manufacturer's app, or factory-reset the module, then retry. Home Assistant raises a repair issue while this condition persists and clears it by itself once registration succeeds.
+
+### The unit stops responding after using the app
+
+The app takes the write lease for 60 seconds. Wait a minute and try again.
+
+## Removing the integration
+
+This integration follows standard integration removal. Removing the config entry also releases the controller slot Home Assistant occupies on the module.
+
+{% include integrations/remove_device_service.md %}

--- a/source/_integrations/mitsubishi_wf_rac.markdown
+++ b/source/_integrations/mitsubishi_wf_rac.markdown
@@ -11,7 +11,6 @@ ha_codeowners:
 ha_domain: mitsubishi_wf_rac
 ha_platforms:
   - climate
-  - diagnostics
 ha_zeroconf: true
 ha_integration_type: device
 ---
@@ -29,42 +28,21 @@ The module is the requirement, not the indoor unit: a unit that works with the S
 ## Prerequisites
 
 - The module has to be on your network already. Set it up once with the manufacturer's app, or through the module's own access point; this integration does not perform that first-time setup.
-- Give the module a fixed address in your router. A changed address is picked up when the module announces itself again, but only then; if it does not, correct it with **Reconfigure**.
+- Give the module a fixed address in your router. A changed address is picked up when the module announces itself again, but only then.
 - The module presents a self-signed certificate, and the connection does not verify it by default. To verify it instead, save the module's certificate as `ac_cert.pem` in your Home Assistant configuration directory; the integration picks it up on the next reload. Fetch it with `openssl s_client -connect <module IP>:51443 -showcerts </dev/null 2>/dev/null | openssl x509 -outform PEM > ac_cert.pem`. This is optional, and it only makes a difference on a network where you do not trust the path to the module.
 - The module accepts a limited number of registered controllers. If its account table is full, Home Assistant cannot register and the integration raises a repair issue saying so; free a slot in the app, or factory-reset the module.
 
 {% include integrations/config_flow.md %}
 
-Units on the same network are discovered automatically and appear as discovered devices. Confirm one and give it a name.
+Units on the same network are discovered automatically and appear as discovered devices. Confirm one to add it.
 
 {% configuration_basic %}
-Name:
-  description: "The name the airco gets in Home Assistant. It names the device and prefixes the entities belonging to it."
 Host:
   description: "The local IP address of the airco's wireless module."
 Port:
   description: "The port the module's local API listens on. This is 51443 on every firmware branch seen so far; discovery fills it in."
 Ignore duplicate IP address:
   description: "Off by default. Adds the airco even though another entry already uses that IP address, for re-adding a unit whose old entry went missing. The module accepts one connection at a time, so two entries polling it produce errors in the log."
-{% endconfiguration_basic %}
-
-## Configuration options
-
-Everything else is configured after setup, with the **Configure** button on the integration entry.
-
-{% configuration_basic %}
-Retry limit:
-  description: "Consecutive failed polls before the airco is marked unavailable. The minimum of three is about three minutes at the 60-second poll interval, which is enough to ride through the module's hourly Wi-Fi reassociation. Raise it on a weak link."
-Target Temp. Offset:
-  description: "Calibrates the setpoint sent to the unit. Positive lowers what is sent while the card keeps showing your setting. Most units round a half degree up to the next whole one, so 0.5 often acts as 1."
-Target Temp. Offset (Cooling):
-  description: "Overrides the general target offset for cool and dry mode. Leave empty to use the general offset there too."
-Target Temp. Offset (Heating):
-  description: "Overrides the general target offset for heat mode. Leave empty to use the general offset for heat too."
-Indoor Temp. Sensor Offset:
-  description: "Added to the unit's own indoor reading before it is shown. Display only; it does not change what the unit does."
-Outdoor Temp. Sensor Offset:
-  description: "The same, for the outdoor temperature the unit reports."
 {% endconfiguration_basic %}
 
 ## Supported functionality
@@ -77,7 +55,7 @@ The integration creates one device per air conditioner with a climate entity tha
 - **Vertical and horizontal swing**, including the unit's 3D auto mode where fitted.
 - **Away preset**, which switches the unit into its own Home Leave mode.
 
-The current temperature shown is the unit's own return-air reading, corrected by the indoor sensor offset.
+The current temperature shown is the unit's own return-air reading.
 
 ## Mitsubishi WF-RAC automation examples
 
@@ -92,6 +70,8 @@ A separate room sensor is the better trigger, so the unit only starts when the r
 - **Trigger**: Time: 21:30
 - **Condition**: Numeric state: bedroom temperature above 23 °C
 - **Action**: Climate: Set target temperature to 22 °C in cool mode
+
+{% my blueprint_import badge blueprint_url="https://www.home-assistant.io/blueprints/integrations/mitsubishi_wf_rac_precool_with_room_sensor.yaml" %}
 
 {% details "YAML example for pre-cooling the bedroom" %}
 
@@ -123,6 +103,8 @@ The unit keeps running against an open window on its own. Give it a couple of mi
 - **Trigger**: State: bedroom window open for 2 minutes
 - **Action**: Climate: Turn off
 
+{% my blueprint_import badge blueprint_url="https://www.home-assistant.io/blueprints/integrations/mitsubishi_wf_rac_off_with_open_window.yaml" %}
+
 {% details "YAML example for switching off with the window open" %}
 
 {% example %}
@@ -148,6 +130,8 @@ On units that report it, Home Leave keeps the room within a wide band rather tha
 - **Trigger**: State: person away from home for 30 minutes
 - **Condition**: The living room unit is not off
 - **Action**: Climate: Set preset mode to `away`
+
+{% my blueprint_import badge blueprint_url="https://www.home-assistant.io/blueprints/integrations/mitsubishi_wf_rac_home_leave_while_away.yaml" %}
 
 {% details "YAML example for falling back to Home Leave" %}
 
@@ -183,9 +167,9 @@ Commands issued together are coalesced into a single frame, because the module a
 
 ## Known limitations
 
-- **The unit briefly goes unavailable about once an hour.** The module reassociates with your Wi-Fi on its own; the default retry limit of three polls is chosen to ride through it. This is the module's behavior, not a network fault.
+- **The unit briefly goes unavailable about once an hour.** The module reassociates with your Wi-Fi on its own; the integration tolerates three failed polls in a row to ride through it. This is the module's behavior, not a network fault.
 - **Only one controller writes at a time.** The module grants a 60-second exclusive write lease to whoever wrote last. A command sent while somebody else holds it, typically the manufacturer's app, is refused and retried once when the lease lapses.
-- **The current temperature is measured at the return air grille**, above the unit and inside its own airflow, so it reads differently from a thermostat placed in the room. The target and sensor offsets exist to calibrate that difference.
+- **The current temperature is measured at the return air grille**, above the unit and inside its own airflow, so it reads differently from a thermostat placed in the room.
 - **A limited number of controllers can be registered** on a module at once. Home Assistant occupies one slot.
 
 ## Troubleshooting

--- a/source/_integrations/mitsubishi_wf_rac.markdown
+++ b/source/_integrations/mitsubishi_wf_rac.markdown
@@ -16,7 +16,7 @@ ha_integration_type: device
 ha_quality_scale: bronze
 ---
 
-The **Mitsubishi WF-RAC** {% term integration %} controls Mitsubishi Heavy Industries air conditioners fitted with the WF-RAC wireless LAN module (sold as part number WF-RAC, and marketed with the Smart M-Air app).
+The **Mitsubishi WF-RAC** {% term integration %} controls [Mitsubishi Heavy Industries air conditioners](https://www.mhi-mth.co.jp/en/products/residential-and-commercial-air-conditioners/rac-sr/) fitted with the WF-RAC wireless LAN module (sold as part number WF-RAC, and marketed with the Smart M-Air app).
 
 It talks to the module over your local network, using the same HTTP API the app uses. No account with the manufacturer is needed and the integration makes no outbound internet connection.
 

--- a/source/_integrations/mitsubishi_wf_rac.markdown
+++ b/source/_integrations/mitsubishi_wf_rac.markdown
@@ -80,7 +80,88 @@ The current temperature shown is the unit's own return-air reading, corrected by
 
 The integration polls each module every 60 seconds over the local network. A command you send is applied immediately rather than waiting for the next poll.
 
-Commands issued close together are coalesced into a single frame, because the module accepts one connection at a time and expects about a second between requests. Changing the mode and the temperature in the same breath therefore reaches the unit as one write, not two.
+Commands issued together are coalesced into a single frame, because the module accepts one connection at a time and expects about a second between requests. A scene that sets the mode, the temperature and the fan speed at once therefore reaches the unit as one write rather than three. Actions issued one after another, each waiting for its own result, are sent separately.
+
+## Examples
+
+### Pre-cool the bedroom before bedtime, but only in summer
+
+The unit measures at the return air grille, so a separate room sensor is the better trigger. This waits for the room itself to be warm rather than switching on by the clock alone.
+
+{% raw %}
+
+```yaml
+automation:
+  - alias: "Pre-cool the bedroom"
+    triggers:
+      - trigger: time
+        at: "21:30:00"
+    conditions:
+      - condition: numeric_state
+        entity_id: sensor.bedroom_temperature
+        above: 23
+    actions:
+      - action: climate.set_temperature
+        target:
+          entity_id: climate.bedroom
+        data:
+          temperature: 22
+          hvac_mode: cool
+```
+
+{% endraw %}
+
+### Turn the unit off when a window is opened
+
+The unit keeps running against an open window on its own. Give it a couple of minutes so a quick airing does not switch it off.
+
+{% raw %}
+
+```yaml
+automation:
+  - alias: "Stop cooling with the window open"
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.bedroom_window
+        to: "on"
+        for: "00:02:00"
+    actions:
+      - action: climate.turn_off
+        target:
+          entity_id: climate.bedroom
+```
+
+{% endraw %}
+
+### Fall back to Home Leave instead of switching off
+
+On units that report it, Home Leave keeps the room within a wide band rather than letting it drift. It is offered as the `away` preset and needs the unit to be cooling or heating already, so the direction it should hold is unambiguous.
+
+{% raw %}
+
+```yaml
+automation:
+  - alias: "Home Leave while nobody is in"
+    triggers:
+      - trigger: state
+        entity_id: person.alex
+        to: "not_home"
+        for: "00:30:00"
+    conditions:
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: climate.living_room
+            state: "off"
+    actions:
+      - action: climate.set_preset_mode
+        target:
+          entity_id: climate.living_room
+        data:
+          preset_mode: away
+```
+
+{% endraw %}
 
 ## Known limitations
 

--- a/source/_integrations/mitsubishi_wf_rac.markdown
+++ b/source/_integrations/mitsubishi_wf_rac.markdown
@@ -3,7 +3,7 @@ title: Mitsubishi WF-RAC
 description: Instructions on how to integrate Mitsubishi Heavy Industries air conditioners with a WF-RAC module into Home Assistant.
 ha_category:
   - Climate
-ha_release: 2026.10
+ha_release: '2026.10'
 ha_iot_class: Local Polling
 ha_config_flow: true
 ha_codeowners:
@@ -13,6 +13,7 @@ ha_platforms:
   - climate
 ha_zeroconf: true
 ha_integration_type: device
+ha_quality_scale: bronze
 ---
 
 The **Mitsubishi WF-RAC** {% term integration %} controls Mitsubishi Heavy Industries air conditioners fitted with the WF-RAC wireless LAN module (sold as part number WF-RAC, and marketed with the Smart M-Air app).
@@ -161,16 +162,16 @@ automation: |
 
 ## Data updates
 
-The integration polls each module every 60 seconds over the local network. A command you send is applied immediately rather than waiting for the next poll.
+The integration {% term polling polls %} each module every 60 seconds over the local network. A command you send is applied immediately rather than waiting for the next poll.
 
 Commands issued together are coalesced into a single frame, because the module accepts one connection at a time and expects about a second between requests. A scene that sets the mode, the temperature and the fan speed at once therefore reaches the unit as one write rather than three. Actions issued one after another, each waiting for its own result, are sent separately.
 
 ## Known limitations
 
-- **The unit briefly goes unavailable about once an hour.** The module reassociates with your Wi-Fi on its own; the integration tolerates three failed polls in a row to ride through it. This is the module's behavior, not a network fault.
-- **Only one controller writes at a time.** The module grants a 60-second exclusive write lease to whoever wrote last. A command sent while somebody else holds it, typically the manufacturer's app, is refused and retried once when the lease lapses.
-- **The current temperature is measured at the return air grille**, above the unit and inside its own airflow, so it reads differently from a thermostat placed in the room.
-- **A limited number of controllers can be registered** on a module at once. Home Assistant occupies one slot.
+- The unit briefly goes unavailable about once an hour. The module reassociates with your Wi-Fi on its own. The integration tolerates three failed polls in a row to ride through it. This is the module's behavior, not a network fault.
+- Only one controller writes at a time. The module grants a 60-second exclusive write lease to whoever wrote last. A command sent while somebody else holds it, typically the manufacturer's app, is refused and retried once when the lease lapses.
+- The current temperature is measured at the return air grille, above the unit and inside its own airflow, so it reads differently from a thermostat placed in the room.
+- A limited number of controllers can be registered on a module at once. Home Assistant occupies one slot.
 
 ## Troubleshooting
 

--- a/source/blueprints/integrations/mitsubishi_wf_rac_home_leave_while_away.yaml
+++ b/source/blueprints/integrations/mitsubishi_wf_rac_home_leave_while_away.yaml
@@ -1,0 +1,99 @@
+blueprint:
+  name: Put a Mitsubishi WF-RAC airco into Home Leave while nobody is in
+  description: >
+    Home Leave holds the room within a wide band instead of letting it drift,
+    so the unit does not have to pull it all the way back on your return. It is
+    offered as the `away` preset, and it needs the unit to be cooling or
+    heating already: that is what tells it which direction to hold. This leaves
+    a unit that is off, in dry, auto or fan-only alone.
+  domain: automation
+  author: blues-sechseck
+  homeassistant:
+    min_version: 2024.10.0
+
+  input:
+    airco:
+      name: Airco
+      description: >
+        The Mitsubishi WF-RAC unit to put into Home Leave. Only units that
+        report the capability offer the preset.
+      selector:
+        entity:
+          filter:
+            - integration: mitsubishi_wf_rac
+              domain: climate
+
+    presence:
+      name: Presence
+      description: A person, device tracker or group that says whether anybody is in.
+      selector:
+        entity:
+          filter:
+            - domain: person
+            - domain: device_tracker
+            - domain: group
+
+    away_delay:
+      name: Away for
+      description: How long everybody has to be gone before the unit falls back.
+      default:
+        minutes: 30
+      selector:
+        duration:
+
+    resume:
+      name: Leave Home Leave on return
+      description: >
+        Restores a normal setpoint the moment presence comes back. The unit
+        does not remember what was set before Home Leave, so it lands on a
+        plain 21 °C rather than on your previous setting.
+      default: true
+      selector:
+        boolean:
+
+variables:
+  resume: !input resume
+
+triggers:
+  - trigger: state
+    entity_id: !input presence
+    to: "not_home"
+    for: !input away_delay
+    id: away
+  - trigger: state
+    entity_id: !input presence
+    to: "home"
+    id: home
+
+actions:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: away
+          # Cooling or heating only: any other mode has no direction to hold,
+          # and the preset is refused there.
+          - condition: state
+            entity_id: !input airco
+            state:
+              - cool
+              - heat
+        sequence:
+          - action: climate.set_preset_mode
+            target:
+              entity_id: !input airco
+            data:
+              preset_mode: away
+      - conditions:
+          - condition: trigger
+            id: home
+          - "{{ resume }}"
+          - condition: state
+            entity_id: !input airco
+            attribute: preset_mode
+            state: away
+        sequence:
+          - action: climate.set_preset_mode
+            target:
+              entity_id: !input airco
+            data:
+              preset_mode: none

--- a/source/blueprints/integrations/mitsubishi_wf_rac_off_with_open_window.yaml
+++ b/source/blueprints/integrations/mitsubishi_wf_rac_off_with_open_window.yaml
@@ -1,0 +1,59 @@
+blueprint:
+  name: Switch a Mitsubishi WF-RAC airco off while a window is open
+  description: >
+    The unit keeps running against an open window on its own, because it only
+    measures the air at its own return grille. This switches it off once a
+    window has been open for a while.
+
+    It does not switch the unit back on afterwards. Nothing in the state tells
+    it whether the unit was running before the window opened, so it would just
+    as often start a unit that was deliberately off.
+  domain: automation
+  author: blues-sechseck
+  homeassistant:
+    min_version: 2024.10.0
+
+  input:
+    airco:
+      name: Airco
+      description: The Mitsubishi WF-RAC unit to switch off.
+      selector:
+        entity:
+          filter:
+            - integration: mitsubishi_wf_rac
+              domain: climate
+
+    window:
+      name: Window
+      description: >
+        The window sensor to watch. Pick several to cover a room with more
+        than one window.
+      selector:
+        entity:
+          multiple: true
+          filter:
+            - domain: binary_sensor
+              device_class: window
+            - domain: binary_sensor
+              device_class: opening
+
+    open_delay:
+      name: Open for
+      description: >
+        How long the window has to stay open before the unit is switched off,
+        so a quick airing does not interrupt it.
+      default:
+        minutes: 2
+      selector:
+        duration:
+
+triggers:
+  - trigger: state
+    entity_id: !input window
+    to: "on"
+    for: !input open_delay
+
+actions:
+  - action: climate.turn_off
+    target:
+      entity_id: !input airco

--- a/source/blueprints/integrations/mitsubishi_wf_rac_precool_with_room_sensor.yaml
+++ b/source/blueprints/integrations/mitsubishi_wf_rac_precool_with_room_sensor.yaml
@@ -1,0 +1,110 @@
+blueprint:
+  name: Pre-cool a room with a Mitsubishi WF-RAC airco, using your own sensor
+  description: >
+    The unit measures at its own return air grille and knows nothing about the
+    room it sits in, so starting it by the clock alone runs it on days that do
+    not need it. This starts it at a time you choose, but only when a sensor in
+    the room says it is actually too warm.
+
+    It works the same way for heating: pick heat as the mode and set the
+    threshold to the temperature the room should not fall below.
+  domain: automation
+  author: blues-sechseck
+  homeassistant:
+    min_version: 2024.10.0
+
+  input:
+    airco:
+      name: Airco
+      description: The Mitsubishi WF-RAC unit to start.
+      selector:
+        entity:
+          filter:
+            - integration: mitsubishi_wf_rac
+              domain: climate
+
+    room_sensor:
+      name: Room sensor
+      description: >
+        A temperature sensor in the room itself. This is what decides whether
+        the unit is needed, rather than the unit's own reading.
+      selector:
+        entity:
+          filter:
+            - domain: sensor
+              device_class: temperature
+
+    start_time:
+      name: Start time
+      description: When to check the room and start the unit if it is needed.
+      selector:
+        time:
+
+    mode:
+      name: Mode
+      description: >
+        Cool starts the unit when the room is above the threshold, heat when it
+        is below.
+      default: cool
+      selector:
+        select:
+          options:
+            - label: Cool
+              value: cool
+            - label: Heat
+              value: heat
+
+    threshold:
+      name: Threshold
+      description: >
+        The room temperature that decides whether the unit is needed at all,
+        in the temperature unit your Home Assistant is set to.
+      default: 23
+      selector:
+        number:
+          min: 5
+          max: 35
+          step: 0.5
+          mode: box
+
+    target_temperature:
+      name: Target temperature
+      description: >
+        The setpoint to send once the unit starts, in the temperature unit
+        your Home Assistant is set to. Each mode has its own range on the
+        unit, so a value at either extreme may be refused.
+      default: 22
+      selector:
+        number:
+          min: 16
+          max: 30
+          step: 0.5
+          mode: box
+
+variables:
+  mode: !input mode
+  room_sensor: !input room_sensor
+  threshold: !input threshold
+
+triggers:
+  - trigger: time
+    at: !input start_time
+
+conditions:
+  # Cooling wants the room above the threshold, heating below it. A sensor
+  # that cannot be read falls back to the threshold itself, which makes both
+  # tests false - the usual 0 would be below every sensible heating threshold
+  # and would start the unit on a dead battery.
+  - >-
+    {{
+      (mode == 'cool' and states(room_sensor) | float(threshold) > threshold)
+      or (mode == 'heat' and states(room_sensor) | float(threshold) < threshold)
+    }}
+
+actions:
+  - action: climate.set_temperature
+    target:
+      entity_id: !input airco
+    data:
+      temperature: !input target_temperature
+      hvac_mode: !input mode


### PR DESCRIPTION
## Proposed change

Documentation for the `mitsubishi_wf_rac` integration, submitted to core in https://github.com/home-assistant/core/pull/181403.

Covers what the integration talks to (Mitsubishi Heavy Industries indoor units fitted with the WF-RAC wireless LAN module), the certificate the module requires and how to obtain it, discovery and manual setup, the climate entity, and the removal procedure.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/181403
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/11109
- This PR fixes or closes issue: fixes #
