### PR TITLE
Style the Get started menu item as a button

### DIFF
--- a/sass/homeassistant/_overrides.scss
+++ b/sass/homeassistant/_overrides.scss
@@ -543,6 +543,50 @@ dd {
   box-shadow: inset 0px -5px rgba($white, .5);
 }
 
+// Call-to-action pill in the main menu, matching the homepage hero button.
+// Declared after the .dark hover rules so it wins the equal-specificity tie.
+.menu>li>a.primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 16px;
+  // Sits the pill's label on the same line as the other menu items, whose
+  // 29px top padding puts their text centre 2px below the bar's centre.
+  margin: 19px 14px 15px;
+  background: $link-color;
+  border-radius: 32px;
+  color: $white;
+  font-family: $heading-font;
+  font-weight: 700;
+  text-transform: uppercase;
+  transition: background-color .33s;
+
+  &:hover,
+  &:focus {
+    padding: 10px 16px;
+    margin: 19px 14px 15px;
+    background: $primary-color;
+    box-shadow: none;
+    color: $white;
+  }
+
+  // Keep the same pill in the collapsed menu. That menu sets its own width,
+  // padding and margin with !important, so the pill has to answer in kind.
+  @media only screen and (max-width: $menu-collapse) {
+    width: auto;
+    padding: 12px 20px !important;
+    // Symmetric so the pill centres against the search button beside it.
+    margin: 12px 24px !important;
+
+    &:hover,
+    &:focus {
+      background: $primary-color;
+      box-shadow: none;
+      color: $white;
+    }
+  }
+}
+
 .site-header {
   position: relative;
 

--- a/sass/homeassistant/_overrides.scss
+++ b/sass/homeassistant/_overrides.scss
@@ -499,11 +499,16 @@ dd {
   a {
     @include box-sizing(border-box);
     display: block;
+    // Space is tightest just above the collapse breakpoint, where the bar has
+    // around 738px to fit roughly 717px of items. The side margin is trimmed
+    // to buy that headroom, and nowrap below stops the longer labels breaking
+    // onto a second line. Both are needed to keep the bar to one line.
     padding: 29px 0px 12px;
-    margin: 0 14px 27px;
+    margin: 0 11px 27px;
     text-decoration: none;
     font-size: 14px;
     line-height: 1;
+    white-space: nowrap;
   }
 
   iconify-icon {
@@ -552,7 +557,7 @@ dd {
   padding: 10px 16px;
   // Sits the pill's label on the same line as the other menu items, whose
   // 29px top padding puts their text centre 2px below the bar's centre.
-  margin: 19px 14px 15px;
+  margin: 19px 11px 15px;
   background: $link-color;
   border-radius: 32px;
   color: $white;
@@ -564,7 +569,7 @@ dd {
   &:hover,
   &:focus {
     padding: 10px 16px;
-    margin: 19px 14px 15px;
+    margin: 19px 11px 15px;
     background: $primary-color;
     box-shadow: none;
     color: $white;

--- a/sass/homeassistant/base/_navigation.scss
+++ b/sass/homeassistant/base/_navigation.scss
@@ -32,9 +32,13 @@ body {
 .toggle {
   display: none;
 }
+// Laid out with flexbox rather than floats so the visual order of individual
+// items can differ between the desktop bar and the collapsed menu.
+.menu {
+  display: flex;
+}
 .menu li {
   list-style: none;
-  float: left;
 }
 
 // @media only screen and (max-width: $lap-end){
@@ -70,8 +74,11 @@ body {
     -webkit-user-select: none;
     user-select: none;
   }
+  // A wrapping row rather than a column: items are full width so they each
+  // take a line, which lets the search and call to action opt out and pair up.
   #toggle:checked ~ .menu {
-    display: block;
+    display: flex;
+    flex-wrap: wrap;
     opacity: 1;
     z-index: 999;
   }
@@ -218,5 +225,34 @@ header .grid {
     top: 0;
     box-shadow: none;
     margin-left: 24px;
+  }
+
+  // Lift search and the call to action to the top of the collapsed menu and
+  // sit them side by side. They share an order value so they keep their
+  // source order relative to each other, and width: auto opts them out of the
+  // full-width rule above so both fit on one line.
+  .menu > .nav-search,
+  .menu > .nav-cta {
+    width: auto;
+    align-self: center;
+  }
+
+  .menu > .nav-search{
+    order: -1;
+  }
+
+  .menu > .nav-cta {
+    order: -2;
+  }
+
+  .menu > .nav-search .docsearch {
+    width: auto;
+  }
+
+  // The DocSearch button carries its own 24px side margins on small screens,
+  // which pushes the icon away from the call to action sitting next to it.
+  .menu > .nav-search .DocSearch-Button {
+    margin-left: 0;
+    margin-right: 0;
   }
 }

--- a/sass/homeassistant/base/_navigation.scss
+++ b/sass/homeassistant/base/_navigation.scss
@@ -227,22 +227,24 @@ header .grid {
     margin-left: 24px;
   }
 
-  // Lift search and the call to action to the top of the collapsed menu and
-  // sit them side by side. They share an order value so they keep their
-  // source order relative to each other, and width: auto opts them out of the
-  // full-width rule above so both fit on one line.
+  // Lift the call to action and search to the top of the collapsed menu and
+  // sit them side by side. Every other item keeps the full width set above, so
+  // it takes a line of its own; width: auto opts these two out of that and
+  // lets them share one line.
   .menu > .nav-search,
   .menu > .nav-cta {
     width: auto;
     align-self: center;
   }
 
-  .menu > .nav-search{
-    order: -1;
-  }
-
+  // Both come before the default order of 0. The call to action leads, with
+  // search beside it, reversing the order they appear in on the desktop bar.
   .menu > .nav-cta {
     order: -2;
+  }
+
+  .menu > .nav-search {
+    order: -1;
   }
 
   .menu > .nav-search .docsearch {

--- a/source/_includes/site/header.html
+++ b/source/_includes/site/header.html
@@ -25,7 +25,6 @@
           data-close="⨉"
         ></label>
         <ul class="menu pull-right">
-          <li><a {% if root == 'getting-started' or root == 'installation' %}class="active"{% endif %} href="/installation/">Getting started</a></li>
           <li>
             <a {% if root == 'docs' or root == 'dashboards' or root == 'voice_control' or root == 'common-tasks' %}class="active"{% endif %} href="/docs/">Documentation {% icon "mdi:chevron-down" %}</a>
             <ul>
@@ -51,9 +50,10 @@
           <li><a {% if root == 'integrations' %}class="active"{% endif %} href="/integrations/">Integrations</a></li>
           <li><a {% if root == 'blog' %}class="active"{% endif %} href="/blog/">Blog</a></li>
           <li><a {% if root == 'help' %}class="active"{% endif %} href="/help/">Need help?</a></li>
-          <li>
+          <li class="nav-search">
             <div class="docsearch" id="docsearch"></div>
           </li>
+          <li class="nav-cta"><a class="primary{% if root == 'getting-started' or root == 'installation' %} active{% endif %}" href="/installation/">Get started {% icon "mdi:arrow-right" %}</a></li>
         </ul>
       </nav>
     </div>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Styles the "Get started" item in the main menu as a button, matching the
primary call to action on the homepage hero: same colour, pill radius,
uppercase Figtree and arrow icon. The item moves to the end of the menu so
the call to action sits at the far right inline with best practices, and the label is shortened from
"Getting started" to "Get started" to match the button.

To let the mobile menu order items differently from the desktop bar, the
menu now lays out with flexbox instead of floats. This is intended to be
visually identical on desktop, and every item sits at the same position as
before.

Below the 1140px breakpoint, the call to action and search are lifted to the
top of the menu and share a single line, with the button keeping its pill
styling and a slightly larger tap target. Without this change, the buttons sit below the fold.


Before:

<img width="839" height="109" alt="image" src="https://github.com/user-attachments/assets/653a55f6-947a-4099-8612-b67d6436d7d9" />

After: 

<img width="799" height="79" alt="image" src="https://github.com/user-attachments/assets/f5008ab1-73f6-4566-8a9c-674c32d9a17a" />


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
