### PR TITLE
Add Litter-Robot camera entity

### DIFF
--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -19,6 +19,7 @@ ha_dhcp: true
 ha_platforms:
   - binary_sensor
   - button
+  - camera
   - diagnostics
   - select
   - sensor
@@ -56,6 +57,7 @@ Password:
 | Entity                        | Domain          | Description                                                                                                 |
 | ----------------------------- | --------------- | ----------------------------------------------------------------------------------------------------------- |
 | Litter box                    | `vacuum`        | Main entity that represents a Litter-Robot unit.                                                            |
+| Camera                        | `camera`        | Live video stream from the built-in camera, only for Litter-Robot 5 Pro.                                    |
 | Night light mode              | `switch`        | When turned on, automatically turns on the night light in darker settings, only for Litter-Robot 3.         |
 | Panel lockout                 | `switch`        | When turned on, disables the buttons on the unit to prevent changes to settings.                            |
 | Sleep mode (per day)          | `switch`        | Enable or disable each day of the week's sleep schedule, only for Litter-Robot 5.                           |


### PR DESCRIPTION
## Proposed change

Documents the `camera` platform added in home-assistant/core#181657: a new **Camera** row in the entity table, and `camera` added to `ha_platforms`.

The entity is created for Litter-Robot 5 units that report camera metadata, which pylitterbot identifies as the Pro model.

## Type of change

- [x] Add a new integration or platform to an existing integration

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#181657

## Checklist

- [x] This PR is related to a pull request in the codebase and I have linked it.
- [x] I have made only one change per PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013N8nU7ZMa6LcxaCbXp5oHQ
