### PR TITLE
Document show_values on water Sankey cards

### DIFF
--- a/source/_dashboards/energy.markdown
+++ b/source/_dashboards/energy.markdown
@@ -294,6 +294,11 @@ max_devices:
   description: Maximum number of devices shown under your home and under each upstream device. Devices beyond the limit are combined into a single **Other** node, smallest first, so their totals are still included. On the devices energy graph, `max_devices` hides the extra devices instead. The limit applies per upstream device, not per floor or area.
   type: integer
   default: 20
+show_values:
+  required: false
+  description: Whether to show the numeric values on each node.
+  type: boolean
+  default: false
 {% endconfiguration %}
 
 ### Examples
@@ -306,6 +311,74 @@ The following example orients the flow from left to right:
 
 ```yaml
 type: water-sankey
+layout: horizontal
+```
+
+## Water flow Sankey graph
+
+<p class='img'>
+  <img src='/images/dashboards/energy/water-sankey.png' alt='Screenshot of the water flow Sankey graph card'>
+  Screenshot of the water flow Sankey graph card.
+</p>
+
+The water flow Sankey graph shows the real-time flow of water in your home. Unlike the water Sankey card, which shows historical water data based on the selected date range, this card displays current flow values and is not affected by the date picker selection.
+
+It visualizes the instantaneous water flow from sources to the various consumers. Devices are grouped into floors and areas if these are configured. Devices combined into the **Other** node are not part of any floor or area.
+
+### YAML configuration
+
+The following YAML options are available:
+
+{% configuration %}
+type:
+  required: true
+  description: "`water-flow-sankey`"
+  type: string
+collection_key:
+  required: false
+  description: "Collection key to use for the card. This links the card to a specific energy dashboard collection. If not provided, defaults to the current dashboard page URL."
+  type: string
+title:
+  required: false
+  description: The title of the card.
+  type: string
+layout:
+  required: false
+  description: "`vertical`, `horizontal` or `auto`. Determines the orientation (flow direction) of the card. `auto` changes it based on the screen size."
+  type: string
+  default: auto
+group_by_area:
+  required: false
+  description: Whether to group the devices by area
+  type: boolean
+  default: true
+group_by_floor:
+  required: false
+  description: Whether to group the devices by floor
+  type: boolean
+  default: true
+max_devices:
+  required: false
+  description: Maximum number of devices shown under your home and under each upstream device. Devices beyond the limit are combined into a single **Other** node, smallest first, so their totals are still included. On the devices energy graph, `max_devices` hides the extra devices instead. The limit applies per upstream device, not per floor or area.
+  type: integer
+  default: 20
+show_values:
+  required: false
+  description: Whether to show the numeric values on each node.
+  type: boolean
+  default: false
+{% endconfiguration %}
+
+### Examples
+
+```yaml
+type: water-flow-sankey
+```
+
+The following example orients the flow from left to right:
+
+```yaml
+type: water-flow-sankey
 layout: horizontal
 ```
 


### PR DESCRIPTION
## Proposed change

Documents the `show_values` config option for the water Sankey graph and water flow Sankey graph cards, matching the style of the existing entries on the energy and power Sankey cards.

Also adds a **Water flow Sankey graph** section so the card editor documentation link for `water-flow-sankey` resolves correctly.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/frontend#53925
- Link to parent pull request in the codebase: home-assistant/frontend#54075
- Link to related documentation pull request: home-assistant/home-assistant.io#47789
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards