### PR TITLE
Document the duration selector modes

### DIFF
--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -750,10 +750,10 @@ enable_millisecond:
   type: boolean
   default: false
   required: false
-allow_negative:
-  description: When `true`, the duration selector will allow for selecting positive or negative values.
-  type: boolean
-  default: false
+mode:
+  description: "Whether the duration can be negative. With `positive`, only positive durations can be entered. With `signed`, the field gets a sign picker, which suits values that can go both ways, like a time correction. With `offset`, the user first chooses between **No offset**, **Before**, and **After**, then enters the duration. This suits times relative to an event, like sunrise or the start of a calendar event."
+  type: string
+  default: positive
   required: false
 {% endconfiguration %}
 
@@ -766,6 +766,16 @@ hours: 12
 minutes: 30
 seconds: 15 # Only when enable_second is set to true (default)
 milliseconds: 500 # Only when enable_millisecond was set to true
+```
+
+With the `signed` and `offset` modes, the time values stay positive. A `negative` key set to `true` means that the duration is negative, or that the offset lies before the event. For a positive duration, or an offset after the event, the key is left out. Choosing **No offset** gives a duration of zero.
+
+```yaml
+# Example output for 30 minutes before the event
+negative: true
+hours: 0
+minutes: 30
+seconds: 0
 ```
 
 ## Entity selector

--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -751,7 +751,7 @@ enable_millisecond:
   default: false
   required: false
 mode:
-  description: "Whether the duration can be negative. With `positive`, only positive durations can be entered. With `signed`, the field gets a sign picker, which suits values that can go both ways, like a time correction. With `offset`, the user first chooses between **No offset**, **Before**, and **After**, then enters the duration. This suits times relative to an event, like sunrise or the start of a calendar event."
+  description: "Whether the duration can be negative. `positive` only lets you enter positive durations. `signed` provides a picker showing values that can go both ways, like a time correction. `offset` lets you choose between **No offset**, **Before**, and **After**, and then enter the duration. Offset suits times relative to an event, like sunrise or the start of a calendar event."
   type: string
   default: positive
   required: false


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Documents the new `mode` option of the duration selector (`positive`, `signed`, `offset`) and the `negative` key in its output. The `allow_negative` option is removed from the page, it is kept in Home Assistant only as a legacy alias of `mode: signed`.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/181884, https://github.com/home-assistant/frontend/pull/54111
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

