### PR TITLE
Document Thermomix SSDP discovery for Cookidoo

### DIFF
--- a/source/_integrations/cookidoo.markdown
+++ b/source/_integrations/cookidoo.markdown
@@ -9,6 +9,7 @@ ha_category:
 ha_iot_class: Cloud Polling
 ha_release: 2025.1
 ha_config_flow: true
+ha_ssdp: true
 ha_codeowners:
   - '@miaucl'
 ha_domain: cookidoo

--- a/source/_integrations/cookidoo.markdown
+++ b/source/_integrations/cookidoo.markdown
@@ -50,13 +50,9 @@ Localization:
 
 ## Discovery
 
-If you own a Thermomix TM7, Home Assistant automatically discovers it on your
-network through SSDP/UPnP and offers to set up the Cookidoo integration for it.
+If you own a Thermomix TM7, Home Assistant automatically discovers it on your network through <abbr title="Simple Service Discovery Protocol">SSDP</abbr> and <abbr title="Universal Plug and Play">UPnP</abbr> and offers to set up the Cookidoo integration.
 
-Because Cookidoo is a cloud account service, discovery cannot configure the
-connection on its own: you still need to sign in with the email address and
-password of the Cookidoo account associated with your Thermomix to complete the
-setup.
+Because Cookidoo is a cloud account service, discovery cannot complete setup on its own. To finish setup, sign in with the email address and password for the Cookidoo account associated with your Thermomix.
 
 ## To-do lists
 

--- a/source/_integrations/cookidoo.markdown
+++ b/source/_integrations/cookidoo.markdown
@@ -48,6 +48,16 @@ Localization:
 
 {% include integrations/config_flow.md %}
 
+## Discovery
+
+If you own a Thermomix TM7, Home Assistant automatically discovers it on your
+network through SSDP/UPnP and offers to set up the Cookidoo integration for it.
+
+Because Cookidoo is a cloud account service, discovery cannot configure the
+connection on its own: you still need to sign in with the email address and
+password of the Cookidoo account associated with your Thermomix to complete the
+setup.
+
 ## To-do lists
 
 This integration provides two non-sortable to-do lists:


### PR DESCRIPTION
## Proposed change

Documents the new automatic SSDP/UPnP discovery of the Vorwerk Thermomix TM7 in the Cookidoo integration. A new "Discovery" section explains that a Thermomix on the network is discovered automatically, and that because Cookidoo is a cloud account service, the user still has to sign in with their Cookidoo credentials to complete setup.

This documents the companion core PR that adds `async_step_ssdp` to the Cookidoo config flow.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/181734
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
