### PR TITLE
Render optional badge and default value in yaml options

### DIFF
--- a/plugins/options_yaml.rb
+++ b/plugins/options_yaml.rb
@@ -2,36 +2,26 @@ require 'safe_yaml'
 require_relative 'configuration'
 
 # Render the options block for the YAML-audience section of action,
-# trigger, and condition pages. Reuses the same `config-vars` layout and
-# type-link helpers as the shared `ConfigurationBlock`, but only shows a
-# "Required" badge on required fields. Optional fields render with no
-# badge at all, so the reader quickly sees which options they must set.
+# trigger, and condition pages. Reuses the same `config-vars` layout,
+# type-link helpers, and Required/Optional badge rendering as the shared
+# `ConfigurationBlock`.
 module Jekyll
   class OptionsYamlBlock < ConfigurationBlock
     def render(context)
       contents = Liquid::Block.instance_method(:render).bind_call(self, context)
-
       site = context.registers[:site]
       converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
-
       vars = SafeYAML.load(contents)
       raise ArgumentError, "options_yaml block must contain a YAML mapping" unless vars.is_a?(Hash)
 
-      # Drop "required: false" so render_config_vars skips the badge entirely
-      # for optional fields. Required fields keep their badge.
-      vars.each_value do |attr|
-        next unless attr.is_a?(Hash)
-        attr.delete('required') if attr['required'] == false
-      end
-
       <<~MARKUP
         <div class="config-vars">
-          #{render_config_vars(
-            vars: vars,
-            component: '',
-            platform: '',
-            converter: converter
-          )}
+        #{render_config_vars(
+          vars: vars,
+          component: '',
+          platform: '',
+          converter: converter
+        )}
         </div>
       MARKUP
     end


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Render word "optional" and the default value, if it exists, for YAML options with `required: false`. 
(The options `required: true` are marked as "Required" in capital letters and in red so they are highlighted and can be easily identified.)

Related to: https://github.com/home-assistant/home-assistant.io/issues/46958
At the moment the default values are not rendered because the option has `required: false`.

EXAMPLE:
_Before_: https://www.home-assistant.io/triggers/calendar.event_ended/

<img width="531" height="243" alt="calendar_before" src="https://github.com/user-attachments/assets/657f9e3c-1a1a-456f-b4e3-5b7e27a844b0" />

_After_: 
<img width="541" height="271" alt="calendar_after" src="https://github.com/user-attachments/assets/a8377af0-0e5d-45fa-818b-1dea1712cace" />

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
