### PR TITLE
Clarify trusted network bypass login behavior

### DIFF
--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -184,6 +184,10 @@ homeassistant:
 Assuming you only created the owner during the onboarding process and have not created any other users, this configuration lets you directly access the Home Assistant main page from your internal network (192.168.0.0/24) or from localhost (127.0.0.1). If you get a login abort error, you can use the Home Assistant authentication provider to log in when accessing your Home Assistant instance from outside your network.
 
 {% note %}
+When `allow_bypass_login: true` and only one user is available, Home Assistant automatically logs in that user from the trusted network. The login screen is not shown, so you cannot choose the Home Assistant authentication provider while those bypass conditions apply.
+{% endnote %}
+
+{% note %}
 The order of `auth_providers` is critical as authentication providers are evaluated top to bottom.
 To enable skip login as intended, the `trusted_networks` provider must be listed before the `homeassistant` provider. If `type: homeassistant` is configured first, Home Assistant will immediately present the login page and the skip login logic will never be reached, even if the client is on a trusted network.
 {% endnote %}
@@ -194,7 +198,7 @@ The command line authentication provider executes a configurable shell command t
 
 This provider can be used to integrate Home Assistant with arbitrary external authentication services, from plaintext databases over LDAP to RADIUS.
 
-Here is a configuration example:
+Here is a configuration example in {% term "`configuration.yaml`" %} for the Command Line authentication provider:
 
 ```yaml
 homeassistant:

--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -184,7 +184,7 @@ homeassistant:
 Assuming you only created the owner during the onboarding process and have not created any other users, this configuration lets you directly access the Home Assistant main page from your internal network (192.168.0.0/24) or from localhost (127.0.0.1). If you get a login abort error, you can use the Home Assistant authentication provider to log in when accessing your Home Assistant instance from outside your network.
 
 {% note %}
-When `allow_bypass_login: true` and only one user is available, Home Assistant automatically logs in that user from the trusted network. The login screen is not shown, so you cannot choose the Home Assistant authentication provider while those bypass conditions apply.
+If you enable `allow_bypass_login` and only one user is available, Home Assistant automatically logs in that user from the trusted network. The login screen is not shown, so you cannot choose the Home Assistant authentication provider while those bypass conditions apply.
 {% endnote %}
 
 {% note %}

--- a/source/_docs/authentication/providers.markdown
+++ b/source/_docs/authentication/providers.markdown
@@ -198,7 +198,7 @@ The command line authentication provider executes a configurable shell command t
 
 This provider can be used to integrate Home Assistant with arbitrary external authentication services, from plaintext databases over LDAP to RADIUS.
 
-Here is a configuration example in {% term "`configuration.yaml`" %} for the Command Line authentication provider:
+Here is a configuration example:
 
 ```yaml
 homeassistant:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Clarify that when `allow_bypass_login: true` applies to a trusted network with only one available user, Home Assistant skips the login screen and the Home Assistant authentication provider cannot be selected while those bypass conditions apply.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #46605

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
