### PR TITLE
Document the Z-Wave JS node status, configuration parameter, and value conditions

### DIFF
--- a/source/_conditions/zwave_js.config_parameter.markdown
+++ b/source/_conditions/zwave_js.config_parameter.markdown
@@ -1,0 +1,189 @@
+---
+title: "Z-Wave JS configuration parameter"
+condition: zwave_js.config_parameter
+domain: zwave_js
+description: "Tests if a configuration parameter on one or more Z-Wave JS nodes has the given value."
+related_conditions:
+  - zwave_js.value
+  - zwave_js.node_status
+---
+
+The **Z-Wave JS configuration parameter** condition passes when a configuration parameter on the selected Z-Wave nodes has the value you specify. Configuration parameters are the device's own settings, such as an LED indicator mode or a motion sensitivity level, and most of them are not exposed as Home Assistant entities.
+
+This condition is useful when:
+
+- You want to branch on a device setting that has no entity, such as a beeper or LED mode.
+- You want to confirm a parameter was actually applied before continuing.
+- You want to check a partial parameter that is packed into a bitmask.
+
+{% include conditions/ui_header.md %}
+
+To use **Z-Wave JS configuration parameter** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. Search for **Z-Wave JS configuration parameter** and select it.
+5. Under **Devices** (see [Selecting nodes](#selecting-nodes)), pick the Z-Wave devices whose nodes you want to check.
+6. Under **Parameter**, enter the parameter number.
+7. Under **Value**, enter the value to compare with.
+8. Optionally set **Bitmask** and **Endpoint**.
+9. Under **Condition passes if** (see [Behavior with multiple nodes](#behavior-with-multiple-nodes)), choose how multiple nodes should combine. The default is **Any**.
+10. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Devices:
+  description: The Z-Wave devices whose nodes to test. Select one or more.
+Parameter:
+  description: The number of the configuration parameter.
+Value:
+  description: The value to compare with, either the raw value or its state label.
+Bitmask:
+  description: Bitmask of a partial parameter, as a number or a hexadecimal string such as `0x1`, if the parameter is split into parts.
+Endpoint:
+  description: The endpoint of the parameter. The default is `0`.
+Condition passes if:
+  description: |
+    When several nodes are selected, controls how results combine:
+
+    - **Any**: passes if at least one node matches (default).
+    - **All**: passes only when every node matches.
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `zwave_js.config_parameter`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: zwave_js.config_parameter
+  options:
+    device_id: 45d7d3230dbb7441473ec883dab294d4
+    parameter: 3
+    value: 255
+{% endexample %}
+
+This passes when parameter 3 on that node is `255`.
+
+Parameters that expose named values can be compared by label instead of by number, and a partial parameter is selected with a bitmask:
+
+{% example %}
+condition: |
+  condition: zwave_js.config_parameter
+  options:
+    device_id: 45d7d3230dbb7441473ec883dab294d4
+    parameter: 3
+    value: "Enable Beeper"
+{% endexample %}
+
+{% example %}
+condition: |
+  condition: zwave_js.config_parameter
+  options:
+    device_id: 8f4219cfa57e23f6f669c4616c2205e2
+    parameter: 101
+    bitmask: "0x1"
+    value: 1
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+condition:
+  description: The condition type. For this condition, use `zwave_js.config_parameter`.
+  required: true
+  type: string
+device_id:
+  description: One or more device IDs of the Z-Wave devices whose nodes to test.
+  required: true
+  type: [string, list]
+parameter:
+  description: The number of the configuration parameter.
+  required: true
+  type: integer
+value:
+  description: The value to compare with, either the raw value or its state label.
+  required: true
+  type: [string, integer, boolean, float]
+bitmask:
+  description: Bitmask of a partial parameter, as a number or a hexadecimal string such as `0x1`, if the parameter is split into parts.
+  required: false
+  type: [string, integer]
+endpoint:
+  description: The endpoint of the parameter.
+  required: false
+  type: integer
+  default: 0
+behavior:
+  description: |
+    When several nodes are selected, controls how results combine:
+
+    - `any` (**Any** in the UI, default): passes if at least one node matches.
+    - `all` (**All** in the UI): passes only when every node matches.
+  required: false
+  type: string
+  default: any
+{% endoptions_yaml %}
+
+## Selecting nodes
+
+A Z-Wave node is represented in Home Assistant as a device, so this condition selects nodes with a device picker rather than a target. Pick one or more Z-Wave devices, and the condition tests the node behind each one.
+
+## Behavior with multiple nodes
+
+When you select more than one device, the **Condition passes if** option controls how the results combine:
+
+- **Any** (default): the condition passes if at least one node's parameter matches.
+- **All**: the condition passes only when every node's parameter matches.
+
+## Good to know
+
+- Parameter numbers, their allowed values, and any bitmasks are specific to the device. Look them up in the device manual or on [Z-Wave JS Config DB](https://devices.zwave-js.io/).
+- A parameter with named values can be compared either by its raw number or by its label, for example `1` or `"Enable"`. The raw value written as a string, such as `"1"`, also matches.
+- The condition is rejected when it is saved if none of the selected nodes has the parameter at all, so a typo in the parameter number surfaces immediately rather than silently never passing.
+- A node that does have the parameter but with a different value simply does not match.
+- The condition does not pass when none of the selected devices resolve to a Z-Wave node. A device that no longer resolves counts as unresolved and makes **All** fail.
+- To change a parameter rather than test it, use the [`zwave_js.set_config_parameter`](/integrations/zwave_js/#action-zwave_jsset_config_parameter) action.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: only run the nightly routine while the lock beeper is on
+
+- **Trigger**: Time: 23:00
+- **Condition**: Z-Wave JS configuration parameter
+  - **Devices**: Front door lock
+  - **Parameter**: 3
+  - **Value**: Enable Beeper
+- **Action**: Send a notification message
+
+{% details "YAML example for checking a configuration parameter" %}
+
+{% example %}
+automation: |
+  alias: "Warn at night while the lock beeper is enabled"
+  triggers:
+    - trigger: time
+      at: "23:00:00"
+  conditions:
+    - condition: zwave_js.config_parameter
+      options:
+        device_id: 45d7d3230dbb7441473ec883dab294d4
+        parameter: 3
+        value: "Enable Beeper"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "The front door lock will beep tonight."
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/zwave_js.node_status.markdown
+++ b/source/_conditions/zwave_js.node_status.markdown
@@ -1,0 +1,197 @@
+---
+title: "Z-Wave JS node status"
+condition: zwave_js.node_status
+domain: zwave_js
+description: "Tests if one or more Z-Wave JS nodes have the given status."
+related_conditions:
+  - zwave_js.config_parameter
+  - zwave_js.value
+---
+
+The **Z-Wave JS node status** condition passes when the selected Z-Wave nodes report the status you choose. Use it to check whether a node is reachable before an automation tries to talk to it.
+
+Z-Wave nodes report one of four statuses. A mains-powered node is normally `alive`, and becomes `dead` when the controller can no longer reach it. A battery-powered node spends most of its life `asleep` and briefly becomes `awake` when it checks in.
+
+This condition is useful when:
+
+- You want to skip an action for a node that has gone `dead` instead of letting the action fail.
+- You want to send a notification only while a node is unreachable.
+- You want to queue work for a battery-powered node only while it is `awake`.
+
+{% include conditions/ui_header.md %}
+
+To use **Z-Wave JS node status** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. Search for **Z-Wave JS node status** and select it.
+5. Under **Devices** (see [Selecting nodes](#selecting-nodes)), pick the Z-Wave devices whose nodes you want to check.
+6. Under **Status**, choose the status to test for.
+7. Under **Condition passes if** (see [Behavior with multiple nodes](#behavior-with-multiple-nodes)), choose how multiple nodes should combine. The default is **Any**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Devices:
+  description: The Z-Wave devices whose nodes to test. Select one or more.
+Status:
+  description: |
+    The node status to test for:
+
+    - **Alive**: the controller can reach the node.
+    - **Asleep**: a battery-powered node is sleeping.
+    - **Awake**: a battery-powered node is briefly awake.
+    - **Dead**: the controller cannot reach the node.
+Condition passes if:
+  description: |
+    When several nodes are selected, controls how results combine:
+
+    - **Any**: passes if at least one node has the status (default).
+    - **All**: passes only when every node has the status.
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `zwave_js.node_status`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: zwave_js.node_status
+  options:
+    device_id: 45d7d3230dbb7441473ec883dab294d4
+    status: alive
+{% endexample %}
+
+This passes when the node behind that device is reachable.
+
+To require every listed node to be dead:
+
+{% example %}
+condition: |
+  condition: zwave_js.node_status
+  options:
+    device_id:
+      - 45d7d3230dbb7441473ec883dab294d4
+      - 8f4219cfa57e23f6f669c4616c2205e2
+    behavior: all
+    status: dead
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+condition:
+  description: The condition type. For this condition, use `zwave_js.node_status`.
+  required: true
+  type: string
+device_id:
+  description: One or more device IDs of the Z-Wave devices whose nodes to test.
+  required: true
+  type: [string, list]
+status:
+  description: "The node status to test for. One of `alive`, `asleep`, `awake`, or `dead`."
+  required: true
+  type: string
+behavior:
+  description: |
+    When several nodes are selected, controls how results combine:
+
+    - `any` (**Any** in the UI, default): passes if at least one node has the status.
+    - `all` (**All** in the UI): passes only when every node has the status.
+  required: false
+  type: string
+  default: any
+{% endoptions_yaml %}
+
+## Selecting nodes
+
+A Z-Wave node is represented in Home Assistant as a device, so this condition selects nodes with a device picker rather than a target. Pick one or more Z-Wave devices, and the condition tests the node behind each one.
+
+## Behavior with multiple nodes
+
+When you select more than one device, the **Condition passes if** option controls how the results combine:
+
+- **Any** (default): the condition passes if at least one node has the status. This suits questions like "is any node in this group unreachable?"
+- **All**: the condition passes only when every node has the status. This suits "is the whole group back online?" checks, so an automation does not report an all-clear while one node is still dead.
+
+## Good to know
+
+- The condition does not pass when none of the selected devices resolve to a Z-Wave node, whichever behavior you choose.
+- A selected device that no longer resolves to a node, because the config entry is unloaded or the device was removed, counts as unresolved and makes **All** fail. It is simply skipped for **Any**.
+- Selecting the same node twice does not change the result. Nodes are de-duplicated before the check.
+- Node statuses are also exposed as a diagnostic sensor per node, so you can use the standard [state condition](/docs/scripts/conditions/#state-condition) instead if you prefer to check that entity.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: only notify while a lock is unreachable
+
+Check a lock's node every hour and notify only while the controller cannot reach it.
+
+- **Trigger**: Time pattern, every hour
+- **Condition**: Z-Wave JS node status
+  - **Devices**: Front door lock
+  - **Status**: Dead
+- **Action**: Send a notification message
+
+{% details "YAML example for notifying about an unreachable node" %}
+
+{% example %}
+automation: |
+  alias: "Notify while the front door lock is unreachable"
+  triggers:
+    - trigger: time_pattern
+      hours: "/1"
+  conditions:
+    - condition: zwave_js.node_status
+      options:
+        device_id: 45d7d3230dbb7441473ec883dab294d4
+        status: dead
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "The front door lock is not responding."
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: refresh a battery node only while it is awake
+
+Battery-powered nodes only accept commands while they are awake. This automation refreshes a sensor's values when the node checks in.
+
+- **Trigger**: Z-Wave JS node status changed, to Awake
+- **Condition**: Z-Wave JS node status
+  - **Devices**: Motion sensor
+  - **Status**: Awake
+- **Action**: Z-Wave refresh value
+
+{% details "YAML example for refreshing a node while it is awake" %}
+
+{% example %}
+automation: |
+  alias: "Refresh the motion sensor while it is awake"
+  triggers:
+    - trigger: state
+      entity_id: sensor.motion_sensor_node_status
+      to: "awake"
+  conditions:
+    - condition: zwave_js.node_status
+      options:
+        device_id: 8f4219cfa57e23f6f669c4616c2205e2
+        status: awake
+  actions:
+    - action: zwave_js.refresh_value
+      target:
+        entity_id: sensor.motion_sensor_air_temperature
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/zwave_js.value.markdown
+++ b/source/_conditions/zwave_js.value.markdown
@@ -159,7 +159,7 @@ When you select more than one device, the **Condition passes if** option control
 
 - **Trigger**: Time: 23:00
 - **Condition**: Z-Wave JS value
-  - **Devices**: Front door lock
+  - **Devices**: Garage door lock
   - **Command class**: 98 (Door Lock)
   - **Property**: latchStatus
   - **Value**: closed

--- a/source/_conditions/zwave_js.value.markdown
+++ b/source/_conditions/zwave_js.value.markdown
@@ -1,0 +1,195 @@
+---
+title: "Z-Wave JS value"
+condition: zwave_js.value
+domain: zwave_js
+description: "Tests if a Z-Wave value on one or more nodes equals the given value."
+related_conditions:
+  - zwave_js.config_parameter
+  - zwave_js.node_status
+---
+
+The **Z-Wave JS value** condition passes when a Z-Wave value on the selected nodes equals the value you specify. Use it to check a Command Class value directly, including values that Home Assistant does not expose as an entity.
+
+This condition is the counterpart of the [Z-Wave value updated](/triggers/zwave_js.value_updated/) trigger. Where that trigger fires on a change, this condition tests the current value.
+
+This condition is useful when:
+
+- You want to check a Z-Wave value that has no Home Assistant entity.
+- You want to test a specific Command Class, property, property key, or endpoint.
+- A device reports detail in a value that its entity state flattens away.
+
+{% include conditions/ui_header.md %}
+
+To use **Z-Wave JS value** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. Search for **Z-Wave JS value** and select it.
+5. Under **Devices** (see [Selecting nodes](#selecting-nodes)), pick the Z-Wave devices whose nodes you want to check.
+6. Under **Command class**, pick the Command Class of the value.
+7. Under **Property**, enter the property of the value, and under **Value**, enter the value to compare with.
+8. Optionally set **Property key** and **Endpoint**.
+9. Under **Condition passes if** (see [Behavior with multiple nodes](#behavior-with-multiple-nodes)), choose how multiple nodes should combine. The default is **Any**.
+10. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Devices:
+  description: The Z-Wave devices whose nodes to test. Select one or more.
+Command class:
+  description: The Command Class of the Z-Wave value.
+Property:
+  description: The property of the Z-Wave value.
+Value:
+  description: The value to compare with, either the raw value or its state label.
+Property key:
+  description: The property key of the Z-Wave value, for values that have one.
+Endpoint:
+  description: The endpoint of the Z-Wave value.
+Condition passes if:
+  description: |
+    When several nodes are selected, controls how results combine:
+
+    - **Any**: passes if at least one node matches (default).
+    - **All**: passes only when every node matches.
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `zwave_js.value`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: zwave_js.value
+  options:
+    device_id: 45d7d3230dbb7441473ec883dab294d4
+    command_class: 98
+    property: currentMode
+    value: "Unsecured"
+{% endexample %}
+
+This passes when the Door Lock Command Class reports the lock as unsecured.
+
+To require every listed node to match, and to select a value that has a property key and an endpoint:
+
+{% example %}
+condition: |
+  condition: zwave_js.value
+  options:
+    device_id:
+      - 45d7d3230dbb7441473ec883dab294d4
+      - 8f4219cfa57e23f6f669c4616c2205e2
+    command_class: 51
+    property: currentColor
+    property_key: 0
+    endpoint: 0
+    value: 255
+    behavior: all
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+condition:
+  description: The condition type. For this condition, use `zwave_js.value`.
+  required: true
+  type: string
+device_id:
+  description: One or more device IDs of the Z-Wave devices whose nodes to test.
+  required: true
+  type: [string, list]
+command_class:
+  description: The numeric ID of the Command Class of the Z-Wave value.
+  required: true
+  type: integer
+property:
+  description: The property of the Z-Wave value.
+  required: true
+  type: [string, integer]
+value:
+  description: The value to compare with, either the raw value or its state label.
+  required: true
+  type: [string, integer, boolean, float]
+property_key:
+  description: The property key of the Z-Wave value.
+  required: false
+  type: [string, integer]
+endpoint:
+  description: The endpoint of the Z-Wave value.
+  required: false
+  type: integer
+behavior:
+  description: |
+    When several nodes are selected, controls how results combine:
+
+    - `any` (**Any** in the UI, default): passes if at least one node matches.
+    - `all` (**All** in the UI): passes only when every node matches.
+  required: false
+  type: string
+  default: any
+{% endoptions_yaml %}
+
+## Selecting nodes
+
+A Z-Wave node is represented in Home Assistant as a device, so this condition selects nodes with a device picker rather than a target. Pick one or more Z-Wave devices, and the condition tests the node behind each one.
+
+## Behavior with multiple nodes
+
+When you select more than one device, the **Condition passes if** option controls how the results combine:
+
+- **Any** (default): the condition passes if at least one node's value matches.
+- **All**: the condition passes only when every node's value matches.
+
+## Good to know
+
+- Property names, property keys, and Command Class IDs come from Z-Wave JS. Refer to the [Z-Wave JS documentation](https://zwave-js.github.io/node-zwave-js/#/api/valueid) for the available values.
+- A value with named states can be compared either by its raw value or by its state label, for example `0` or `"Unsecured"`. The raw value written as a string, such as `"0"`, also matches.
+- A property key of `0` is a real key, for example a Color Switch component, and is not the same as leaving the property key out.
+- The condition is rejected when it is saved if none of the selected nodes has the value at all, so a typo in the Command Class or property surfaces immediately rather than silently never passing.
+- A node that does have the value but with a different reading simply does not match.
+- The condition does not pass when none of the selected devices resolve to a Z-Wave node. A device that no longer resolves counts as unresolved and makes **All** fail.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: only close the garage if the latch reports closed
+
+- **Trigger**: Time: 23:00
+- **Condition**: Z-Wave JS value
+  - **Devices**: Front door lock
+  - **Command class**: 98 (Door Lock)
+  - **Property**: latchStatus
+  - **Value**: closed
+- **Action**: Send a notification message
+
+{% details "YAML example for checking a Z-Wave value" %}
+
+{% example %}
+automation: |
+  alias: "Confirm the latch is closed at night"
+  triggers:
+    - trigger: time
+      at: "23:00:00"
+  conditions:
+    - condition: zwave_js.value
+      options:
+        device_id: 45d7d3230dbb7441473ec883dab294d4
+        command_class: 98
+        property: latchStatus
+        value: "closed"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "The front door latch is closed for the night."
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -669,6 +669,8 @@ actions:
 
 {% include integrations/triggers.md %}
 
+{% include integrations/conditions.md %}
+
 {% include integrations/actions.md %}
 
 ## Setting up a Z-Wave server without using the Z-Wave JS app


### PR DESCRIPTION
## Proposed change

Documents the three new Z-Wave JS conditions added in home-assistant/core#181133: `zwave_js.node_status`, `zwave_js.config_parameter`, and `zwave_js.value`.

Adds a page per condition under `source/_conditions/`, and adds the `integrations/conditions.md` include to the Z-Wave JS integration page so the three appear in its list of conditions.

Each page covers:

- **Picking nodes with the device selector.** A node is a device, so these conditions take a `device_id` field rather than a target, and the pages explain that rather than reusing the entity-oriented `conditions/targets.md` include.
- **The `any` and `all` behavior**, including that nothing passes when no selected device resolves to a node, and that a device that no longer resolves counts as unresolved and fails `all`.
- **Raw values versus state labels.** A value or configuration parameter with named states can be compared by number, by label, or by the raw value written as a string.
- **Validation at save time.** The condition is rejected if no selected node has the parameter or value at all, so a typo surfaces immediately instead of silently never passing.
- **Z-Wave specifics**, such as a property key of `0` being a real key, bitmasks for partial parameters, and where to look up parameter numbers and Command Class IDs.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/181133
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)
