### PR TITLE
Correct the Lyngdorf network requirements

### DIFF
--- a/source/_integrations/lyngdorf.markdown
+++ b/source/_integrations/lyngdorf.markdown
@@ -53,7 +53,9 @@ The MP-60 is the only model that has been tested in the wild so far. Other model
 
 ## Prerequisites
 
-- Your Lyngdorf device must be connected to the same network as Home Assistant.
+- Home Assistant must be able to reach the device on TCP port 84, which carries the control protocol.
+- The device is identified by the serial number in its UPnP description. Home Assistant sends a unicast SSDP request to the device on UDP port 1900, then fetches the description over HTTP from the port the device advertises. The device assigns that port itself and it is not fixed, so a firewall rule cannot rely on a particular number. This applies when adding a device by IP address as well as when one is discovered.
+- Automatic discovery additionally needs the device on the same subnet as Home Assistant, because it relies on multicast SSDP. A device on another subnet can still be added by IP address.
 
 {% include integrations/config_flow.md %}
 
@@ -201,7 +203,7 @@ The Lyngdorf device does not show up as a discovered device in Home Assistant.
 
 To resolve this issue, try the following steps:
 
-1. Make sure your Lyngdorf device is powered on and connected to the same network as Home Assistant.
+1. Make sure your Lyngdorf device is powered on and on the same subnet as Home Assistant. Automatic discovery uses multicast SSDP, which does not cross subnets.
 2. Check that UPnP/SSDP is not blocked on your network.
 3. Add the device manually using its IP address.
 

--- a/source/_integrations/lyngdorf.markdown
+++ b/source/_integrations/lyngdorf.markdown
@@ -203,7 +203,7 @@ The Lyngdorf device does not show up as a discovered device in Home Assistant.
 
 To resolve this issue, try the following steps:
 
-1. Make sure your Lyngdorf device is powered on and on the same subnet as Home Assistant. Automatic discovery uses multicast SSDP, which does not cross subnets.
+1. Make sure your Lyngdorf device is powered on and connected to the same subnet as Home Assistant. Automatic discovery uses multicast SSDP, which does not cross subnets.
 2. Check that UPnP/SSDP is not blocked on your network.
 3. Add the device manually using its IP address.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

The same-network requirement is wrong. The serial lookup is a unicast SSDP
M-SEARCH sent to the device, not a multicast search, so a device on another
subnet works fine when added by IP address. The current wording tells those
users they are unsupported. Verified against the library version this release
pins, `lyngdorf==1.4.9`, where `async_get_device_serial` sends the M-SEARCH
directly to the host.

Only automatic discovery needs the same subnet, and the troubleshooting step
now says so rather than repeating the same-network claim.

The wording is taken from #47746, which corrected the same paragraphs on `next`,
so the two branches converge.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
