### PR TITLE
Clarify infrared fallback without device integration

### DIFF
--- a/source/_integrations/infrared.markdown
+++ b/source/_integrations/infrared.markdown
@@ -56,6 +56,7 @@ The **Infrared** {% term integration %} is a building block that other integrati
 3. Add the integration for your infrared-controlled device, such as [LG Infrared](/integrations/lg_infrared/).
    - To add the integration, follow the steps in the integration documentation.
    - During integration setup, when you are asked which infrared emitter to use, select the emitter from your infrared remote adapter.
+   - If no device-specific integration is available for your infrared-controlled device, check the documentation for your infrared remote adapter integration for other supported ways to control it. For example, the [Broadlink integration](/integrations/broadlink/#remote) provides a `remote` entity that can learn and send infrared commands using the `remote.learn_command` and `remote.send_command` actions.
 4. If you have infrared-controlled devices in different rooms, place multiple infrared remote adapters around your home.
    - During setup of the infrared-controlled device, select the remote adapter closest to that device.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Clarify what users can do when no device-specific Infrared integration is available. The setup instructions now point users to their infrared adapter integration for alternative supported control methods and use Broadlink's existing `remote.learn_command` and `remote.send_command` actions as a concrete example.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #47555

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
