### PR TITLE
Fix sun.elevation_crossed_threshold YAML to include active_choice

### DIFF
--- a/source/_integrations/sun.markdown
+++ b/source/_integrations/sun.markdown
@@ -102,6 +102,7 @@ trigger: |
     threshold:
       type: below
       value:
+        active_choice: number
         number: -4
 {% endexample %}
 

--- a/source/_triggers/sun.elevation_crossed_threshold.markdown
+++ b/source/_triggers/sun.elevation_crossed_threshold.markdown
@@ -57,6 +57,7 @@ trigger: |
     threshold:
       type: below
       value:
+        active_choice: number
         number: 4
 {% endexample %}
 
@@ -71,10 +72,10 @@ threshold:
   description: |
     A mapping that defines the elevation crossing that fires the trigger. Angles are in degrees.
 
-    - `type: above` (exclusive): Fires when the elevation crosses to strictly above `value`. Provide `value` with a `number` key (a fixed angle in degrees) or an `entity` key (an `input_number`, `number`, or `sensor` entity).
-    - `type: below` (exclusive): Fires when the elevation crosses to strictly below `value`. Provide `value` with a `number` key (a fixed angle in degrees) or an `entity` key (an `input_number`, `number`, or `sensor` entity).
-    - `type: between` (exclusive): Fires when the elevation crosses into the range. Provide `value_min` and `value_max`, each with a `number` key (a fixed angle in degrees) or an `entity` key.
-    - `type: outside` (inclusive): Fires when the elevation crosses out of the range. Provide `value_min` and `value_max`, each with a `number` key (a fixed angle in degrees) or an `entity` key.
+    - `type: above` (exclusive): Fires when the elevation crosses to strictly above `value`. Provide `value` with `active_choice: number` and a `number` key (a fixed angle in degrees), or `active_choice: entity` and an `entity` key (an `input_number`, `number`, or `sensor` entity).
+    - `type: below` (exclusive): Fires when the elevation crosses to strictly below `value`. Provide `value` with `active_choice: number` and a `number` key (a fixed angle in degrees), or `active_choice: entity` and an `entity` key (an `input_number`, `number`, or `sensor` entity).
+    - `type: between` (exclusive): Fires when the elevation crosses into the range. Provide `value_min` and `value_max`, each with `active_choice: number` and a `number` key (a fixed angle in degrees), or `active_choice: entity` and an `entity` key.
+    - `type: outside` (inclusive): Fires when the elevation crosses out of the range. Provide `value_min` and `value_max`, each with `active_choice: number` and a `number` key (a fixed angle in degrees), or `active_choice: entity` and an `entity` key.
   required: true
   type: map
 for:
@@ -119,6 +120,7 @@ automation: |
         threshold:
           type: below
           value:
+            active_choice: number
             number: 4
   actions:
     - action: light.turn_on
@@ -149,8 +151,10 @@ automation: |
         threshold:
           type: between
           value_min:
+            active_choice: number
             number: 0
           value_max:
+            active_choice: number
             number: 15
         for: "00:02:00"
   actions:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The documented YAML for `sun.elevation_crossed_threshold` was missing `active_choice: number` under `threshold.value`. UI exports include this field, and without it the trigger does not work correctly in YAML.

Updates the examples and the YAML options description on the trigger page, and the duplicate example on the Sun integration page (`source/_integrations/sun.markdown`), to match the UI export.

Fixes #47922

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #47922

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
