### PR TITLE
Sharpen the Sofar troubleshooting section

### DIFF
--- a/source/_integrations/sofar.markdown
+++ b/source/_integrations/sofar.markdown
@@ -229,7 +229,6 @@ The **Sofar** {% term integration %} {% term polling polls %} the inverter's liv
 
 ## Known limitations
 
-- This is an early release of the integration, added to Home Assistant one platform at a time.
 - Only Modbus TCP connections are supported. Direct serial (RTU) connections aren't supported yet.
 - Only newer-generation Sofar inverters are recognized. Older, legacy models aren't supported yet.
 
@@ -240,10 +239,19 @@ The **Sofar** {% term integration %} {% term polling polls %} the inverter's liv
 1. Make sure the inverter (or the Modbus TCP bridge it's connected through) is powered on and reachable on the network.
 2. Confirm the host and port are correct, and that nothing else is holding open the same Modbus connection.
 3. Check that Modbus is enabled on the inverter, if it has a setting for this.
+4. If it still fails, enable [debug logging](/docs/configuration/troubleshooting/#debug-logs-and-diagnostics), reproduce the failure, and include the log in the issue report, together with the host, port, and Modbus unit ID you used.
 
 ### Inverter isn't recognized
 
 The integration only recognizes inverter models it knows the register map for. If setup fails with an unrecognized inverter error, your model isn't supported yet.
+
+Because setup didn't finish, there's nothing to download {% term diagnostics %} data from yet. Include the first ten characters of your inverter's serial number and the model name from its label in the issue report instead. Together, those identify which register map the inverter uses. The rest of the serial number isn't needed.
+
+### Entities are missing for your inverter
+
+If the integration set up successfully but entities you expect aren't there, such as battery or EPS/backup sensors on a hybrid inverter, the inverter is reporting that it doesn't serve those registers.
+
+Download the {% term diagnostics %} data and include it in the issue report. It lists which register blocks the inverter reports it supports, which shows whether the model genuinely lacks that hardware or the integration is reading it wrongly.
 
 ## Removing the integration
 

--- a/source/_integrations/sofar.markdown
+++ b/source/_integrations/sofar.markdown
@@ -166,7 +166,7 @@ automation: |
 
 ### Automation: run an appliance on surplus solar
 
-Appliances that don't care when they run are the cheapest way to use your own production instead of selling it. This automation starts the dishwasher once the inverter has been producing more than the house is using for ten minutes, which is long enough to know it isn't a passing gap in the clouds.
+Appliances that don't care when they run are the cheapest way to use your own production instead of selling it. This automation starts the dishwasher once the inverter has been producing more than the house is using for 10 minutes, which is long enough to know it isn't a passing gap in the clouds.
 
 - **Trigger**: Template, true while **PV power total** stays more than 1.5 kW above **Active power load system** for 10 minutes
 - **Action**: Turn on switch
@@ -245,13 +245,15 @@ The **Sofar** {% term integration %} {% term polling polls %} the inverter's liv
 
 The integration only recognizes inverter models it knows the register map for. If setup fails with an unrecognized inverter error, your model isn't supported yet.
 
-Because setup didn't finish, there's nothing to download {% term diagnostics %} data from yet. Include the first ten characters of your inverter's serial number and the model name from its label in the issue report instead. Together, those identify which register map the inverter uses. The rest of the serial number isn't needed.
+Because setup didn't finish, the integration isn't added yet, so the **Download diagnostics** option isn't shown. Include the first 10 characters of your inverter's serial number and the model name from its label in the issue report instead. Together, those identify which register map the inverter uses. The rest of the serial number isn't needed.
 
 ### Entities are missing for your inverter
 
 If the integration set up successfully but entities you expect aren't there, such as battery or EPS/backup sensors on a hybrid inverter, the inverter is reporting that it doesn't serve those registers.
 
 Download the {% term diagnostics %} data and include it in the issue report. It lists which register blocks the inverter reports it supports, which shows whether the model genuinely lacks that hardware or the integration is reading it wrongly.
+
+To download it, go to {% my integrations title="**Settings** > **Devices & services**" %} and find the **Sofar** integration. Select the three-dot menu {% icon "mdi:dots-vertical" %} and choose **Download diagnostics**.
 
 ## Removing the integration
 

--- a/source/_integrations/sofar.markdown
+++ b/source/_integrations/sofar.markdown
@@ -243,7 +243,11 @@ The **Sofar** {% term integration %} {% term polling polls %} the inverter's liv
 
 ### Inverter isn't recognized
 
+#### Description
+
 The integration only recognizes inverter models it knows the register map for. If setup fails with an unrecognized inverter error, your model isn't supported yet.
+
+#### Resolution
 
 Because setup didn't finish, the integration isn't added yet, so the **Download diagnostics** option isn't shown. Include the first 10 characters of your inverter's serial number and the model name from its label in the issue report instead. Together, those identify which register map the inverter uses. The rest of the serial number isn't needed.
 

--- a/source/_integrations/sofar.markdown
+++ b/source/_integrations/sofar.markdown
@@ -249,7 +249,11 @@ Because setup didn't finish, the integration isn't added yet, so the **Download 
 
 ### Entities are missing for your inverter
 
+#### Description
+
 If the integration set up successfully but entities you expect aren't there, such as battery or EPS/backup sensors on a hybrid inverter, the inverter is reporting that it doesn't serve those registers.
+
+#### Resolution
 
 Download the {% term diagnostics %} data and include it in the issue report. It lists which register blocks the inverter reports it supports, which shows whether the model genuinely lacks that hardware or the integration is reading it wrongly.
 

--- a/source/_integrations/sofar.markdown
+++ b/source/_integrations/sofar.markdown
@@ -234,12 +234,14 @@ The **Sofar** {% term integration %} {% term polling polls %} the inverter's liv
 
 ## Troubleshooting
 
+If these steps don't help, [open an issue on GitHub](https://github.com/home-assistant/core/issues/new?template=bug_report.yml&integration_name=Sofar&integration_link=https%3A%2F%2Fwww.home-assistant.io%2Fintegrations%2Fsofar) and include the details listed for your symptom.
+
 ### Cannot connect to the inverter
 
 1. Make sure the inverter (or the Modbus TCP bridge it's connected through) is powered on and reachable on the network.
 2. Confirm the host and port are correct, and that nothing else is holding open the same Modbus connection.
 3. Check that Modbus is enabled on the inverter, if it has a setting for this.
-4. If it still fails, enable [debug logging](/docs/configuration/troubleshooting/#debug-logs-and-diagnostics), reproduce the failure, and include the log in the issue report, together with the host, port, and Modbus unit ID you used.
+4. If it still fails, include the host, port, and Modbus unit ID in the issue report. If the integration is already added, also enable [debug logging](/docs/configuration/troubleshooting/#debug-logs-and-diagnostics), reproduce the failure, and include the log.
 
 ### Inverter isn't recognized
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
The Sofar troubleshooting section asked for the wrong thing in the wrong places. Diagnostics are per config entry, but both documented symptoms are setup failures, so there's no entry and no **Download diagnostics** menu item to find. This points each symptom at data that actually exists:

- **Cannot connect to the inverter**: added a final step for debug logging, plus the host, port, and Modbus unit ID.
- **Inverter isn't recognized**: setup never finished, so there's nothing to download diagnostics from. Asks for the first ten characters of the serial number and the model name instead, which is what identifies the register map. Ten covers the longest prefix the library matches on.
- **Entities are missing for your inverter**: new section. This is the case where an entry does exist, so diagnostics work and show which register blocks the inverter reports it serves. That separates a model that lacks the hardware from one being read wrongly.

Also drops the "early release, added one platform at a time" limitation. That rollout is complete: binary sensor, button, select, sensor, switch, and diagnostics have all shipped. The `number` entities the line implied were never added and aren't planned, since the power limits and passive-mode setpoints have to be written as whole register groups and became actions instead.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/181628
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
