### PR TITLE
Document the Z-Wave JS triggers in the automation editor

### DIFF
--- a/source/_triggers/zwave_js.event.markdown
+++ b/source/_triggers/zwave_js.event.markdown
@@ -16,11 +16,47 @@ This trigger is useful when:
 - You want to react to a node event that is not exposed as an entity state.
 - You need to match a specific event by name and, optionally, by event data.
 
-{% note %}
-This trigger is configured in YAML only. It cannot be added from the automation editor in the UI.
-{% endnote %}
-
 There is strict validation in place based on all known event types. If you come across an event type that is not supported, open a GitHub issue in the [`home-assistant/core`](https://github.com/home-assistant/core/issues) repository.
+
+{% include triggers/ui_header.md %}
+
+To use **Z-Wave JS event received** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Search for **Z-Wave JS event received** and select it.
+5. Under **Event source**, choose whether you are watching a **Controller**, **Driver**, or **Node** event.
+6. Point the trigger at what should emit the event:
+   - For a **Node** event, pick **Devices**, **Entities**, or both.
+   - For a **Controller** or **Driver** event, pick a **Config entry** instead, and leave devices and entities empty.
+7. Under **Event**, enter the event name, for example `interview failed`.
+8. Optionally set **Event data** to match specific fields, and turn on **Partial dictionary match** if you only want to match a subset of a nested mapping.
+9. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Event source:
+  description: |
+    The layer that emits the event:
+
+    - **Controller**: events from the Z-Wave controller, such as inclusion progress.
+    - **Driver**: events from the Z-Wave JS driver itself.
+    - **Node**: events from a specific node.
+Config entry:
+  description: The Z-Wave config entry to watch. Used for **Controller** and **Driver** events instead of devices and entities.
+Devices:
+  description: The Z-Wave devices whose node events to watch. Used for **Node** events.
+Entities:
+  description: Entities whose devices should be watched. Used for **Node** events.
+Event:
+  description: The name of the event to match, for example `value notification`.
+Event data:
+  description: Event data to match against. The trigger only fires when the event data matches.
+Partial dictionary match:
+  description: Match only the listed keys of a nested mapping rather than the whole mapping. The default is off.
+{% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}
 
@@ -80,7 +116,7 @@ partial_dict_match:
 
 - Event names and the structure of event data come from Z-Wave JS. The set of available fields depends on the event.
 - When an event includes nested fields (for example, an `args` mapping inside `event_data`), use `partial_dict_match: true` if you only want to match a subset of those fields.
-- This trigger does not appear in the automation editor in the UI. You can add it by editing the automation in YAML mode.
+- Node events need at least one device or entity. Controller and driver events must not have any, and take a config entry instead.
 
 ### Available trigger data
 

--- a/source/_triggers/zwave_js.value_updated.markdown
+++ b/source/_triggers/zwave_js.value_updated.markdown
@@ -16,9 +16,40 @@ This trigger is useful when:
 - A device sends value updates without changing entity state, for example, when the device does not follow the Z-Wave specification.
 - You need to filter on a specific Command Class, property, property key, or endpoint.
 
-{% note %}
-This trigger is configured in YAML only. It cannot be added from the automation editor in the UI.
-{% endnote %}
+{% include triggers/ui_header.md %}
+
+To use **Z-Wave JS value updated** in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. Search for **Z-Wave JS value updated** and select it.
+5. Pick the nodes to watch under **Devices**, **Entities**, or both.
+6. Under **Command class**, pick the Command Class of the value, and under **Property**, enter its property.
+7. Optionally set **Property key** and **Endpoint** to narrow down which value is meant.
+8. Optionally set **From** and **To** to only fire on specific previous or new values.
+9. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Devices:
+  description: The Z-Wave devices whose values to watch.
+Entities:
+  description: Entities whose devices should be watched.
+Command class:
+  description: The Command Class of the Z-Wave value to watch.
+Property:
+  description: The property of the Z-Wave value to watch.
+Property key:
+  description: The property key of the Z-Wave value, for values that have one.
+Endpoint:
+  description: The endpoint of the Z-Wave value.
+From:
+  description: One previous value, or a list of them. The trigger fires when the previous value matches any of them.
+To:
+  description: One new value, or a list of them. The trigger fires when the new value matches any of them.
+{% endoptions_ui %}
 
 {% include triggers/yaml_header.md %}
 
@@ -82,7 +113,7 @@ to:
 
 - Property names, property keys, and Command Class IDs come from Z-Wave JS. Refer to the [Z-Wave JS documentation](https://zwave-js.github.io/node-zwave-js/#/api/valueid) for the available values.
 - When `from` or `to` is a list, the trigger fires if the value matches any item in the list.
-- This trigger does not appear in the automation editor in the UI. You can add it by editing the automation in YAML mode.
+- At least one of **Devices** or **Entities** is required, and an entity is resolved to the node behind it.
 
 ### Available trigger data
 


### PR DESCRIPTION
## Proposed change

Both Z-Wave JS trigger pages still say the trigger is YAML only and cannot be added from the automation editor. That stopped being true when home-assistant/core#181129 added `triggers.yaml`, strings, and icons for `zwave_js.event` and `zwave_js.value_updated`, which is what lets the editor render them.

For each of the two pages:

- Removes the note claiming the trigger is YAML only, and the matching **Good to know** bullet saying it does not appear in the editor.
- Adds a **Using this trigger from the user interface** section with a step-by-step walkthrough and an **Options in the UI** list, matching the field names and selectors the integration actually ships.
- Replaces the removed bullet with the targeting rule that does apply. Node events need at least one device or entity while controller and driver events take a config entry instead, and the value updated trigger needs at least one device or entity.

The YAML sections are unchanged, since the YAML shape did not change.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/181129
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)
