### PR TITLE
Document variables for target-based triggers

### DIFF
--- a/source/_includes/triggers/targets.md
+++ b/source/_includes/triggers/targets.md
@@ -15,6 +15,7 @@ This trigger requires a target. The target is the object that Home Assistant wil
 
 You can also select different target types in one trigger. For example, you can add a specific entity and an area as targets in the same trigger to monitor both of them at once.
 
+{% if page.trigger %}
 ### Trigger variables
 
 When the trigger fires, the `trigger` variable identifies the entity that caused it to fire. This is useful when a target contains multiple entities, such as a device, area, floor, or label.
@@ -26,8 +27,9 @@ The following trigger-specific variables are available:
 | `trigger.entity_id` | Entity ID of the entity that caused the trigger to fire. |
 | `trigger.from_state` | Previous state object of that entity. |
 | `trigger.to_state` | New state object of that entity. |
-| `trigger.for` | Duration configured for the trigger, or `None` if no duration is configured. |
+| `trigger.for` | Timedelta object of how long the trigger criteria was met, if applicable. |
 
 For example, use `{{ trigger.to_state.name }}` in an action to include the name of the entity that caused the trigger in a notification.
 
 The `trigger` variable describes the entity that caused the trigger to fire; it does not contain all entities resolved from the configured target.
+{% endif %}

--- a/source/_includes/triggers/targets.md
+++ b/source/_includes/triggers/targets.md
@@ -14,3 +14,20 @@ This trigger requires a target. The target is the object that Home Assistant wil
 - **Label**: every {{ target_domain }} entity that shares a label.
 
 You can also select different target types in one trigger. For example, you can add a specific entity and an area as targets in the same trigger to monitor both of them at once.
+
+### Trigger variables
+
+When the trigger fires, the `trigger` variable identifies the entity that caused it to fire. This is useful when a target contains multiple entities, such as a device, area, floor, or label.
+
+The following trigger-specific variables are available:
+
+| Template variable | Data |
+| ---- | ---- |
+| `trigger.entity_id` | Entity ID of the entity that caused the trigger to fire. |
+| `trigger.from_state` | Previous state object of that entity. |
+| `trigger.to_state` | New state object of that entity. |
+| `trigger.for` | Duration configured for the trigger, or `None` if no duration is configured. |
+
+For example, use `{{ trigger.to_state.name }}` in an action to include the name of the entity that caused the trigger in a notification.
+
+The `trigger` variable describes the entity that caused the trigger to fire; it does not contain all entities resolved from the configured target.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Document the trigger-specific variables exposed by target-based entity triggers. This clarifies how to identify the individual entity that caused a trigger to fire when a device, area, floor, or label resolves to multiple entities, and makes clear that the `trigger` variable does not contain the complete resolved target.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #46987

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging the code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
