### PR TITLE
Update Flexit unit ID range to match config flow fix

### DIFF
--- a/source/_integrations/flexit.markdown
+++ b/source/_integrations/flexit.markdown
@@ -40,7 +40,7 @@ Host:
 Port:
   description: "The port of your Flexit CI66 Modbus bridge. Defaults to `502`. Only shown for a network connection."
 Unit ID:
-  description: "The Modbus unit ID of your Flexit unit. Enter a value from `1` through `32`."
+  description: "The Modbus unit ID of your Flexit unit. Enter a value from `1` through `31`."
 {% endconfiguration_basic %}
 
 {% note %}


### PR DESCRIPTION
## Proposed change

Update the Flexit integration documentation to reflect the corrected Modbus unit ID range (`1` through `31`) enforced by the config flow.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#181788
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards