### PR TITLE
Energy cards: power elements use a real-time collection of their own

### DIFF
--- a/source/_dashboards/energy.markdown
+++ b/source/_dashboards/energy.markdown
@@ -645,7 +645,7 @@ type:
   type: string
 collection_key:
   required: false
-  description: "Collection key to use for the card. This links the card to a specific energy dashboard collection. If not provided, defaults to the current dashboard page URL."
+  description: "Collection key to use for the card. This links the card to a specific energy dashboard collection. If not provided, the card uses the real-time collection of the current dashboard page, which always shows today; see [Using multiple collections](#using-multiple-collections)."
   type: string
 title:
   required: false
@@ -693,7 +693,7 @@ layout: horizontal
   Screenshot of the power Sankey graph card.
 </p>
 
-The power sources graph shows historical power data.
+The power sources graph shows the power of your grid, solar, and battery sources over the day. By default it shows today and moves to the new day at midnight. It is not linked to an `energy-date-selection` card on the same dashboard unless both use the same `collection_key`; see [Using multiple collections](#using-multiple-collections).
 
 ### YAML configuration
 
@@ -706,7 +706,7 @@ type:
   type: string
 collection_key:
   required: false
-  description: "Collection key to use for the card. This links the card to a specific energy dashboard collection. If not provided, defaults to the current dashboard page URL."
+  description: "Collection key to use for the card. This links the card to a specific energy dashboard collection. If not provided, the card uses the real-time collection of the current dashboard page, which always shows today; see [Using multiple collections](#using-multiple-collections)."
   type: string
 title:
   required: false
@@ -748,9 +748,8 @@ type:
   type: string
 collection_key:
   required: false
-  description: "Collection key to use for the badge. This links the badge to a specific energy dashboard collection. Defaults to `energy_dashboard`."
+  description: "Collection key to use for the badge. This links the badge to a specific energy dashboard collection. If not provided, the badge uses the real-time collection of the current dashboard page, which always shows today; see [Using multiple collections](#using-multiple-collections)."
   type: string
-  default: energy_dashboard
 {% endconfiguration %}
 
 ### Example
@@ -820,6 +819,8 @@ type: water-total
 ## Using multiple collections
 
 By default, all energy cards on the current dashboard are linked together. Any `energy-date-selection` cards on this dashboard control what data is shown. If there are none, a default date of today is used. When you add multiple date selection cards, they always show the same date. Any `energy-date-selection` card on a different dashboard does not affect energy cards on the current dashboard.
+
+The real-time power elements are the exception: the [power flow Sankey graph](#power-flow-sankey-graph), the [power sources graph](#power-sources-graph), and the [power consumption badge](#power-consumption-badge). Without a `collection_key` they use a real-time collection of their own for the current dashboard, which always shows today and moves to the new day at midnight, so an `energy-date-selection` card on the same dashboard does not affect them. To show the power sources graph for the selected period instead, give it and the date selection card the same `collection_key`.
 
 To enable multiple different date selections on the same dashboard, they must be linked to different collections. This is done using the `collection_key` parameter, either in the visual editor or in the card YAML, with a value of any custom string that begins with `energy_` (strings that do not start with `energy_` will generate an error).
 

--- a/source/_dashboards/energy.markdown
+++ b/source/_dashboards/energy.markdown
@@ -645,7 +645,7 @@ type:
   type: string
 collection_key:
   required: false
-  description: "Collection key to use for the card. This links the card to a specific energy dashboard collection. If not provided, the card uses the real-time collection of the current dashboard page, which always shows today; see [Using multiple collections](#using-multiple-collections)."
+  description: "Collection key to use for the card. This links the card to a specific energy dashboard collection. The card shows current power regardless of the date selected in that collection. If not provided, the card uses the real-time collection of the current dashboard page. See [Using multiple collections](#using-multiple-collections)."
   type: string
 title:
   required: false
@@ -693,7 +693,7 @@ layout: horizontal
   Screenshot of the power Sankey graph card.
 </p>
 
-The power sources graph shows the power of your grid, solar, and battery sources over the day. By default it shows today and moves to the new day at midnight. It is not linked to an `energy-date-selection` card on the same dashboard unless both use the same `collection_key`; see [Using multiple collections](#using-multiple-collections).
+The power sources graph shows the power of your grid, solar, and battery sources over the day. By default, it shows today and moves to the new day at midnight. It is not linked to an `energy-date-selection` card on the same dashboard unless both use the same `collection_key`. See [Using multiple collections](#using-multiple-collections).
 
 ### YAML configuration
 
@@ -706,7 +706,7 @@ type:
   type: string
 collection_key:
   required: false
-  description: "Collection key to use for the card. This links the card to a specific energy dashboard collection. If not provided, the card uses the real-time collection of the current dashboard page, which always shows today; see [Using multiple collections](#using-multiple-collections)."
+  description: "Collection key to use for the card. This links the card to a specific energy dashboard collection. If not provided, the card uses the real-time collection of the current dashboard page, which always shows today. See [Using multiple collections](#using-multiple-collections)."
   type: string
 title:
   required: false
@@ -748,7 +748,7 @@ type:
   type: string
 collection_key:
   required: false
-  description: "Collection key to use for the badge. This links the badge to a specific energy dashboard collection. If not provided, the badge uses the real-time collection of the current dashboard page, which always shows today; see [Using multiple collections](#using-multiple-collections)."
+  description: "Collection key to use for the badge. This links the badge to a specific energy dashboard collection. The badge shows current power regardless of the date selected in that collection. If not provided, the badge uses the real-time collection of the current dashboard page. See [Using multiple collections](#using-multiple-collections)."
   type: string
 {% endconfiguration %}
 
@@ -820,7 +820,7 @@ type: water-total
 
 By default, all energy cards on the current dashboard are linked together. Any `energy-date-selection` cards on this dashboard control what data is shown. If there are none, a default date of today is used. When you add multiple date selection cards, they always show the same date. Any `energy-date-selection` card on a different dashboard does not affect energy cards on the current dashboard.
 
-The real-time power elements are the exception: the [power flow Sankey graph](#power-flow-sankey-graph), the [power sources graph](#power-sources-graph), and the [power consumption badge](#power-consumption-badge). Without a `collection_key` they use a real-time collection of their own for the current dashboard, which always shows today and moves to the new day at midnight, so an `energy-date-selection` card on the same dashboard does not affect them. To show the power sources graph for the selected period instead, give it and the date selection card the same `collection_key`.
+The real-time power elements are the exception: the [power flow Sankey graph](#power-flow-sankey-graph), the [power sources graph](#power-sources-graph), and the [power consumption badge](#power-consumption-badge). Without a `collection_key`, they use a real-time collection of their own for the current dashboard. That collection always shows today and moves to the new day at midnight. An `energy-date-selection` card on the same dashboard therefore does not affect them. The power flow Sankey graph and the power consumption badge show current power and never follow a date selection. The power sources graph can follow one: give it and the date selection card the same `collection_key` to show the selected period.
 
 To enable multiple different date selections on the same dashboard, they must be linked to different collections. This is done using the `collection_key` parameter, either in the visual editor or in the card YAML, with a value of any custom string that begins with `energy_` (strings that do not start with `energy_` will generate an error).
 

--- a/source/_dashboards/energy.markdown
+++ b/source/_dashboards/energy.markdown
@@ -689,8 +689,8 @@ layout: horizontal
 ## Power sources graph
 
 <p class='img'>
-  <img src='/images/dashboards/energy/power-sources.png' alt='Screenshot of the Sankey sources graph card'>
-  Screenshot of the power Sankey graph card.
+  <img src='/images/dashboards/energy/power-sources.png' alt='Screenshot of the power sources graph card'>
+  Screenshot of the power sources graph card.
 </p>
 
 The power sources graph shows the power of your grid, solar, and battery sources over the day. By default, it shows today and moves to the new day at midnight. It is not linked to an `energy-date-selection` card on the same dashboard unless both use the same `collection_key`. See [Using multiple collections](#using-multiple-collections).
@@ -818,7 +818,7 @@ type: water-total
 
 ## Using multiple collections
 
-By default, all energy cards on the current dashboard are linked together. Any `energy-date-selection` cards on this dashboard control what data is shown. If there are none, a default date of today is used. When you add multiple date selection cards, they always show the same date. Any `energy-date-selection` card on a different dashboard does not affect energy cards on the current dashboard.
+By default, the energy cards on the current dashboard are linked together, except for the real-time power elements described below. Any `energy-date-selection` cards on this dashboard control what data is shown. If there are none, a default date of today is used. When you add multiple date selection cards, they always show the same date. Any `energy-date-selection` card on a different dashboard does not affect energy cards on the current dashboard.
 
 The real-time power elements are the exception: the [power flow Sankey graph](#power-flow-sankey-graph), the [power sources graph](#power-sources-graph), and the [power consumption badge](#power-consumption-badge). Without a `collection_key`, they use a real-time collection of their own for the current dashboard. That collection always shows today and moves to the new day at midnight. An `energy-date-selection` card on the same dashboard therefore does not affect them. The power flow Sankey graph and the power consumption badge show current power and never follow a date selection. The power sources graph can follow one: give it and the date selection card the same `collection_key` to show the selected period.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
Documents the behavior change in home-assistant/frontend#54071. When no `collection_key` is set, the power flow Sankey graph, the power sources graph and the power consumption badge now use a real-time collection of their own for the dashboard page (like the energy dashboard's **Now** view) instead of the page's default energy collection. That collection always shows today and rolls over at midnight, so an `energy-date-selection` card on the same dashboard no longer affects these elements unless both are given the same `collection_key`.

Changes on the energy cards page:

- `collection_key` descriptions of the three power elements: the new default, with a link to "Using multiple collections". The power consumption badge no longer claims a default of `energy_dashboard`.
- Power sources graph introduction: what it shows, that it shows today by default, and how to link it to a date picker.
- "Using multiple collections": the power elements as the exception to "all energy cards on a dashboard are linked".



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/frontend#54071
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the current branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
