### PR TITLE
Document NeoPool automatic device time sync option

### DIFF
--- a/source/_integrations/neopool.markdown
+++ b/source/_integrations/neopool.markdown
@@ -39,6 +39,7 @@ The NeoPool integration brings your pool controller into Home Assistant, providi
 - **Surface pool-controller problems**: expose alarm states as sensor readings, and raise a repair issue if the controller's GPIO configuration register becomes corrupted.
 - **Control the pool light**: turn the pool light relay on and off when the relay timer is in a manual mode. Opt-in through the integration options.
 - **Control filtration and relays**: run the filtration pump manually, start and stop backwash, drive the auxiliary relays, and toggle the controller's configuration flags.
+- **Keep the controller clock accurate**: automatically correct the controller's clock when it drifts from Home Assistant time. Opt-in through the integration options.
 
 ## Supported devices
 
@@ -98,6 +99,8 @@ Enable auxiliary relays 1 to 4:
   description: Turn on for each auxiliary relay you have wired to a device. When enabled, an **Auxiliary relay** switch is added for that relay. Off by default because the controller cannot detect what, if anything, is wired to each auxiliary relay.
 Enable cover sensor:
   description: Turn on if a pool cover sensor is wired to the controller. When enabled, the **Enable cover reduction** switch is added so you can toggle the cover-driven hydrolysis reduction. Off by default because the controller cannot detect whether a cover sensor is present.
+Automatically sync device clock:
+  description: Turn on to let Home Assistant keep the controller's clock in sync. When enabled, each poll compares the controller clock against Home Assistant time and corrects it if it has drifted by more than a few minutes. Off by default. The controller keeps its own real-time clock, which several features depend on, such as timers, runtime counters, and scheduling, and it can drift or reset after a power loss.
 {% endconfiguration_basic %}
 
 ## Supported functionality

--- a/source/_integrations/neopool.markdown
+++ b/source/_integrations/neopool.markdown
@@ -39,7 +39,7 @@ The NeoPool integration brings your pool controller into Home Assistant, providi
 - **Surface pool-controller problems**: expose alarm states as sensor readings, and raise a repair issue if the controller's GPIO configuration register becomes corrupted.
 - **Control the pool light**: turn the pool light relay on and off when the relay timer is in a manual mode. Opt-in through the integration options.
 - **Control filtration and relays**: run the filtration pump manually, start and stop backwash, drive the auxiliary relays, and toggle the controller's configuration flags.
-- **Keep the controller clock accurate**: automatically correct the controller's clock when it drifts from Home Assistant time. Opt-in through the integration options.
+- **Keep the controller's clock accurate**: automatically correct the controller's clock when it drifts from Home Assistant time. Opt-in through the integration options.
 
 ## Supported devices
 
@@ -100,7 +100,7 @@ Enable auxiliary relays 1 to 4:
 Enable cover sensor:
   description: Turn on if a pool cover sensor is wired to the controller. When enabled, the **Enable cover reduction** switch is added so you can toggle the cover-driven hydrolysis reduction. Off by default because the controller cannot detect whether a cover sensor is present.
 Automatically sync device clock:
-  description: Turn on to let Home Assistant keep the controller's clock in sync. When enabled, each poll compares the controller clock against Home Assistant time and corrects it if it has drifted by more than a few minutes. Off by default. The controller keeps its own real-time clock, which several features depend on, such as timers, runtime counters, and scheduling, and it can drift or reset after a power loss.
+  description: Turn on to let Home Assistant keep the controller's clock in sync. When enabled, each poll compares the controller's clock against Home Assistant time and corrects it if it has drifted by more than a few minutes. Off by default. The controller keeps its own real-time clock, which several features depend on, such as timers, runtime counters, and scheduling, and it can drift or reset after a power loss.
 {% endconfiguration_basic %}
 
 ## Supported functionality


### PR DESCRIPTION
## Proposed change

Document the new **Automatically sync device clock** option in the NeoPool integration.

The controller keeps its own real-time clock, which several features depend on (timers, runtime counters, scheduling), and it can drift or reset after a power loss. The new opt-in option lets Home Assistant correct the controller clock on each poll when it drifts too far from Home Assistant time.

This adds:

- A **Keep the controller clock accurate** bullet to the Use cases section, matching the existing opt-in entries.
- An **Automatically sync device clock** entry in the Configuration options block, describing what it does and that it is off by default.

Parent code PR: home-assistant/core#181543

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#181543
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
