### PR TITLE
Document the Silla Prism charging mode select

### DIFF
--- a/source/_integrations/silla_prism.markdown
+++ b/source/_integrations/silla_prism.markdown
@@ -60,7 +60,12 @@ The integration creates a single device with the following entities.
 
 ### Selects
 
-- **Charging mode**: The operating mode of the port. **Solar** charges only with the surplus available, **Normal** charges at the set current, and **Paused** suspends charging without disconnecting the vehicle. The Prism also pauses charging on its own when load balancing runs out of available power; that condition cannot be selected back, so the charging mode reads as unknown while it lasts and the status sensor reports the port as paused.
+- **Charging mode**: The operating mode of the port:
+  - **Solar**: Charges only with the surplus power available.
+  - **Normal**: Charges at the maximum current set on the wallbox itself.
+  - **Paused**: Suspends charging without disconnecting the vehicle.
+
+The Prism can also pause charging on its own when load balancing runs out of available power. That mode cannot be set from Home Assistant, so the charging mode is `unknown` for as long as it lasts. The status sensor still reports the port as paused.
 
 ## Data updates
 

--- a/source/_integrations/silla_prism.markdown
+++ b/source/_integrations/silla_prism.markdown
@@ -3,8 +3,10 @@ title: Silla Prism
 description: Instructions on how to integrate your Silla Prism EV wallbox with Home Assistant.
 ha_category:
   - Car
+  - Select
   - Sensor
 ha_platforms:
+  - select
   - sensor
 ha_iot_class: Local Push
 ha_codeowners:
@@ -56,13 +58,17 @@ The integration creates a single device with the following entities.
 - **Temperature**: Internal temperature of the Prism.
 - **Grid power**: Power drawn from the grid. Positive values are imports, negative values are exports.
 
+### Selects
+
+- **Charging mode**: The operating mode of the port. **Solar** charges only with the surplus available, **Normal** charges at the set current, and **Paused** suspends charging without disconnecting the vehicle. The Prism also pauses charging on its own when load balancing runs out of available power; that condition cannot be selected back, so the charging mode reads as unknown while it lasts and the status sensor reports the port as paused.
+
 ## Data updates
 
 The Prism pushes an MQTT message whenever a value changes, so entities update in real time. Status topics are retained on the broker, so Home Assistant restores the current values immediately after a restart. The session time is the exception: the Prism publishes it without the retain flag, about once a minute, so the session start sensor stays unknown for up to a couple of minutes after a restart.
 
 ## Known limitations
 
-- The integration currently provides read-only sensors. Setting the charging current and changing the charging mode are not available yet.
+- Setting the charging current is not available yet.
 - Only the first charging port is supported. On a Prism DUO, the second cable is not exposed.
 - The current limit used for custom load balancing, the night schedule, and charge authorization are not exposed yet.
 - Solar and home power flows are only meaningful when a Powerwall or compatible meter is configured on the Prism; otherwise they report `0`.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the charging mode select added to the Silla Prism integration, the
first of the follow-ups left out of the initial PR when it was reduced to a
single platform.

Adds the `select` platform and category, a **Selects** section describing the
three selectable modes, and the note that the Prism's own load-balancing pause
cannot be selected back, so the entity reads as unknown while it lasts. The
known limitation about the integration being read-only is narrowed to the
charging current, which is still not exposed.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#181424
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

