### PR TITLE
Document the tile card state position option

### DIFF
--- a/source/_dashboards/tile.markdown
+++ b/source/_dashboards/tile.markdown
@@ -71,6 +71,12 @@ time_format:
   description: >
     Controls how timestamps in `state_content` are formatted. Valid values are `relative`, `total`, `date`, `time`, and `datetime`. Can also be defined as a map with a `type` key and an optional `style` key (`long` or `short`).
   type: [string, map]
+state_position:
+  required: false
+  description: >
+    Position of the state on the tile card. Can be `secondary` or `inline`. With `secondary`, the state is displayed below the name. With `inline`, the state is displayed next to the name, at the end of the same row. The `inline` value is not available when `vertical` is enabled, and it forces the features to the bottom of the card.
+  type: string
+  default: secondary
 tap_action:
   required: false
   description: Action taken on card tap. See [action documentation](/dashboards/actions/#tap-action). By default, it will show the "more-info" dialog.
@@ -101,7 +107,8 @@ features:
   type: list
 features_position:
   required: false
-  description: Position of the features on the tile card. Can be `bottom` or `inline`. When set to `inline`, the first feature is displayed next to the name and any remaining features are displayed below it, two per row. A feature that is alone on a row takes the full width. `inline` is not compatible with the `vertical` option.
+  description: >
+    Position of the features on the tile card. Can be `bottom` or `inline`. When set to `inline`, the first feature is displayed next to the name and any remaining features are displayed below it, two per row. A feature that is alone on a row takes the full width. The `inline` value is not available when `vertical` is enabled, or when the state is placed inline.
   type: string
   default: bottom
 
@@ -143,6 +150,12 @@ state_content:
   - state
   - brightness
   - last-changed
+```
+
+```yaml
+type: tile
+entity: select.home_mode
+state_position: inline
 ```
 
 ```yaml


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->

## Proposed change

<!--
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the
    additional information section.
-->

Documents the new `state_position` option on the tile card. The default value `secondary` keeps the state below the name, which is the current behavior. `state_position: inline` moves the state next to the name, at the end of the same row.

The change has three parts:

- A `state_position` entry in the configuration table.
- One sentence added to `features_position`, because the inline features value is now incompatible with `state_position: inline` as well as with `vertical`.
- A short YAML example.

## Type of change

<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/frontend/pull/54110
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

