### PR TITLE
Update 'since' date in timedelta_string markdown

### DIFF
--- a/source/_template_functions/timedelta_string.markdown
+++ b/source/_template_functions/timedelta_string.markdown
@@ -8,7 +8,7 @@ available_as:
 category: datetime
 return_type: string
 limited: false
-since: "2026.6"
+since: "2026.10"
 related_functions:
   - timedelta
   - as_timedelta


### PR DESCRIPTION
## Proposed change

Following the introduction of timedelta_string in PR https://github.com/home-assistant/core/pull/169773, and that comment in its related doc PR https://github.com/home-assistant/home-assistant.io/pull/45180#discussion_r3957445336, we need to update the "since" because the code PR was merged in September, so for the 2026.10 release, instead of the initial assumed release 2026.06.

Confirmed in [netlify preview](https://deploy-preview-48011--home-assistant-docs.netlify.app/template-functions/timedelta_string/):
<img width="1173" height="452" alt="image" src="https://github.com/user-attachments/assets/dde1a5a8-58c2-43ff-9c9a-c88cc3c76e45" />


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/169773 / https://github.com/home-assistant/home-assistant.io/pull/45180
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
