### PR TITLE
Teslemetry: document the Charge on solar Labs preview feature

### DIFF
--- a/source/_integrations/teslemetry.markdown
+++ b/source/_integrations/teslemetry.markdown
@@ -80,7 +80,8 @@ Removing the Teslemetry integration doesn't revoke the access key from your Powe
 ## Entities
 
 These are the entities available in the Teslemetry integration. Not all entities are enabled by default, and not all values are always available.
-Entities in the device tracker platform specifically require the `Vehicle location` scope, and will appear unavailable otherwise. 
+Entities in the device tracker platform specifically require the `Vehicle location` scope, and will appear unavailable otherwise.
+The **Charge on solar** switch and **Charge on solar lower limit** number are part of a Labs preview feature and only appear once you enable it, as described in [Charge on solar](#charge-on-solar) below.
 
 ### Vehicles
 
@@ -168,6 +169,7 @@ Entities in the device tracker platform specifically require the `Vehicle locati
 |Media player|Media player|Yes|Both|
 |Number|Charge current|Yes|Both|
 |Number|Charge limit|Yes|Both|
+|Number|Charge on solar lower limit|Yes|Both|
 |Select|Seat cooler front left|Yes|Both|
 |Select|Seat cooler front right|Yes|Both|
 |Select|Seat heater front left|Yes|Both|
@@ -274,6 +276,7 @@ Entities in the device tracker platform specifically require the `Vehicle locati
 |Switch|Auto seat climate right|Yes|Both|
 |Switch|Auto steering wheel heater|Yes|Both|
 |Switch|Charge|Yes|Both|
+|Switch|Charge on solar|Yes|Both|
 |Switch|Defrost|Yes|Both|
 |Switch|Guest mode|Yes|Streaming|
 |Switch|Sentry mode|Yes|Both|
@@ -342,6 +345,21 @@ Entities in the device tracker platform specifically require the `Vehicle locati
 
 {% include integrations/actions.md %}
 
+## Charge on solar
+
+{% labs %}
+Requires the **Charge on solar** Labs preview feature. Enable it at {% my labs title="**Settings** > **System** > **Labs**" %}.
+{% endlabs %}
+
+Charge on solar lets your Tesla vehicle keep charging while your home has excess solar power, and pause again once that excess runs out. Enabling the **Charge on solar** Labs preview feature adds two entities for each vehicle that has granted the `Vehicle commands` scope:
+
+- A **Charge on solar** switch to turn the mode on or off.
+- A **Charge on solar lower limit** number for the battery percentage the vehicle keeps charging to even without solar, so it doesn't sit too low.
+
+There's no separate upper limit entity for charge on solar. It reuses the vehicle's existing **Charge limit** number as the upper bound, so the lower limit can never be set above it. If you lower the charge limit below the current lower limit, the lower limit follows it down.
+
+If you disable the Labs preview feature, or the `Vehicle commands` scope is no longer granted, both entities are removed until they become available again.
+
 ## Energy dashboard
 
 The Tesla Fleet API only provides power data for Powerwall and Solar products. This means they cannot be used on the energy dashboard directly.
@@ -376,6 +394,7 @@ Energy sites are cloud-polled: live status and site information every 30 seconds
 -   **Vehicle Sleep:** The integration will not actively wake a vehicle to fetch data. However, sending commands (such as locking, unlocking, or climate control) will wake the vehicle.
 -   **Rate Limits:** While Teslemetry handles upstream rate limiting with Tesla, excessive polling or command usage from aggressive automations may encounter temporary API limits.
 -   **Virtual Key:** See [Prerequisites](#prerequisites) for when a virtual key is needed. To set one up, follow the instructions on the [Teslemetry Console](https://teslemetry.com/console).
+-   **Charge on solar assumed state:** Tesla's API doesn't currently report charge on solar's status back from the vehicle, so the **Charge on solar** switch and its lower limit number show the state of the last command you sent rather than confirmed feedback from the vehicle.
 
 ## Troubleshooting
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the Charge on solar Labs preview feature for Teslemetry, which the Teslemetry page did not cover at all.

Charge on solar lets a vehicle keep charging while the home has excess solar, and pause again once that excess runs out. Enabling the Labs preview feature adds two entities per vehicle that has granted the vehicle commands scope: a **Charge on solar** switch, and a **Charge on solar lower limit** number for the battery percentage the vehicle keeps charging to even without solar.

The upper bound is the existing charge limit entity rather than a new control, and the lower limit is capped at that value so it cannot be set above it. Both entities appear only while the Labs preview feature is enabled and the scope is granted, and disappear when either is withdrawn.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/181717
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
