### PR TITLE
Clarify Southwest Gas Opower credentials for opower integration

### DIFF
--- a/source/_integrations/opower.markdown
+++ b/source/_integrations/opower.markdown
@@ -106,11 +106,15 @@ You will be asked to re-authenticate via MFA every 180 days.
 
 ### Southwest Gas
 
-Use your Opower (Energy Savings Portal) credentials when you set up the integration. These are different from your Southwest Gas MyAccount website credentials.
+Use your **Energy Savings Portal** (Opower) credentials when you set up the integration. These are different from your Southwest Gas **MyAccount** credentials.
 
-If you haven't created an Opower account yet, sign in to the Southwest Gas MyAccount portal and follow the **Energy Savings Portal** link ("Compare your monthly natural gas usage with similar homes and get personalized tips on how to save on your natural gas bill"). Have your Southwest Gas bill handy with your account number to sign up. Then use those Energy Savings Portal credentials in Home Assistant.
+If you do not have an Energy Savings Portal account yet:
 
-If you get an invalid credentials error but you can still sign in on the Southwest Gas website, you are likely using your MyAccount credentials instead of your Energy Savings Portal credentials.
+1. Sign in to the Southwest Gas MyAccount portal.
+2. Select **Energy Savings Portal**.
+3. Follow the prompts to create an account. You will need your bill account number.
+
+If you see an invalid credentials error, but you can still sign in to the Southwest Gas MyAccount portal, you are likely entering your MyAccount credentials instead of your Energy Savings Portal credentials.
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/opower.markdown
+++ b/source/_integrations/opower.markdown
@@ -104,6 +104,14 @@ You will be asked to re-authenticate via MFA periodically.
 The integration properly supports Multi-Factor Authentication (MFA) for PG&E via either email or phone.
 You will be asked to re-authenticate via MFA every 180 days.
 
+### Southwest Gas
+
+Use your Opower (Energy Savings Portal) credentials when you set up the integration. These are different from your Southwest Gas MyAccount website credentials.
+
+If you haven't created an Opower account yet, sign in to the Southwest Gas MyAccount portal and follow the **Energy Savings Portal** link ("Compare your monthly natural gas usage with similar homes and get personalized tips on how to save on your natural gas bill"). Have your Southwest Gas bill handy with your account number to sign up. Then use those Energy Savings Portal credentials in Home Assistant.
+
+If you get an invalid credentials error but you can still sign in on the Southwest Gas website, you are likely using your MyAccount credentials instead of your Energy Savings Portal credentials.
+
 {% include integrations/config_flow.md %}
 
 ## Sensors

--- a/source/_integrations/opower.markdown
+++ b/source/_integrations/opower.markdown
@@ -108,13 +108,9 @@ You will be asked to re-authenticate via MFA every 180 days.
 
 Use your **Energy Savings Portal** (Opower) credentials when you set up the integration. These are different from your Southwest Gas **MyAccount** credentials.
 
-If you do not have an Energy Savings Portal account yet:
+If you do not have an Energy Savings Portal account yet, create one at the [Southwest Gas Energy Savings Portal](https://swg.opower.com/). You will need your utility account number and full name exactly as they appear on your energy bill.
 
-1. Sign in to the Southwest Gas MyAccount portal.
-2. Select **Energy Savings Portal**.
-3. Follow the prompts to create an account. You will need your bill account number.
-
-If you see an invalid credentials error, but you can still sign in to the Southwest Gas MyAccount portal, you are likely entering your MyAccount credentials instead of your Energy Savings Portal credentials.
+If you see **Invalid authentication**, but you can still sign in to the Southwest Gas **MyAccount** portal, you are likely entering your **MyAccount** credentials instead of your **Energy Savings Portal** credentials.
 
 {% include integrations/config_flow.md %}
 


### PR DESCRIPTION
## Proposed change

Southwest Gas users report invalid credentials when they use their Southwest Gas MyAccount website credentials in the Opower integration (home-assistant/core#174372). The integration logs in via `swg.opower.com` (Energy Savings Portal), which uses separate credentials.

Adds a Southwest Gas section under Utility Authentication Requirements explaining:
- use Energy Savings Portal / Opower credentials, not MyAccount credentials,
- how to create them directly at the Southwest Gas Energy Savings Portal (https://swg.opower.com/), which has a separate login and a Create one link, using the utility account number and full name exactly as they appear on the energy bill.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/174372

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
