### PR TITLE
Correct the Lyngdorf P-series streaming support

### DIFF
--- a/source/_integrations/lyngdorf.markdown
+++ b/source/_integrations/lyngdorf.markdown
@@ -43,9 +43,9 @@ Every model gets a main zone media player and the RoomPerfect position and voici
 | [TDAI-2170](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-2170/) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | [TDAI-2210](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-2210/) | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
 | [TDAI-3400](https://lyngdorf.steinwaylyngdorf.com/lyngdorf-tdai-3400/) | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
-| [P100](https://steinwaylyngdorf.com/steinway-sons-p100/) | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ |
-| [P200](https://steinwaylyngdorf.com/steinway-sons-p200/) | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ |
-| [P300](https://steinwaylyngdorf.com/steinway-sons-p300/) | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ |
+| [P100](https://steinwaylyngdorf.com/steinway-sons-p100/) | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
+| [P200](https://steinwaylyngdorf.com/steinway-sons-p200/) | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
+| [P300](https://steinwaylyngdorf.com/steinway-sons-p300/) | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
 
 The P100, P200, and P300 are made by Lyngdorf and marketed as [Steinway & Lyngdorf].
 
@@ -150,7 +150,7 @@ The **Lyngdorf** integration uses local push to receive real-time updates from t
 - Only the MP-60, TDAI-1120, and TDAI-3400 have been tested against real hardware. The other models are implemented from the protocol documentation and may not support all features.
 - Only local network control is supported.
 - Pausing a source that is controlled by another app, such as AirPlay, ends the session rather than pausing it. The device cannot resume it; only the controlling app can start it again. This is how those protocols work, and is not specific to Home Assistant.
-- Now playing information, playback position, and transport controls require a model with a streaming module. The TDAI-2170 and the P-series do not have one.
+- Now playing information, playback position, and transport controls require a model with a streaming module. The TDAI-2170 does not have one.
 - The trims and lip sync apply to the main zone only.
 - The remote keys drive the device's own menus only. There is no way to read what is on screen, so an automation cannot know where in a menu it is.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

The page says the P series has no streaming module. It does, so the P100, P200
and P300 get now playing information, playback position and transport controls,
and the TDAI-2170 is the only model without one.

The evidence is not equal across the three models, and the wording is chosen to
match that rather than flatten it:

- **P200: measured.** An owner probed it with a live Spotify Connect session.
  `!SRC(4)"Spotify"` answers `!STREAMTYPE(2)`, and the value tracks what the
  streaming module is playing rather than the selected source: it stayed at 2
  with an unrelated source selected and fell to 0 only when switching sources
  ended the session. The unit answers the StreamUnlimited HTTP API on port 8080
  for every path the library uses, reporting the same streaming firmware as the
  MP family.
- **P100 and P300: derived from the vendor manual.** Its table annotates every
  P100 restriction explicitly and leaves "Internal Player" unmarked, on the
  index that matches both the MP table and the P200's measured value. That is
  evidence, not a measurement. If an owner reports otherwise this should be
  narrowed rather than defended.
- **TDAI-2170: firmware-verified** as the only non-streaming model.

No documentation change is needed for how the feature works; the existing
paragraph under supported functionality already describes it and applies as
written.

The capability arrives with `lyngdorf` 2.2.0, merged in
home-assistant/core#181415, so this should not publish before that release does.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/181415
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
