### PR TITLE
Document Ukraine Alarm air alert levels

### DIFF
--- a/source/_integrations/ukraine_alarm.markdown
+++ b/source/_integrations/ukraine_alarm.markdown
@@ -14,7 +14,7 @@ ha_platforms:
 ha_integration_type: service
 ---
 
-The **Ukraine Alarm** {% term integration %} uses the siren.pp.ua API - public wrapper for [Ukraine Alarm](https://www.ukrainealarm.com/) web service to offer air-raid siren notifications. The {% term integration %} will create 8 binary sensors for your selected region in Ukraine:
+The **Ukraine Alarm** {% term integration %} uses the siren.pp.ua API, a public wrapper for the [Ukraine Alarm](https://www.ukrainealarm.com/) web service, to provide air-raid siren notifications. The {% term integration %} creates 8 binary sensors for your selected region in Ukraine:
 
 - Air
 - Air (red)

--- a/source/_integrations/ukraine_alarm.markdown
+++ b/source/_integrations/ukraine_alarm.markdown
@@ -35,15 +35,6 @@ The service reports a danger level for air alerts, where red is the more severe 
 
 The service can report both levels for a region at the same time, in which case both sensors are on. The service attaches levels to every alert type, but they are only meaningful for air alerts, so the other sensors are not affected by them.
 
-**Air (red)** and **Air (yellow)** carry two extra state attributes:
-
-| Attribute | Description |
-| --------- | ----------- |
-| `reasons` | The reasons reported for the level, for example `Ракетна загроза (червоний рівень)`. A level can have more than one reason, and older alerts are reported without one, so this can be an empty list while the sensor is on. |
-| `created_at` | When the level was raised. This is the start of the level itself, not of the air alert. |
-
-A region can have several air alerts active at the same time, so both attributes are collected across all of them. When a level is reported more than once, `created_at` is the oldest of the reported times.
-
 Siren check interval is set to 10 seconds to avoid overloading the API and still be able to react fast enough.
 
 {% include integrations/config_flow.md %}

--- a/source/_integrations/ukraine_alarm.markdown
+++ b/source/_integrations/ukraine_alarm.markdown
@@ -33,7 +33,16 @@ The service reports a danger level for air alerts, where red is the more severe 
 - **Air (red)** is on while an air alert with the red level is active.
 - **Air (yellow)** is on while an air alert with the yellow level is active.
 
-The service can report both levels for a region at the same time, in which case both sensors are on. Levels are reported for air alerts only, so the other sensors are not affected by them.
+The service can report both levels for a region at the same time, in which case both sensors are on. The service attaches levels to every alert type, but they are only meaningful for air alerts, so the other sensors are not affected by them.
+
+**Air (red)** and **Air (yellow)** carry two extra state attributes:
+
+| Attribute | Description |
+| --------- | ----------- |
+| `reasons` | The reasons reported for the level, for example `Ракетна загроза (червоний рівень)`. A level can have more than one reason, and older alerts are reported without one, so this can be an empty list while the sensor is on. |
+| `created_at` | When the level was raised. This is the start of the level itself, not of the air alert. |
+
+A region can have several air alerts active at the same time, so both attributes are collected across all of them. When a level is reported more than once, `created_at` is the oldest of the reported times.
 
 Siren check interval is set to 10 seconds to avoid overloading the API and still be able to react fast enough.
 

--- a/source/_integrations/ukraine_alarm.markdown
+++ b/source/_integrations/ukraine_alarm.markdown
@@ -14,14 +14,26 @@ ha_platforms:
 ha_integration_type: service
 ---
 
-The **Ukraine Alarm** {% term integration %} uses the siren.pp.ua API - public wrapper for [Ukraine Alarm](https://www.ukrainealarm.com/) web service to offer air-raid siren notifications. The {% term integration %} will create 6 binary sensors for your selected region in Ukraine:
+The **Ukraine Alarm** {% term integration %} uses the siren.pp.ua API - public wrapper for [Ukraine Alarm](https://www.ukrainealarm.com/) web service to offer air-raid siren notifications. The {% term integration %} will create 8 binary sensors for your selected region in Ukraine:
 
 - Air
+- Air (red)
+- Air (yellow)
 - Artillery
 - Chemical
 - Nuclear
 - Urban Fights
 - Unknown
+
+## Air alert levels
+
+The service reports a danger level for air alerts, where red is the more severe level and yellow the less severe one:
+
+- **Air** is on whenever an air alert is active for the region, whether or not a level is reported for it.
+- **Air (red)** is on while an air alert with the red level is active.
+- **Air (yellow)** is on while an air alert with the yellow level is active.
+
+The service can report both levels for a region at the same time, in which case both sensors are on. Levels are reported for air alerts only, so the other sensors are not affected by them.
 
 Siren check interval is set to 10 seconds to avoid overloading the API and still be able to react fast enough.
 


### PR DESCRIPTION
## Proposed change

Documents the two new binary sensors added by home-assistant/core#181558, which expose the danger level the Ukraine Alarm service now reports for air alerts.

The service reports a red or a yellow level for air alerts, and can report both for a region at the same time, so `Air (red)` and `Air (yellow)` are documented as independent sensors. The existing `Air` sensor is unchanged and stays on for any active air alert, including one that carries no level.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- This PR fixes or closes issue: fixes #
- Link to parent pull request in the codebase: home-assistant/core#181558
- Link to parent pull request in the Brands repository: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
