### PR TITLE
Document Ring last recording timestamp

### DIFF
--- a/source/_integrations/ring.markdown
+++ b/source/_integrations/ring.markdown
@@ -93,15 +93,15 @@ Two camera entities are provided: `live_view` and `last_recording`.
 Downloading and playing Ring video from the `last_recording` camera will require a Ring Protect plan.
 {% endimportant %}
 
-The `last_recording` camera provides a `last_recording_at` state attribute showing when Ring created the current recording. Until Home Assistant retrieves recording history, its value is `null`. If the history contains a recording, the value is a UTC timestamp in ISO 8601 format. If no recording history is available, the value is `null`.
-
 ### Event
 
 The event entity captures events like doorbell rings, motion alerts, and intercom unlocking.
 
 ### Sensor
 
-Once you have enabled the [Ring integration](/integrations/ring), you can start using the sensor platform. Currently, it supports battery level and Wi-Fi signal.
+Once you have enabled the [Ring integration](/integrations/ring), you can start using the sensor platform. Currently, it supports battery level, Wi-Fi signal, and the last recording timestamp for subscribed video devices.
+
+The `last_recording` timestamp sensor is disabled by default. When enabled, it shows when Ring created the latest ready recording. Its state is `unknown` until Home Assistant retrieves recording history.
 
 The volume sensors are being replaced with the number entity, which allows setting the volume. You should migrate any automations using the volume sensors to the number entity by release 2025.4.0.
 

--- a/source/_integrations/ring.markdown
+++ b/source/_integrations/ring.markdown
@@ -93,7 +93,7 @@ Two camera entities are provided: `live_view` and `last_recording`.
 Downloading and playing Ring video from the `last_recording` camera will require a Ring Protect plan.
 {% endimportant %}
 
-The `last_recording` camera provides a `last_recording_at` state attribute containing the UTC date and time when Ring created the recording, serialized in ISO 8601 format. Its value is `null` until recording history has been retrieved and whenever no recording history is available.
+The `last_recording` camera provides a `last_recording_at` state attribute containing the UTC date and time when Ring created the recording, in ISO 8601 format. Its value is `null` until Home Assistant retrieves the recording history or when no recording history is available.
 
 ### Event
 

--- a/source/_integrations/ring.markdown
+++ b/source/_integrations/ring.markdown
@@ -93,7 +93,7 @@ Two camera entities are provided: `live_view` and `last_recording`.
 Downloading and playing Ring video from the `last_recording` camera will require a Ring Protect plan.
 {% endimportant %}
 
-The `last_recording` camera provides a `last_recording_at` state attribute containing the UTC date and time when Ring created the recording, in ISO 8601 format. Its value is `null` until Home Assistant retrieves the recording history or when no recording history is available.
+The `last_recording` camera provides a `last_recording_at` state attribute showing when Ring created the current recording. Until Home Assistant retrieves recording history, its value is `null`. If the history contains a recording, the value is a UTC timestamp in ISO 8601 format. If no recording history is available, the value is `null`.
 
 ### Event
 

--- a/source/_integrations/ring.markdown
+++ b/source/_integrations/ring.markdown
@@ -93,7 +93,7 @@ Two camera entities are provided: `live_view` and `last_recording`.
 Downloading and playing Ring video from the `last_recording` camera will require a Ring Protect plan.
 {% endimportant %}
 
-The `last_recording` camera provides a `last_recording_at` state attribute with the date and time when Ring created the recording. The attribute is empty until recording history has been retrieved and is cleared when no recording history is available.
+The `last_recording` camera provides a `last_recording_at` state attribute containing the UTC date and time when Ring created the recording, serialized in ISO 8601 format. Its value is `null` until recording history has been retrieved and whenever no recording history is available.
 
 ### Event
 

--- a/source/_integrations/ring.markdown
+++ b/source/_integrations/ring.markdown
@@ -93,6 +93,8 @@ Two camera entities are provided: `live_view` and `last_recording`.
 Downloading and playing Ring video from the `last_recording` camera will require a Ring Protect plan.
 {% endimportant %}
 
+The `last_recording` camera provides a `last_recording_at` state attribute with the date and time when Ring created the recording. The attribute is empty until recording history has been retrieved and is cleared when no recording history is available.
+
 ### Event
 
 The event entity captures events like doorbell rings, motion alerts, and intercom unlocking.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Document the new disabled-by-default Ring `last_recording` timestamp sensor. The sensor is available for subscribed video devices and reports when Ring created the latest ready recording.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/181480
- Link to parent pull request in the Brands repository: Not applicable
- This PR fixes or closes issue: Not applicable

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards