### PR TITLE
Add the OHF iOS app to apple-app-site-association

### DIFF
--- a/source/.well-known/apple-app-site-association
+++ b/source/.well-known/apple-app-site-association
@@ -55,6 +55,24 @@
           "/ios/*",
           "/tag/*"
         ]
+      },
+      {
+        "appID": "GUYFAK8DC6.io.home-assistant.app.dev",
+        "paths": [
+          "NOT /ios/beta",
+          "NOT /ios/beta/*",
+          "/ios/*",
+          "/tag/*"
+        ]
+      },
+      {
+        "appID": "GUYFAK8DC6.io.home-assistant.app",
+        "paths": [
+          "NOT /ios/beta",
+          "NOT /ios/beta/*",
+          "/ios/*",
+          "/tag/*"
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Proposed change

The Home Assistant iOS app is moving to the Open Home Foundation Apple developer account with a new bundle ID. This adds the new app IDs (`GUYFAK8DC6.io.home-assistant.app` and its `.dev` build) to the apple-app-site-association file so universal links keep opening in the new app. The existing entries stay so the current app keeps working during the transition.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
