### PR TITLE
Document Flexit sensor entities

### DIFF
--- a/source/_integrations/flexit.markdown
+++ b/source/_integrations/flexit.markdown
@@ -4,12 +4,14 @@ description: Instructions on how to integrate a Flexit air handling unit into Ho
 ha_category:
   - Binary sensor
   - Climate
+  - Sensor
 ha_release: 0.47
 ha_iot_class: Local Polling
 ha_domain: flexit
 ha_platforms:
   - binary_sensor
   - climate
+  - sensor
 ha_integration_type: device
 ha_quality_scale: legacy
 ha_codeowners:
@@ -69,6 +71,16 @@ The following binary sensors are categorized as diagnostic entities:
 
 - **Filter alarm**: Indicates whether the unit needs a filter replacement.
 - **Electric heater enabled**: Indicates whether the electric heater is enabled.
+
+### Sensors
+
+The following sensors are categorized as diagnostic entities:
+
+- **Air filter operating time**: The number of hours the current air filter has been in use.
+- **Heat exchanger regulation**: The current regulation level of the heat exchanger.
+- **Electric heater regulation**: The current regulation level of the electric heater.
+- **Cooling regulation**: The current regulation level of the cooling function.
+- **Outdoor air temperature**: The temperature of the air entering the unit from outside.
 
 ## Data updates
 


### PR DESCRIPTION
## Proposed change

Document the new diagnostic sensor entities added to the Flexit integration: air filter operating time, heat exchanger regulation, electric heater regulation, cooling regulation, and outdoor air temperature.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#181882
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards