### PR TITLE
Document additional meter value sensors for WattWächter Plus

### DIFF
--- a/source/_integrations/wattwaechter.markdown
+++ b/source/_integrations/wattwaechter.markdown
@@ -52,11 +52,14 @@ The WattWächter Plus provides sensors that are based on your smart meter's repo
 - **Total feed-in (kWh)**: Total energy exported (fed back into the grid).
 - **Consumption tariff 1 / 2 (kWh)**: Energy consumption per tariff, if your meter supports dual tariffs.
 - **Feed-in tariff 1 / 2 (kWh)**: Energy feed-in per tariff.
+- **Absolute energy (kWh)**: Total energy regardless of direction, if reported by your meter.
+- **Reactive energy consumption / feed-in (kvarh)**: Reactive energy totals, if reported by your meter.
 
 ### Power sensors
 
 - **Active power (W)**: Current power being consumed or fed in. Negative values indicate feed-in.
 - **Active power L1 / L2 / L3 (W)**: Active power per phase.
+- **Maximum demand (kW)**: The maximum power demand, if reported by your meter.
 
 ### Voltage and current sensors
 
@@ -70,7 +73,7 @@ The WattWächter Plus provides sensors that are based on your smart meter's repo
 
 ### Additional meter values
 
-Smart meters can report values beyond the well-known ones listed above. The integration creates a sensor for every additional OBIS code your meter reports, deriving the sensor type from the reported unit. Cumulative energy registers are recorded as continuously increasing totals, and device metadata such as the meter's serial number is created as diagnostic entities.
+Smart meters can report values beyond the well-known ones listed above. The integration creates a sensor for every additional OBIS code your meter reports, deriving the sensor type from the reported unit. Cumulative energy registers are recorded as continuously increasing totals, and device metadata such as the meter's serial number is created as diagnostic entities. These additional sensors are disabled by default; enable the ones you need from the device page.
 
 ### Diagnostic sensors
 

--- a/source/_integrations/wattwaechter.markdown
+++ b/source/_integrations/wattwaechter.markdown
@@ -68,6 +68,10 @@ The WattWächter Plus provides sensors that are based on your smart meter's repo
 - **Grid frequency (Hz)**: The current grid frequency.
 - **Power factor / Power factor L1 / L2 / L3**: The power factor (total and per phase).
 
+### Additional meter values
+
+Smart meters can report values beyond the well-known ones listed above. The integration creates a sensor for every additional OBIS code your meter reports, deriving the sensor type from the reported unit. Cumulative energy registers are recorded as continuously increasing totals, and device metadata such as the meter's serial number is created as diagnostic entities.
+
 ### Diagnostic sensors
 
 The following sensors are created with the diagnostic entity category and are disabled by default:


### PR DESCRIPTION
## Proposed change

Documents the generic OBIS sensors added to the WattWächter Plus integration by home-assistant/core#181880: every OBIS code the meter reports beyond the well-known ones now creates a sensor, with the sensor type derived from the reported unit and device metadata exposed as diagnostic entities.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#181880
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
