### PR TITLE
Triggers: fix name of battery crossed threshold trigger

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2256,7 +2256,7 @@ source/_triggers/assist_satellite.started_processing.markdown @home-assistant/co
 source/_triggers/assist_satellite.started_responding.markdown @home-assistant/core @synesthesiam @arturpragacz
 source/_triggers/battery.became_low.markdown @home-assistant/core
 source/_triggers/battery.level_changed.markdown @home-assistant/core
-source/_triggers/battery.level_crossed.markdown @home-assistant/core
+source/_triggers/battery.level_crossed_threshold.markdown @home-assistant/core
 source/_triggers/battery.no_longer_low.markdown @home-assistant/core
 source/_triggers/battery.started_charging.markdown @home-assistant/core
 source/_triggers/battery.stopped_charging.markdown @home-assistant/core

--- a/source/_conditions/battery.is_level.markdown
+++ b/source/_conditions/battery.is_level.markdown
@@ -155,7 +155,7 @@ behavior:
 - The target sensor must have the battery device class.
 - Entities that are unavailable (`unavailable`) or have an unknown state (`unknown`) are skipped for **Any** and fail for **All**.
 - Battery level is expressed as a percentage from 0 to 100.
-- This condition checks the entity's current battery reading. To react to changes in the reading, use the [Battery level changed](/triggers/battery.level_changed/) or [Battery level crossed threshold](/triggers/battery.level_crossed/) trigger instead.
+- This condition checks the entity's current battery reading. To react to changes in the reading, use the [Battery level changed](/triggers/battery.level_changed/) or [Battery level crossed threshold](/triggers/battery.level_crossed_threshold/) trigger instead.
 - When you use a sensor as a dynamic threshold, its value is read at the moment the condition runs. The threshold is not continuously tracked; it is re-evaluated each time the automation fires.
 - For an overview of the status of your battery {% term entities %}, open the [**Maintenance** dashboard](/dashboards/dashboards/#dashboards-only-shown-in-the-dashboard-list-by-default). This dashboard allows you to quickly see which batteries need replacing.
 

--- a/source/_includes/triggers/threshold_crossed_steps.md
+++ b/source/_includes/triggers/threshold_crossed_steps.md
@@ -2,7 +2,7 @@
 Reusable "To use ... in an automation" steps for entity triggers that use the
 threshold-mapping schema and fire when a reading crosses a threshold. Used by
 humidity.crossed_threshold; reusable by climate.target_humidity_crossed_threshold,
-light.brightness_crossed_threshold, battery.level_crossed, and similar.
+light.brightness_crossed_threshold, battery.level_crossed_threshold, and similar.
 
 Parameters:
   title           UI display name. For example: "Relative humidity crossed threshold".

--- a/source/_redirects
+++ b/source/_redirects
@@ -823,6 +823,7 @@ layout: null
 # Renamed entity triggers and conditions (consistent keys)
 /triggers/battery.low /triggers/battery.became_low/ 301
 /triggers/battery.not_low /triggers/battery.no_longer_low/ 301
+/triggers/battery.level_crossed /triggers/battery.level_crossed_threshold/ 301
 /triggers/lawn_mower.docked /triggers/lawn_mower.returned_to_dock/ 301
 /triggers/schedule.turned_off /triggers/schedule.block_ended/ 301
 /triggers/schedule.turned_on /triggers/schedule.block_started/ 301

--- a/source/_triggers/battery.became_low.markdown
+++ b/source/_triggers/battery.became_low.markdown
@@ -96,7 +96,7 @@ for:
 
 - Use a binary sensor entity with the battery device class.
 - Use a label to group battery-powered devices across different areas, and target that label to monitor them all from a single automation.
-- For battery percentage sensors, use [Battery level crossed threshold](/triggers/battery.level_crossed/) instead.
+- For battery percentage sensors, use [Battery level crossed threshold](/triggers/battery.level_crossed_threshold/) instead.
 - Combine this trigger with a notification action to get a push notification on your phone the moment any sensor runs low.
 
 {% include triggers/try_it.md %}

--- a/source/_triggers/battery.level_changed.markdown
+++ b/source/_triggers/battery.level_changed.markdown
@@ -4,7 +4,7 @@ trigger: battery.level_changed
 domain: battery
 description: "Triggers when the battery level of one or more batteries changes."
 related_triggers:
-  - battery.level_crossed
+  - battery.level_crossed_threshold
 ---
 
 The **Battery level changed** trigger fires after a battery level reading changes. Battery levels drain gradually as devices are used, recharge when plugged in, or spike briefly when sensors report a fresh reading. Use the threshold type to filter which changes matter to your automation.
@@ -124,7 +124,7 @@ threshold:
 - Use a sensor with the battery device class.
 - The threshold type controls both the direction and the landing zone of the change. Use **Above** or **Below** to filter by direction, **In range** to fire only when the new value is inside a range, and **Outside range** to fire only when it escapes a range.
 - Use **Any change** to fire on every reading update regardless of direction or where the new value lands.
-- To react only when a battery level first crosses a specific value, use [Battery level crossed threshold](/triggers/battery.level_crossed/) instead.
+- To react only when a battery level first crosses a specific value, use [Battery level crossed threshold](/triggers/battery.level_crossed_threshold/) instead.
 - Pair this trigger with the Battery level condition to verify the reading meets a threshold before continuing the automation.
 
 {% include triggers/try_it.md %}

--- a/source/_triggers/battery.level_crossed_threshold.markdown
+++ b/source/_triggers/battery.level_crossed_threshold.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Battery level crossed threshold"
-trigger: battery.level_crossed
+trigger: battery.level_crossed_threshold
 domain: battery
 description: "Triggers after one or more battery level readings cross a threshold."
 related_triggers:
@@ -60,11 +60,11 @@ For at least:
 
 {% include triggers/yaml_header.md %}
 
-In YAML, **Battery level crossed threshold** is referred to as `battery.level_crossed`. A basic example looks like this:
+In YAML, **Battery level crossed threshold** is referred to as `battery.level_crossed_threshold`. A basic example looks like this:
 
 {% example %}
 trigger: |
-  trigger: battery.level_crossed
+  trigger: battery.level_crossed_threshold
   target:
     entity_id: sensor.hallway_motion_sensor_battery
   options:
@@ -80,7 +80,7 @@ To fire when a device charges back into a safe range:
 
 {% example %}
 trigger: |
-  trigger: battery.level_crossed
+  trigger: battery.level_crossed_threshold
   target:
     entity_id:
       - sensor.hallway_motion_sensor_battery
@@ -101,7 +101,7 @@ To use a number helper as a dynamic threshold you can adjust without editing the
 
 {% example %}
 trigger: |
-  trigger: battery.level_crossed
+  trigger: battery.level_crossed_threshold
   target:
     label_id: critical_sensors
   options:
@@ -187,7 +187,7 @@ Smoke detector batteries failing silently is a safety risk. This automation send
 automation: |
   alias: "Alert when smoke detector battery is critical"
   triggers:
-    - trigger: battery.level_crossed
+    - trigger: battery.level_crossed_threshold
       target:
         label_id: smoke_detectors
       options:
@@ -223,7 +223,7 @@ The robot vacuum takes a while to charge. This automation sends a notification a
 automation: |
   alias: "Notify when robot vacuum is fully charged"
   triggers:
-    - trigger: battery.level_crossed
+    - trigger: battery.level_crossed_threshold
       target:
         entity_id: sensor.robot_vacuum_battery
       options:
@@ -258,7 +258,7 @@ Use a number helper so you can change the alert threshold from the UI without ed
 automation: |
   alias: "Garden camera low battery alert"
   triggers:
-    - trigger: battery.level_crossed
+    - trigger: battery.level_crossed_threshold
       target:
         entity_id: sensor.garden_camera_battery
       options:

--- a/source/_triggers/battery.no_longer_low.markdown
+++ b/source/_triggers/battery.no_longer_low.markdown
@@ -94,7 +94,7 @@ for:
 
 - Use a binary sensor entity with the battery device class.
 - What counts as "low" depends on the device and its integration. The battery binary sensor is controlled by the device or its integration, not by Home Assistant.
-- For battery percentage sensors, use [Battery level crossed threshold](/triggers/battery.level_crossed/) instead.
+- For battery percentage sensors, use [Battery level crossed threshold](/triggers/battery.level_crossed_threshold/) instead.
 - Use this trigger together with [Battery low](/triggers/battery.became_low/) to build a complete low-battery workflow: alert when a device goes low, and confirm or log when it is healthy again.
 
 {% include triggers/try_it.md %}

--- a/source/_triggers/battery.started_charging.markdown
+++ b/source/_triggers/battery.started_charging.markdown
@@ -6,7 +6,7 @@ description: "Triggers when one or more batteries start charging."
 related_triggers:
   - battery.stopped_charging
   - battery.level_changed
-  - battery.level_crossed
+  - battery.level_crossed_threshold
 ---
 
 The **Battery started charging** trigger fires when a battery-powered device transitions from not charging to actively charging. A device starts charging when it is connected to a power source, such as a charger, dock, or USB cable. Use this trigger to confirm when a device is plugged in, kick off automations that should run while a device charges, or log charging sessions over time.
@@ -85,7 +85,7 @@ for:
 - Use a binary sensor with the battery charging device class.
 - **Battery started charging** fires only when a device transitions from not charging to actively charging. If a device is already charging when Home Assistant starts, the trigger does not fire.
 - To react when a device stops charging, use [Battery stopped charging](/triggers/battery.stopped_charging/).
-- To fire when the battery level crosses a specific percentage, use [Battery level crossed threshold](/triggers/battery.level_crossed/) instead.
+- To fire when the battery level crosses a specific percentage, use [Battery level crossed threshold](/triggers/battery.level_crossed_threshold/) instead.
 
 {% include triggers/try_it.md %}
 

--- a/source/_triggers/battery.stopped_charging.markdown
+++ b/source/_triggers/battery.stopped_charging.markdown
@@ -6,7 +6,7 @@ description: "Triggers when one or more battery-powered devices stop charging."
 related_triggers:
   - battery.started_charging
   - battery.level_changed
-  - battery.level_crossed
+  - battery.level_crossed_threshold
 ---
 
 The **Battery stopped charging** trigger fires when a battery-powered device transitions from actively charging to not charging. A device stops charging when it is unplugged, removed from its dock, or when it reaches full charge and the charger cuts off. Use this trigger to detect when a device is unplugged unexpectedly, confirm when a charge cycle completes, or start automations that should run once a device is ready to use.
@@ -85,7 +85,7 @@ for:
 - Use a binary sensor with the battery charging device class.
 - **Battery stopped charging** fires both when a device is unplugged and when it finishes charging naturally. If you only want to react when the battery is full, combine this trigger with a condition that checks the battery level.
 - To react when a device starts charging, use [Battery started charging](/triggers/battery.started_charging/).
-- To fire when the battery level crosses a specific percentage, use [Battery level crossed threshold](/triggers/battery.level_crossed/) instead.
+- To fire when the battery level crosses a specific percentage, use [Battery level crossed threshold](/triggers/battery.level_crossed_threshold/) instead.
 
 {% include triggers/try_it.md %}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
- Update trigger name for Battery crossed threshold


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #47966

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
