### PR TITLE
Document access token authentication for the Matrix integration

### DIFF
--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -131,8 +131,13 @@ In this case, the integration can't sign in with single sign-on, but it works wi
 
 4. Restart Home Assistant and send a test message. A full restart is needed, because the integration only reads `.matrix.conf` during startup.
 
-{% important %}
-An access token gives full access to the Matrix account. Treat it like a password. If it is ever exposed, end that session on your homeserver and create a new token.
+{% important title="Risk of unauthorized account access" %}
+The access token grants full access to the Matrix account. If the token is exposed, anyone who obtains it can read and send messages as this account until the token is revoked.
+
+To reduce this risk:
+
+- Store the token as securely as a password.
+- If the token is ever exposed, end that session on your homeserver and create a new token.
 {% endimportant %}
 
 ### Event data

--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -106,7 +106,7 @@ On every restart, the integration first tries the saved access token and only si
 
 Because `.matrix.conf` starts with a dot, some backup and file copy tools skip it. Include it when you back up, move, or rebuild your installation, so that the integration keeps its session.
 
-#### Homeservers that don't allow password sign-in
+#### Setting up authentication with an access token
 
 Some homeservers don't allow accounts to sign in with a password at all. This is the case, for example, on a homeserver that uses Matrix Authentication Service together with an external single sign-on provider, and has password sign-in turned off.
 

--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -112,22 +112,21 @@ Some homeservers don't allow accounts to sign in with a password. For example, o
 
 In this case, the integration can't sign in with single sign-on, but it works with an access token that you create yourself:
 
