### PR TITLE
Warn about and/or not returning booleans in template condition docs

### DIFF
--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -668,15 +668,17 @@ Within an automation, template conditions also have access to the `trigger` vari
 Be careful when combining `and`/`or` with a value that isn't already a boolean, such as a list, string, or number. In Python and Jinja, `and`/`or` don't always evaluate to a boolean — they return whichever operand determined the result. For example:
 
 ```yaml
-condition: template
-value_template: "{{ some_list is defined and some_list }}"
+conditions:
+  - condition: template
+    value_template: "{{ some_list is defined and some_list }}"
 ```
 
-If `some_list` is a non-empty list like `[255, 0, 0]`, this renders as the list itself (`[255, 0, 0]`), not `true`. Since a template condition only passes when the rendered result is exactly `true`, the condition silently fails even though `some_list` is genuinely defined and non-empty. Force a real boolean with a comparison instead:
+If `some_list` is a non-empty list like `[255, 0, 0]`, this renders as the list itself (`[255, 0, 0]`), not `true`. Since a template condition only passes when the rendered result is the (case-insensitive) string `true`, the condition silently fails even though `some_list` is genuinely defined and non-empty. Force a real boolean with a comparison instead:
 
 ```yaml
-condition: template
-value_template: "{{ some_list is defined and some_list | length > 0 }}"
+conditions:
+  - condition: template
+    value_template: "{{ some_list is defined and some_list | length > 0 }}"
 ```
 {% endnote %}
 

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -664,23 +664,22 @@ conditions:
 
 Within an automation, template conditions also have access to the `trigger` variable as [described here][automation-templating].
 
-{% note %}
-Be careful when combining `and`/`or` with a value that isn't already a boolean, such as a list, string, or number. In Python and Jinja, `and`/`or` don't always evaluate to a boolean — they return whichever operand determined the result. For example:
+{% important %}
+Be careful when combining `and`/`or` with a value that isn't already a boolean, such as a list, string, or number. In Python and Jinja, `and`/`or` don't always evaluate to a boolean. Instead, they return whichever operand determined the result. For example, if `some_list` is a non-empty list like `[255, 0, 0]`:
+
+{% example %}
+template: |
+  {{ some_list is defined and some_list }}
+output: |
+  [255, 0, 0]
+{% endexample %}
+
+This renders as the list itself, not `true`. Since a template condition only passes when the rendered result is the (case-insensitive) string `true`, the condition silently fails even though `some_list` is genuinely defined and non-empty. Force a real boolean with a comparison instead:
 
 ```yaml
-conditions:
-  - condition: template
-    value_template: "{{ some_list is defined and some_list }}"
+conditions: "{{ some_list is defined and some_list | length > 0 }}"
 ```
-
-If `some_list` is a non-empty list like `[255, 0, 0]`, this renders as the list itself (`[255, 0, 0]`), not `true`. Since a template condition only passes when the rendered result is the (case-insensitive) string `true`, the condition silently fails even though `some_list` is genuinely defined and non-empty. Force a real boolean with a comparison instead:
-
-```yaml
-conditions:
-  - condition: template
-    value_template: "{{ some_list is defined and some_list | length > 0 }}"
-```
-{% endnote %}
+{% endimportant %}
 
 #### Template condition shorthand notation
 

--- a/source/_docs/scripts/conditions.markdown
+++ b/source/_docs/scripts/conditions.markdown
@@ -664,6 +664,22 @@ conditions:
 
 Within an automation, template conditions also have access to the `trigger` variable as [described here][automation-templating].
 
+{% note %}
+Be careful when combining `and`/`or` with a value that isn't already a boolean, such as a list, string, or number. In Python and Jinja, `and`/`or` don't always evaluate to a boolean — they return whichever operand determined the result. For example:
+
+```yaml
+condition: template
+value_template: "{{ some_list is defined and some_list }}"
+```
+
+If `some_list` is a non-empty list like `[255, 0, 0]`, this renders as the list itself (`[255, 0, 0]`), not `true`. Since a template condition only passes when the rendered result is exactly `true`, the condition silently fails even though `some_list` is genuinely defined and non-empty. Force a real boolean with a comparison instead:
+
+```yaml
+condition: template
+value_template: "{{ some_list is defined and some_list | length > 0 }}"
+```
+{% endnote %}
+
 #### Template condition shorthand notation
 
 The template condition has a shorthand notation that can be used to make your scripts and automations shorter.


### PR DESCRIPTION
## Proposed change

`condition: template` (and the shorthand `conditions: "{{ ... }}"`) only passes when the rendered result is the case-insensitive string `true`. `and`/`or` in Python/Jinja don't coerce to a boolean, they return whichever operand determined the result. So `{{ x is defined and x }}` renders as the value of `x` itself (for example, a non-empty list) when `x` is truthy, not `true`, and the condition silently fails even though `x` is genuinely defined and non-empty.

I hit this for real in a script that only worked when a `color_rgb` field was passed: the condition guarding the color branch used `color_rgb is defined and color_rgb`, which never rendered `true` for a non-empty list, so the color was silently never applied.

This PR adds an `{% important %}` box to the Template condition section with a minimal reproducible example (using the `{% example %}` tag to show the actual rendered output) and the fix, right after the existing basic example.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue:
- I checked for an existing issue/PR about this first. The closest one I found, [#143892](https://github.com/home-assistant/core/issues/143892), is about a different (and already resolved as "working as designed") native-typing quirk with lowercase `true`/`false`, not this `and`/`or` operand-passthrough pitfall.
- I checked the current `homeassistant/helpers/condition.py` source to confirm `condition: template` renders with `parse_result=False` and compares the lowercased string against `"true"`, and verified locally that `{{ true and [255, 0, 0] }}` renders as `[255, 0, 0]`, not `True`/`true`, and that `{{ x is defined and x | length > 0 }}` renders `True`/`False` correctly.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards](https://developers.home-assistant.io/docs/documenting/standards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
