### PR TITLE
Document automatic removal of unshared ScorpionTrack vehicles

### DIFF
--- a/source/_integrations/scorpiontrack.markdown
+++ b/source/_integrations/scorpiontrack.markdown
@@ -88,6 +88,16 @@ Confirm that the ScorpionTrack share still includes vehicles and that the share 
 
 If you report a problem, you can [download diagnostics](/integrations/diagnostics/) from the ScorpionTrack integration. The download uses the most recent cached data and does not make another request to ScorpionTrack. Share tokens, names, registrations, addresses, and coordinates are redacted. Review the file before sharing it.
 
+## Removing a vehicle
+
+After removing a vehicle from the ScorpionTrack share, wait for a successful update in Home Assistant. The vehicle's entities become unavailable, but the device is kept until you choose to delete it.
+
+To delete the device, go to {% my integration domain="scorpiontrack" title="**Settings** > **Devices & services** > **ScorpionTrack**" %}, open the vehicle, and select **Delete** from the {% icon "mdi:dots-vertical" %} menu. Deletion is only allowed when the latest update succeeded and the vehicle is no longer in the share. A vehicle that is still shared cannot be deleted, even if its location is unavailable.
+
+Deleting the device also removes its entities from Home Assistant. It does not delete the vehicle from your ScorpionTrack account.
+
+If you later add that vehicle back to the share, reload the integration to create its device and entities again.
+
 ## Removing the integration
 
 This integration follows standard integration removal.

--- a/source/_integrations/scorpiontrack.markdown
+++ b/source/_integrations/scorpiontrack.markdown
@@ -90,19 +90,26 @@ If you report a problem, you can [download diagnostics](/integrations/diagnostic
 
 ## Removing a vehicle
 
-After removing a vehicle from the ScorpionTrack share, wait for a successful update in Home Assistant. The vehicle's entities become unavailable, but the device is kept until you choose to delete it.
+If a vehicle is no longer part of the ScorpionTrack share, you can delete its device from Home Assistant.
 
-To delete the device:
+### Prerequisites
+
+You can only delete the device when both of these are true:
+
+- The vehicle has been removed from the ScorpionTrack share.
+- Home Assistant has completed a successful update since the vehicle was removed.
+
+After a successful update confirms the vehicle is no longer shared, its entities become unavailable. The device remains until you delete it. A vehicle that is still part of the share cannot be deleted, even if its location is temporarily unavailable.
+
+### To delete the device:
 
 1. Go to {% my integration domain="scorpiontrack" title="**Settings** > **Devices & services** > **ScorpionTrack**" %}.
-2. Open the vehicle's device.
+2. Select the device for the vehicle you removed.
 3. From the {% icon "mdi:dots-vertical" %} menu, select **Delete**.
-
-Deletion is only allowed when the latest update succeeded and the vehicle is no longer in the share. A vehicle that is still shared cannot be deleted, even if its location is unavailable.
 
 Deleting the device also removes its entities from Home Assistant. It does not delete the vehicle from your ScorpionTrack account.
 
-If you later add that vehicle back to the share, reload the integration to create its device and entities again.
+If you add that vehicle back to the share later, reload the integration to create its device and entities again.
 
 ## Removing the integration
 

--- a/source/_integrations/scorpiontrack.markdown
+++ b/source/_integrations/scorpiontrack.markdown
@@ -90,26 +90,9 @@ If you report a problem, you can [download diagnostics](/integrations/diagnostic
 
 ## Removing a vehicle
 
-If a vehicle is no longer part of the ScorpionTrack share, you can delete its device from Home Assistant.
+After a successful update confirms that a vehicle is no longer in the ScorpionTrack share, Home Assistant automatically removes its device and entities. Failed updates or missing location data do not remove a shared vehicle.
 
-### Prerequisites
-
-You can only delete the device when both of these are true:
-
-- The vehicle has been removed from the ScorpionTrack share.
-- Home Assistant has completed a successful update since the vehicle was removed.
-
-After a successful update confirms the vehicle is no longer shared, its entities become unavailable. The device remains until you delete it. A vehicle that is still part of the share cannot be deleted, even if its location is temporarily unavailable.
-
-### To delete the device:
-
-1. Go to {% my integration domain="scorpiontrack" title="**Settings** > **Devices & services** > **ScorpionTrack**" %}.
-2. Select the device for the vehicle you removed.
-3. From the {% icon "mdi:dots-vertical" %} menu, select **Delete**.
-
-Deleting the device also removes its entities from Home Assistant. It does not delete the vehicle from your ScorpionTrack account.
-
-If you add that vehicle back to the share later, reload the integration to create its device and entities again.
+If you add the vehicle back to the share, Home Assistant creates its device and entities on the next successful update. You do not need to reload the integration.
 
 ## Removing the integration
 

--- a/source/_integrations/scorpiontrack.markdown
+++ b/source/_integrations/scorpiontrack.markdown
@@ -92,7 +92,13 @@ If you report a problem, you can [download diagnostics](/integrations/diagnostic
 
 After removing a vehicle from the ScorpionTrack share, wait for a successful update in Home Assistant. The vehicle's entities become unavailable, but the device is kept until you choose to delete it.
 
-To delete the device, go to {% my integration domain="scorpiontrack" title="**Settings** > **Devices & services** > **ScorpionTrack**" %}, open the vehicle, and select **Delete** from the {% icon "mdi:dots-vertical" %} menu. Deletion is only allowed when the latest update succeeded and the vehicle is no longer in the share. A vehicle that is still shared cannot be deleted, even if its location is unavailable.
+To delete the device:
+
+1. Go to {% my integration domain="scorpiontrack" title="**Settings** > **Devices & services** > **ScorpionTrack**" %}.
+2. Open the vehicle's device.
+3. From the {% icon "mdi:dots-vertical" %} menu, select **Delete**.
+
+Deletion is only allowed when the latest update succeeded and the vehicle is no longer in the share. A vehicle that is still shared cannot be deleted, even if its location is unavailable.
 
 Deleting the device also removes its entities from Home Assistant. It does not delete the vehicle from your ScorpionTrack account.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

I am documenting automatic removal of vehicles that are no longer in a ScorpionTrack share. The note explains when removal happens and how a vehicle returns without reloading the integration.

I ran the documentation linters to check the wording and formatting.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/181852
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
