### PR TITLE
Add vehicle_details option to OpenALPR Cloud docs

### DIFF
--- a/source/_integrations/openalpr_cloud.markdown
+++ b/source/_integrations/openalpr_cloud.markdown
@@ -49,6 +49,16 @@ confidence:
   required: false
   type: integer
   default: 80
+vehicle_details:
+  description: >-
+    Lets the integration request the most likely color, make, and model of
+    the vehicle from OpenALPR. The results are exposed as the `color`,
+    `manufacturer`, and `model` extra state attributes and included in the
+    `image_processing.found_plate` event. Only plates that meet the
+    `confidence` threshold are included.
+  required: false
+  type: boolean
+  default: false
 source:
   description: List of image sources.
   required: true


### PR DESCRIPTION
Document the optional `vehicle_details` config option that is being added by home-assistant/core#179477.

## Proposed change

`source/_integrations/openalpr_cloud.markdown` gains an entry for the new `vehicle_details` boolean option (`required: false`, `default: false`) in the YAML configuration reference. When enabled, the integration asks OpenALPR for the most likely color, make, and model of the detected vehicle and exposes the results as the `color`, `manufacturer`, and `model` extra state attributes, included in the `image_processing.found_plate` event data. Only plates meeting the `confidence` threshold are included.

## Type of change
- [x] Documentation / UI improvement

## Additional information
- Related core PR: home-assistant/core#179477 (adds the `vehicle_details` option to the `openalpr_cloud` image platform).
- Core-side review finding `…/pull/179477/files#discussion-r3949934618` asked for the docs + a link to the docs PR; the core comment links [this PR](#48033).
- Review follow-up (Copilot PR #48033): dropped the redundant "Optional." prefix (already covered by `required: false`) and the event is now named in full as `image_processing.found_plate` so it matches the `event_type` readers look for in automations.
- Retargeted to `next` per the Home Assistant bot instruction (feature docs must target `next`).