+{% important %}
+
+**Risk of unauthorized account access**
+
+The access token grants full access to the Matrix account. If the token is exposed, anyone who obtains it can read and send messages as this account until the token is revoked.
+
+To reduce this risk:
+
+- Store the token as securely as a password.
+- If the token is ever exposed, end that session on your homeserver and create a new token.
+{% endimportant %}
 1. On your homeserver, create an access token for the Matrix account that Home Assistant uses. How you do this depends on your homeserver:
 
    - On a homeserver that uses [Matrix Authentication Service](https://element-hq.github.io/matrix-authentication-service/), an administrator can create a long-lived compatibility token with the [`mas-cli manage issue-compatibility-token`](https://element-hq.github.io/matrix-authentication-service/reference/cli/manage.html#manage-issue-compatibility-token) command. It takes the local part of the Matrix ID, for example `my_matrix_bot`, and not the full Matrix ID. The token is shown only once, so copy it right away.
    - On a Synapse homeserver without Matrix Authentication Service, an administrator can use the [login as a user](https://element-hq.github.io/synapse/latest/admin_api/user_admin_api.html#login-as-a-user) admin API. By default, the tokens it returns do not expire.
-
-    {% important %}
-    
-    **Risk of unauthorized account access**
-    
-    The access token grants full access to the Matrix account. If the token is exposed, anyone who obtains it can read and send messages as this account until the token is revoked.
-    
-    To reduce this risk:
-    
-    - Store the token as securely as a password.
-    - If the token is ever exposed, end that session on your homeserver and create a new token.
-    {% endimportant %}
     
 2. Create or edit the file `.matrix.conf` in your configuration directory. It holds one entry per Matrix ID:
 

--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -118,14 +118,14 @@ In this case, the integration can't sign in with single sign-on, but it works wi
    - On a Synapse homeserver without Matrix Authentication Service, an administrator can use the [login as a user](https://element-hq.github.io/synapse/latest/admin_api/user_admin_api.html#login-as-a-user) admin API. By default, the tokens it returns do not expire.
     {% important %}
     
-      **Risk of unauthorized account access**
-      
-      The access token grants full access to the Matrix account. If the token is exposed, anyone who obtains it can read and send messages as this account until the token is revoked.
-      
-      To reduce this risk:
-      
-      - Store the token as securely as a password.
-      - If the token is ever exposed, end that session on your homeserver and create a new token.
+    **Risk of unauthorized account access**
+    
+    The access token grants full access to the Matrix account. If the token is exposed, anyone who obtains it can read and send messages as this account until the token is revoked.
+    
+    To reduce this risk:
+    
+    - Store the token as securely as a password.
+    - If the token is ever exposed, end that session on your homeserver and create a new token.
     {% endimportant %}
 2. Create or edit the file `.matrix.conf` in your configuration directory. It holds one entry per Matrix ID:
 

--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -116,7 +116,17 @@ In this case, the integration can't sign in with single sign-on, but it works wi
 
    - On a homeserver that uses [Matrix Authentication Service](https://element-hq.github.io/matrix-authentication-service/), an administrator can create a long-lived compatibility token with the [`mas-cli manage issue-compatibility-token`](https://element-hq.github.io/matrix-authentication-service/reference/cli/manage.html#manage-issue-compatibility-token) command. It takes the local part of the Matrix ID, for example `my_matrix_bot`, and not the full Matrix ID. The token is shown only once, so copy it right away.
    - On a Synapse homeserver without Matrix Authentication Service, an administrator can use the [login as a user](https://element-hq.github.io/synapse/latest/admin_api/user_admin_api.html#login-as-a-user) admin API. By default, the tokens it returns do not expire.
-
+    {% important %}
+    
+      **Risk of unauthorized account access**
+      
+      The access token grants full access to the Matrix account. If the token is exposed, anyone who obtains it can read and send messages as this account until the token is revoked.
+      
+      To reduce this risk:
+      
+      - Store the token as securely as a password.
+      - If the token is ever exposed, end that session on your homeserver and create a new token.
+    {% endimportant %}
 2. Create or edit the file `.matrix.conf` in your configuration directory. It holds one entry per Matrix ID:
 
    ```json
@@ -130,17 +140,6 @@ In this case, the integration can't sign in with single sign-on, but it works wi
 3. Keep the `password` option in your configuration. It is required, but it is not used while the access token works. If the account has no password, you can enter any text as its value.
 
 4. Restart Home Assistant and send a test message. A full restart is needed, because the integration only reads `.matrix.conf` during startup.
-
-      {% important %}
-      **Risk of unauthorized account access**
-      
-      The access token grants full access to the Matrix account. If the token is exposed, anyone who obtains it can read and send messages as this account until the token is revoked.
-      
-      To reduce this risk:
-      
-      - Store the token as securely as a password.
-      - If the token is ever exposed, end that session on your homeserver and create a new token.
-      {% endimportant %}
 
 ### Event data
 

--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -108,7 +108,7 @@ Because `.matrix.conf` starts with a dot, some backup and file copy tools skip i
 
 #### Setting up authentication with an access token
 
-Some homeservers don't allow accounts to sign in with a password at all. This is the case, for example, on a homeserver that uses Matrix Authentication Service together with an external single sign-on provider, and has password sign-in turned off.
+Some homeservers don't allow accounts to sign in with a password. For example, on a homeserver that uses Matrix Authentication Service together with an external single sign-on provider and has password sign-in turned off.
 
 The integration can't sign in with single sign-on, but it works with an access token that you create yourself:
 

--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -131,14 +131,16 @@ In this case, the integration can't sign in with single sign-on, but it works wi
 
 4. Restart Home Assistant and send a test message. A full restart is needed, because the integration only reads `.matrix.conf` during startup.
 
-{% important title="Risk of unauthorized account access" %}
-The access token grants full access to the Matrix account. If the token is exposed, anyone who obtains it can read and send messages as this account until the token is revoked.
-
-To reduce this risk:
-
-- Store the token as securely as a password.
-- If the token is ever exposed, end that session on your homeserver and create a new token.
-{% endimportant %}
+      {% important %}
+      **Risk of unauthorized account access**
+      
+      The access token grants full access to the Matrix account. If the token is exposed, anyone who obtains it can read and send messages as this account until the token is revoked.
+      
+      To reduce this risk:
+      
+      - Store the token as securely as a password.
+      - If the token is ever exposed, end that session on your homeserver and create a new token.
+      {% endimportant %}
 
 ### Event data
 

--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -48,7 +48,7 @@ username:
   required: true
   type: string
 password:
-  description: The password for your Matrix account.
+  description: "The password for your Matrix account. It is only used when there is no valid access token stored yet. See [Authentication](#authentication)."
   required: true
   type: string
 homeserver:
@@ -97,6 +97,43 @@ commands:
 {% warning %}
 To prevent infinite loops when reacting to commands, you have to use a separate account for the Matrix integration.
 {% endwarning %}
+
+### Authentication
+
+The integration signs in with the username and password from your configuration. After a successful sign-in, it saves the access token that the homeserver returned to a file named `.matrix.conf` in your configuration directory, next to your {% term "`configuration.yaml`" %} file.
+
+On every restart, the integration first tries the saved access token and only signs in with the password if the homeserver rejects that token. The file is only created after the first successful sign-in, so it is normal that it is not there yet on a new installation.
+
+Because `.matrix.conf` starts with a dot, some backup and file copy tools skip it. Include it when you back up, move, or rebuild your installation, so that the integration keeps its session.
+
+#### Homeservers that don't allow password sign-in
+
+Some homeservers don't allow accounts to sign in with a password at all. This is the case, for example, on a homeserver that uses Matrix Authentication Service together with an external single sign-on provider, and has password sign-in turned off.
+
+The integration can't sign in with single sign-on, but it works with an access token that you create yourself:
+
+1. On your homeserver, create an access token for the Matrix account that Home Assistant uses. How you do this depends on your homeserver:
+
+   - On a homeserver that uses [Matrix Authentication Service](https://element-hq.github.io/matrix-authentication-service/), an administrator can create a long-lived compatibility token with the [`mas-cli manage issue-compatibility-token`](https://element-hq.github.io/matrix-authentication-service/reference/cli/manage.html#manage-issue-compatibility-token) command. It takes the local part of the Matrix ID, for example `my_matrix_bot`, and not the full Matrix ID. The token is shown only once, so copy it right away.
+   - On a Synapse homeserver without Matrix Authentication Service, an administrator can use the [login as a user](https://element-hq.github.io/synapse/latest/admin_api/user_admin_api.html#login-as-a-user) admin API. By default, the tokens it returns do not expire.
+
+2. Create or edit the file `.matrix.conf` in your configuration directory. It holds one entry per Matrix ID:
+
+   ```json
+   {
+     "@my_matrix_bot:example.com": "YOUR_ACCESS_TOKEN"
+   }
+   ```
+
+   If the file already exists, change only the value that belongs to your Matrix ID and leave the rest of the file as it is. Make sure Home Assistant can read the file.
+
+3. Keep the `password` option in your configuration. It is required, but it is not used while the access token works. If the account has no password, you can enter any text as its value.
+
+4. Restart Home Assistant and send a test message. A full restart is needed, because the integration only reads `.matrix.conf` during startup.
+
+{% important %}
+An access token gives full access to the Matrix account. Treat it like a password. If it is ever exposed, end that session on your homeserver and create a new token.
+{% endimportant %}
 
 ### Event data
 
@@ -282,3 +319,26 @@ data:
 ```
 
 {% include integrations/actions.md %}
+
+## Troubleshooting
+
+### Home Assistant stopped sending Matrix messages
+
+#### Symptom: "Login failed, both token and username/password are invalid"
+
+Messages are no longer delivered to your Matrix rooms, and {% my logs title="**Settings** > **System** > **Logs**" %} shows the message `Login failed, both token and username/password are invalid`.
+
+#### Description
+
+The homeserver rejected the saved access token, and signing in with the password did not work either. The saved access token stops working when one of the following happens:
+
+- The session or the device of the Matrix account was ended on the homeserver, for example by signing the account out everywhere.
+- The file `.matrix.conf` was deleted.
+- The homeserver ends sessions that were inactive for a long time.
+
+Normally, the integration then signs in again with the password. On a homeserver that doesn't allow password sign-in, that is not possible, so the integration stays signed out until you provide a new access token.
+
+#### Resolution
+
+- If your homeserver allows password sign-in, check the `username` and `password` options in your {% term "`configuration.yaml`" %} file, then restart Home Assistant.
+- If your homeserver doesn't allow password sign-in, create a new access token and save it in `.matrix.conf`, as described in [Homeservers that don't allow password sign-in](#homeservers-that-dont-allow-password-sign-in).

--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -110,7 +110,7 @@ Because `.matrix.conf` starts with a dot, some backup and file copy tools skip i
 
 Some homeservers don't allow accounts to sign in with a password. For example, on a homeserver that uses Matrix Authentication Service together with an external single sign-on provider and has password sign-in turned off.
 
-The integration can't sign in with single sign-on, but it works with an access token that you create yourself:
+In this case, the integration can't sign in with single sign-on, but it works with an access token that you create yourself:
 
 1. On your homeserver, create an access token for the Matrix account that Home Assistant uses. How you do this depends on your homeserver:
 

--- a/source/_integrations/matrix.markdown
+++ b/source/_integrations/matrix.markdown
@@ -116,6 +116,7 @@ In this case, the integration can't sign in with single sign-on, but it works wi
 
    - On a homeserver that uses [Matrix Authentication Service](https://element-hq.github.io/matrix-authentication-service/), an administrator can create a long-lived compatibility token with the [`mas-cli manage issue-compatibility-token`](https://element-hq.github.io/matrix-authentication-service/reference/cli/manage.html#manage-issue-compatibility-token) command. It takes the local part of the Matrix ID, for example `my_matrix_bot`, and not the full Matrix ID. The token is shown only once, so copy it right away.
    - On a Synapse homeserver without Matrix Authentication Service, an administrator can use the [login as a user](https://element-hq.github.io/synapse/latest/admin_api/user_admin_api.html#login-as-a-user) admin API. By default, the tokens it returns do not expire.
+
     {% important %}
     
     **Risk of unauthorized account access**
@@ -127,6 +128,7 @@ In this case, the integration can't sign in with single sign-on, but it works wi
     - Store the token as securely as a password.
     - If the token is ever exposed, end that session on your homeserver and create a new token.
     {% endimportant %}
+    
 2. Create or edit the file `.matrix.conf` in your configuration directory. It holds one entry per Matrix ID:
 
    ```json


### PR DESCRIPTION
## Proposed change
 The Matrix integration signs in with a username and password, but it stores the resulting access token in `.matrix.conf` and prefers that token on every start.

None of this is currently documented documented, which makes two situations hard to resolve:
 - Homeservers that do not allow password sign-in at all, for example when they use Matrix Authentication Service with an external single sign-on provider. The integration cannot sign in there, even though it works fine with an access token
that the administrator provides in `.matrix.conf`.
- Installations where the saved token becomes invalid, for example after the session is ended on the homeserver or after `.matrix.conf` is lost during a migration or restore. The integration then falls back to the password, and on a homeserver
without password sign-in it stops delivering messages with only a log entry.

 This PR adds to `source/_integrations/matrix.markdown`:
 - An **Authentication** section that explains the token-first sign-in, where `.matrix.conf` lives, and that the file is easy to miss during backups because it is a hidden file.
- A **Homeservers that don't allow password sign-in** section with the steps to create an access token and write it to `.matrix.conf`, including the note that the `password` option must stay in the configuration because it is required by the
schema.
- A **Troubleshooting** entry for `Login failed, both token and username/password are invalid`, with the causes and the resolution.
- A pointer from the `password` option description to the new section.

 The described behavior was verified against
`homeassistant/components/matrix/__init__.py` on `dev`: `SESSION_FILE = ".matrix.conf"`, `_login()` calls `restore_login()` and validates it with `whoami()` before the password branch, `_store_auth_token()` writes the file with `private=True`, and `CONFIG_SCHEMA` still has `vol.Required(CONF_PASSWORD)`. This behavior has been in place since 2023.10.0.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Related core issue: home-assistant/core#104138

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
