### PR TITLE
Document NeoPool winter mode via disable polling

### DIFF
--- a/source/_integrations/neopool.markdown
+++ b/source/_integrations/neopool.markdown
@@ -162,6 +162,19 @@ The integration {% term polling polls %} the controller over Modbus TCP at a fix
 
 If a poll cycle fails (for example, because the Modbus gateway becomes unreachable), all entities transition to `unavailable` until the next successful poll.
 
+## Winter mode
+
+In colder climates the pool is often closed for the season. The controller is drained, powered down, and sometimes removed entirely and stored indoors until spring. While it is offline, every poll fails, the log fills with connection errors, and the integration keeps retrying reconnects for months. To avoid this, turn off polling for the integration so it stops contacting the controller while it is away:
+
+1. Go to {% my integrations title="**Settings** > **Devices & services**" %}.
+2. Select the NeoPool integration.
+3. Open the three-dot {% icon "mdi:dots-vertical" %} menu, then select **System options**.
+4. Turn off **Enable polling for updates**, then select **Update**.
+
+   ![Screenshot showing the System Options dialog with the Enable polling for updates toggle](/images/screenshots/custom_polling_01.png)
+
+With polling off, the integration stops all Modbus communication and makes no reconnect attempts, so an absent controller is never contacted. All entities report `unavailable` rather than serving stale readings, while the config entry, options, and history stay in place. The last known device data is kept, so the entities survive a Home Assistant restart without any reconfiguration. In spring, turn **Enable polling for updates** back on to resume.
+
 ## Reconfigure
 
 If your Modbus TCP gateway moves to a different IP address or port, or you need to change the unit ID or Modbus framer, you can update the connection settings without removing and re-adding the integration:

--- a/source/_integrations/neopool.markdown
+++ b/source/_integrations/neopool.markdown
@@ -164,16 +164,16 @@ If a poll cycle fails (for example, because the Modbus gateway becomes unreachab
 
 ## Winter mode
 
-In colder climates the pool is often closed for the season. The controller is drained, powered down, and sometimes removed entirely and stored indoors until spring. While it is offline, every poll fails, the log fills with connection errors, and the integration keeps retrying reconnects for months. To avoid this, turn off polling for the integration so it stops contacting the controller while it is away:
+In colder climates, the pool is often closed for the season. The controller is drained, powered down, and sometimes removed entirely and stored indoors until spring. While it is offline, every poll fails and the log fills with connection errors. To avoid this, turn off polling so the integration stops contacting the controller while it is away:
 
 1. Go to {% my integrations title="**Settings** > **Devices & services**" %}.
 2. Select the NeoPool integration.
 3. Open the three-dot {% icon "mdi:dots-vertical" %} menu, then select **System options**.
 4. Turn off **Enable polling for updates**, then select **Update**.
 
-   ![Screenshot showing the System Options dialog with the Enable polling for updates toggle](/images/screenshots/custom_polling_01.png)
+   ![Screenshot showing the System options dialog with the Enable polling for updates toggle](/images/screenshots/custom_polling_01.png)
 
-With polling off, the integration stops all Modbus communication and makes no reconnect attempts, so an absent controller is never contacted. All entities report `unavailable` rather than serving stale readings, while the config entry, options, and history stay in place. The last known device data is kept, so the entities survive a Home Assistant restart without any reconfiguration. In spring, turn **Enable polling for updates** back on to resume.
+With polling off, the integration stops all Modbus communication, so an absent controller is never contacted. All entities report `unavailable` rather than serving stale readings, while the config entry, options, and history stay in place. The integration still loads after a Home Assistant restart with no reconfiguration. In spring, turn **Enable polling for updates** back on to resume.
 
 ## Reconfigure
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Adds a **Winter mode** section to the NeoPool integration page. In colder climates the pool controller is powered off, and sometimes removed entirely, for the off-season, so polling fails all winter and the log fills with connection errors. The new section tells users to turn off **Enable polling for updates** in the integration's System options, and explains what happens while polling is off: no Modbus traffic, all entities report `unavailable`, and the config entry and history stay in place so setup survives a restart with no reconfiguration.

Reuses the existing System Options screenshot (`custom_polling_01.png`). No new images or includes.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#181648
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
