### PR TITLE
Fix duplicate "the" in dashboard action navigate docs

### DIFF
--- a/source/dashboards/actions.markdown
+++ b/source/dashboards/actions.markdown
@@ -65,7 +65,7 @@ tap_action:
       default: none
     navigation_replace:
       required: false
-      description: "Whether to replace the current page in the the history with the new URL when the `action` is defined as `navigate`"
+      description: "Whether to replace the current page in the history with the new URL when the `action` is defined as `navigate`"
       type: boolean
       default: none
     url_path:
@@ -137,7 +137,7 @@ hold_action:
       default: none
     navigation_replace:
       required: false
-      description: "Whether to replace the current page in the the history with the new URL when the `action` is defined as `navigate`"
+      description: "Whether to replace the current page in the history with the new URL when the `action` is defined as `navigate`"
       type: boolean
       default: none
     url_path:
@@ -209,7 +209,7 @@ double_tap_action:
       default: none
     navigation_replace:
       required: false
-      description: "Whether to replace the current page in the the history with the new URL when the `action` is defined as `navigate`"
+      description: "Whether to replace the current page in the history with the new URL when the `action` is defined as `navigate`"
       type: boolean
       default: none
     url_path:


### PR DESCRIPTION
## Proposed change
Remove doubled \"the\" in the navigate action \`replace\` option descriptions (\"in the the history\" → \"in the history\").

## Type of change
- [x] Documentation improvement / correction

## Checklist
- [x] The documentation change is related to a documentation problem.