### PR TITLE
Document the Lyngdorf maximum volume sensor

### DIFF
--- a/source/_integrations/lyngdorf.markdown
+++ b/source/_integrations/lyngdorf.markdown
@@ -113,7 +113,7 @@ Diagnostic sensors report what the device is receiving and playing:
 - **Audio information** and **Video information**: The incoming signal formats.
 - **Streaming source**: The active streaming service.
 - **Zone B audio input** and **Zone B streaming source**: The same for Zone B, where present.
-- **Maximum volume**: The volume ceiling set in the device's own menu, above which volume commands have no effect. This sensor is only created on models that report a ceiling, and is disabled by default.
+- **Maximum volume**: The highest volume allowed by the device, set in its own menu. Commands to raise the volume above this limit have no effect. This sensor is only created on models that report a maximum. It is disabled by default.
 
 ## Use cases
 

--- a/source/_integrations/lyngdorf.markdown
+++ b/source/_integrations/lyngdorf.markdown
@@ -113,7 +113,7 @@ Diagnostic sensors report what the device is receiving and playing:
 - **Audio information** and **Video information**: The incoming signal formats.
 - **Streaming source**: The active streaming service.
 - **Zone B audio input** and **Zone B streaming source**: The same for Zone B, where present.
-- **Maximum volume**: The volume ceiling set in the device's own menu. The device clamps anything above it, so the top of the volume slider does nothing while a ceiling is set. Only created on models that report one, and disabled by default.
+- **Maximum volume**: The volume ceiling set in the device's own menu, above which volume commands have no effect. This sensor is only created on models that report a ceiling, and is disabled by default.
 
 ## Use cases
 

--- a/source/_integrations/lyngdorf.markdown
+++ b/source/_integrations/lyngdorf.markdown
@@ -113,6 +113,7 @@ Diagnostic sensors report what the device is receiving and playing:
 - **Audio information** and **Video information**: The incoming signal formats.
 - **Streaming source**: The active streaming service.
 - **Zone B audio input** and **Zone B streaming source**: The same for Zone B, where present.
+- **Maximum volume**: The volume ceiling set in the device's own menu. The device clamps anything above it, so the top of the volume slider does nothing while a ceiling is set. Only created on models that report one, and disabled by default.
 
 ## Use cases
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Documents the maximum volume sensor added in
home-assistant/core#181800.

Lyngdorf processors have a volume ceiling set in the device's own menu, and the
device silently clamps anything written above it, so the top of the volume
slider does nothing with no explanation. On a receiver reporting a `0.0` dB
ceiling against its `-99.9` to `24.0` dB range, that is the top fifth of the
slider. The sensor makes the ceiling visible.

The entry notes both constraints: it is only created on models that report a
ceiling, and it is disabled by default because most owners set none.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/181800
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
